### PR TITLE
Fix crash when presenting bottom sheet twice

### DIFF
--- a/Sources/BottomSheet/BottomSheetPresentationController.swift
+++ b/Sources/BottomSheet/BottomSheetPresentationController.swift
@@ -173,6 +173,7 @@ public final class BottomSheetPresentationController: UIPresentationController {
 
         dimmingView.removeFromSuperview()
         swipeBar.removeFromSuperview()
+        presentedViewTopAnchorConstraint = nil
     }
 }
 


### PR DESCRIPTION
Clear reference to `presentedViewTopAnchorConstraint` when bottom sheet is dismissed since it can't (and shouldn't) be reused when presented again.