### PR TITLE
Duplicated filter decoding tests

### DIFF
--- a/UnitTests/FilterBuilder/FilterDecodingTests.swift
+++ b/UnitTests/FilterBuilder/FilterDecodingTests.swift
@@ -6,8 +6,12 @@
 import XCTest
 
 class FilterDecodingTests: XCTestCase, TestDataDecoder {
-    lazy var decodedTestFilter: FilterSetup? = {
+    private lazy var filterSetupDecodedUsingDecodable: FilterSetup? = {
         return filterDataFromJSONFile(named: "DecodingTestFilter")
+    }()
+
+    private lazy var filterSetupDecodedFromDictionary: FilterSetup? = {
+        return filterDataFromDictionaryDecodedFromJSONFile(named: "DecodingTestFilter")
     }()
 
     func testFilterCanBeDecodedFromJSONData() {
@@ -28,10 +32,59 @@ class FilterDecodingTests: XCTestCase, TestDataDecoder {
         XCTAssertNotNil(filter)
     }
 
-    func testFilterPropertiesAreDecodedWithExpectedValues() {
+    func testFilterCanBeDecodedFromDictionaryData() {
         // Given
-        let filter = decodedTestFilter
+        let data = dataFromJSONFile(named: "DecodingTestFilter")
 
+        // When
+        let filter: FilterSetup?
+
+        if let data = data, let decodedData = try? JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [AnyHashable: Any] {
+            filter = FilterSetup.decode(from: decodedData)
+        } else {
+            filter = nil
+        }
+
+        // Then
+        XCTAssertNotNil(data)
+        XCTAssertNotNil(filter)
+    }
+
+    func testFilterPropertiesAreDecodedWithExpectedValues() {
+        testFilterPropertiesAreDecodedWithExpectedValues(filterSetup: filterSetupDecodedUsingDecodable)
+    }
+
+    func testFilterFromDictionaryPropertiesAreDecodedWithExpectedValues() {
+        testFilterPropertiesAreDecodedWithExpectedValues(filterSetup: filterSetupDecodedFromDictionary)
+    }
+
+    func testFilterDataElementWithNestedQueriesWithFiltersIsDecodedWithExpectedValues() {
+        testFilterDataElementWithNestedQueriesWithFiltersIsDecodedWithExpectedValues(filterSetup: filterSetupDecodedUsingDecodable)
+    }
+
+    func testFilterDataFromDictionaryElementWithNestedQueriesWithFiltersIsDecodedWithExpectedValues() {
+        testFilterDataElementWithNestedQueriesWithFiltersIsDecodedWithExpectedValues(filterSetup: filterSetupDecodedFromDictionary)
+    }
+
+    func testFilterDataWithRangeIsDecodedWithExpectedValues() {
+        testFilterDataWithRangeIsDecodedWithExpectedValues(filterSetup: filterSetupDecodedUsingDecodable)
+    }
+
+    func testFilterDataFromDictionaryWithRangeIsDecodedWithExpectedValues() {
+        testFilterDataWithRangeIsDecodedWithExpectedValues(filterSetup: filterSetupDecodedFromDictionary)
+    }
+
+    func testFilterDataWithQueriesWithoutFilterIsDecodedWithExpectedValues() {
+        testFilterDataWithQueriesWithoutFilterIsDecodedWithExpectedValues(filterSetup: filterSetupDecodedUsingDecodable)
+    }
+
+    func testFilterDataFromDictionaryWithQueriesWithoutFilterIsDecodedWithExpectedValues() {
+        testFilterDataWithQueriesWithoutFilterIsDecodedWithExpectedValues(filterSetup: filterSetupDecodedFromDictionary)
+    }
+}
+
+private extension FilterDecodingTests {
+    func testFilterPropertiesAreDecodedWithExpectedValues(filterSetup: FilterSetup?) {
         // When
         let expectedMarket = "car-norway"
         let expectedHits = 63455
@@ -40,17 +93,17 @@ class FilterDecodingTests: XCTestCase, TestDataDecoder {
         let expectedNumberOfFilterDataElements = 21 // raw filter keys 'market' and 'q' should not be parsed into filter data
 
         // Then
-        XCTAssertNotNil(filter)
-        XCTAssertEqual(filter?.market, expectedMarket)
-        XCTAssertEqual(filter?.hits, expectedHits)
-        XCTAssertEqual(filter?.filterTitle, expetedFilterTitle)
-        XCTAssertEqual(filter?.rawFilterKeys.count, expectedNumberOfRawFilterKeys)
-        XCTAssertEqual(filter?.filters.count, expectedNumberOfFilterDataElements)
+        XCTAssertNotNil(filterSetup)
+        XCTAssertEqual(filterSetup?.market, expectedMarket)
+        XCTAssertEqual(filterSetup?.hits, expectedHits)
+        XCTAssertEqual(filterSetup?.filterTitle, expetedFilterTitle)
+        XCTAssertEqual(filterSetup?.rawFilterKeys.count, expectedNumberOfRawFilterKeys)
+        XCTAssertEqual(filterSetup?.filters.count, expectedNumberOfFilterDataElements)
     }
 
-    func testFilterDataElementWithNestedQueriesWithFiltersIsDecodedWithExpectedValues() {
+    func testFilterDataElementWithNestedQueriesWithFiltersIsDecodedWithExpectedValues(filterSetup: FilterSetup?) {
         // Given
-        let filterDataElement = decodedTestFilter?.filterData(forKey: .make)
+        let filterDataElement = filterSetup?.filterData(forKey: .make)
 
         // When
         let firstQueryElement = filterDataElement?.queries?.first
@@ -79,9 +132,9 @@ class FilterDecodingTests: XCTestCase, TestDataDecoder {
         XCTAssertEqual(firstQueryElement?.filter?.queries.first?.totalResults, 2)
     }
 
-    func testFilterDataWithRangeIsDecodedWithExpectedValues() {
+    func testFilterDataWithRangeIsDecodedWithExpectedValues(filterSetup: FilterSetup?) {
         // Given, When
-        let filterDataElement = decodedTestFilter?.filterData(forKey: .numberOfSeats)
+        let filterDataElement = filterSetup?.filterData(forKey: .numberOfSeats)
 
         // Then
         XCTAssertNotNil(filterDataElement)
@@ -93,9 +146,9 @@ class FilterDecodingTests: XCTestCase, TestDataDecoder {
         XCTAssertNil(filterDataElement?.queries)
     }
 
-    func testFilterDataWithQueriesWithoutFilterIsDecodedWithExpectedValues() {
+    func testFilterDataWithQueriesWithoutFilterIsDecodedWithExpectedValues(filterSetup: FilterSetup?) {
         // Given
-        let filterDataElement = decodedTestFilter?.filterData(forKey: .transmission)
+        let filterDataElement = filterSetup?.filterData(forKey: .transmission)
 
         // When
         let firstQueryElement = filterDataElement?.queries?.first

--- a/UnitTests/TestDataDecoder.swift
+++ b/UnitTests/TestDataDecoder.swift
@@ -8,6 +8,7 @@ import XCTest
 protocol TestDataDecoder {
     func dataFromJSONFile(named name: String) -> Data?
     func filterDataFromJSONFile(named name: String) -> FilterSetup?
+    func filterDataFromDictionaryDecodedFromJSONFile(named name: String) -> FilterSetup?
 }
 
 extension TestDataDecoder {
@@ -27,5 +28,17 @@ extension TestDataDecoder {
         }
 
         return try? JSONDecoder().decode(FilterSetup.self, from: data)
+    }
+
+    func filterDataFromDictionaryDecodedFromJSONFile(named name: String) -> FilterSetup? {
+        guard let data = dataFromJSONFile(named: name) else {
+            return nil
+        }
+
+        guard let decodedData = try? JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [AnyHashable: Any] else {
+            return nil
+        }
+
+        return FilterSetup.decode(from: decodedData)
     }
 }


### PR DESCRIPTION
# Why? 
New methods to decode from a dictionary representing the JSON data should have some tests.

# What?
Using exactly same tests for verifying result of decode as when decoding with `Decodable`.