### PR TITLE
Fix issue with popover trying to present itself with arrow down 

### DIFF
--- a/Sources/CustomPopoverPresentation/CustomPopoverPresentationController.swift
+++ b/Sources/CustomPopoverPresentation/CustomPopoverPresentationController.swift
@@ -45,7 +45,7 @@ final class CustomPopoverPresentationController: UIPopoverPresentationController
         super.init(presentedViewController: presentedViewController, presenting: presentingViewController)
         backgroundColor = .milk
         popoverBackgroundViewClass = PopoverBackgroundView.self
-        permittedArrowDirections = [.up]
+        super.permittedArrowDirections = [.up]
     }
 
     public override func presentationTransitionWillBegin() {


### PR DESCRIPTION
Also fixes crash on master, because 2 earlier PRs tried to fix this in incompatible ways.

Note: Overriding the `permittedArrowDirections` property doesn't seem to be enough to stop popover from trying to use arrow down. This makes sure the only allowed arrow is up, while keeping the property override so it is not possible to change the `permittedArrowDirections`.