### PR TITLE
Delegate when a popover will be dismissed

### DIFF
--- a/Demo/Fullscreen/PopoverDemoViewController.swift
+++ b/Demo/Fullscreen/PopoverDemoViewController.swift
@@ -16,7 +16,7 @@ final class PopoverDemoViewController: UIViewController {
 
     lazy var popoverPresentationTransitioningDelegate: CustomPopoverPresentationTransitioningDelegate = {
         let transitioningDelegate = CustomPopoverPresentationTransitioningDelegate()
-        transitioningDelegate.popoverPresentationControllerWillDismissPopoverHandler = popoverPresentationControllerWillDismissPopoverHandler
+        transitioningDelegate.willDismissPopoverHandler = willDismissPopoverHandler
         return transitioningDelegate
     }()
 
@@ -72,7 +72,7 @@ private extension PopoverDemoViewController {
         }
     }
 
-    func popoverPresentationControllerWillDismissPopoverHandler(_ popoverPresentationController: UIPopoverPresentationController) {
+    func willDismissPopoverHandler(_ popoverPresentationController: UIPopoverPresentationController) {
         guard let selectedIndex = horizontalScrollButtonGroupView.indexesForSelectedButtons.first else {
             return
         }

--- a/Sources/CustomPopoverPresentation/CustomPopoverPresentationController.swift
+++ b/Sources/CustomPopoverPresentation/CustomPopoverPresentationController.swift
@@ -44,7 +44,7 @@ final class CustomPopoverPresentationController: UIPopoverPresentationController
 
         // The alpha for the UIDimmingView provided by Apple is 20%. According to design we need 40%
         dimmingView?.backgroundColor = UIColor.black.withAlphaComponent(.dimmingViewAlpha)
-        
+
         snapshotView.frame = sourceView.convert(sourceView.bounds, to: containerView)
         snapshotView.alpha = 0.0
         containerView?.addSubview(snapshotView)

--- a/Sources/CustomPopoverPresentation/CustomPopoverPresentationTransitioningDelegate.swift
+++ b/Sources/CustomPopoverPresentation/CustomPopoverPresentationTransitioningDelegate.swift
@@ -9,8 +9,8 @@ public final class CustomPopoverPresentationTransitioningDelegate: NSObject, UIV
 
     public var shouldDismissPopoverHandler: ((_ popoverPresentationController: UIPopoverPresentationController) -> Bool)?
     public var prepareForPopoverPresentationHandler: ((_ popoverPresentationController: UIPopoverPresentationController) -> Void)?
-    public var popoverPresentationControllerDidDismissPopoverHandler: ((_ popoverPresentationController: UIPopoverPresentationController) -> Void)?
-    public var popoverPresentationControllerWillDismissPopoverHandler: ((_ popoverPresentationController: UIPopoverPresentationController) -> Void)?
+    public var didDismissPopoverHandler: ((_ popoverPresentationController: UIPopoverPresentationController) -> Void)?
+    public var willDismissPopoverHandler: ((_ popoverPresentationController: UIPopoverPresentationController) -> Void)?
 
     public func presentationController(forPresented presented: UIViewController, presenting: UIViewController?, source: UIViewController) -> UIPresentationController? {
         guard let sourceView = sourceView else {
@@ -36,11 +36,11 @@ extension CustomPopoverPresentationTransitioningDelegate: CustomPopoverPresentat
     }
 
     func customPopoverPresentationControllerWillDismissPopover(_ customPopoverPresentationController: CustomPopoverPresentationController) {
-        popoverPresentationControllerWillDismissPopoverHandler?(customPopoverPresentationController)
+        willDismissPopoverHandler?(customPopoverPresentationController)
     }
 
     public func popoverPresentationControllerDidDismissPopover(_ popoverPresentationController: UIPopoverPresentationController) {
-        popoverPresentationControllerDidDismissPopoverHandler?(popoverPresentationController)
+        didDismissPopoverHandler?(popoverPresentationController)
     }
 
     public func adaptivePresentationStyle(for controller: UIPresentationController) -> UIModalPresentationStyle {


### PR DESCRIPTION
# Why
At the moment we can only get notified when a popover did dismiss. At the time this is notified it's to late to update the views in the presenting view controller without the update being visible. 
To be able to update views before dismissal has ended we have had to use the execution of `shouldDismissPopover` method to update the UI which is not optimal.

# What
+ Adds a `CustomPopoverPresentationControllerDelegate` with a `customPopoverPresentationControllerWillDismissPopover(_ :)` method.
+ Call this method when `dismissalTransitionWillBegin()` is called
+ Conform to `CustomPopoverPresentationControllerDelegate` in `CustomPopoverPresentationTransitioningDelegate`