### PR TITLE
Fix "swipe handle" animation

### DIFF
--- a/Sources/BottomSheet/BottomSheetPresentationController.swift
+++ b/Sources/BottomSheet/BottomSheetPresentationController.swift
@@ -127,21 +127,13 @@ public final class BottomSheetPresentationController: UIPresentationController {
         }
 
         containerView.addSubview(dimmingView)
-        containerView.addSubview(swipeHandleContainer)
+        presentedView?.addSubview(swipeHandleContainer)
+        presentedView?.sendSubviewToBack(swipeHandleContainer)
         swipeHandleContainer.addSubview(swipeHandle)
 
-        let finalFrame = frameOfPresentedViewInContainerView
-        let swipeHandleContainerSize = CGSize(width: finalFrame.width, height: BottomSheetPresentationController.swipeHandleSize.height + .mediumSpacing)
-        let swipeHandleContainerFinalOrigin = CGPoint(x: 0, y: finalFrame.origin.y - swipeHandleContainerSize.height)
-        let dismissalTransitionRect = self.dismissalTransitionRect(in: containerView.frame)
-        let offSceenTransform = CGAffineTransform(translationX: 0, y: dismissalTransitionRect.height)
-
-        swipeHandleContainer.frame = CGRect(origin: swipeHandleContainerFinalOrigin, size: swipeHandleContainerSize)
-        swipeHandleContainer.transform = offSceenTransform
         dimmingView.alpha = 0.0
 
-        presentingViewController.transitionCoordinator?.animate(alongsideTransition: { [weak self] _ in
-            self?.swipeHandleContainer.transform = .identity
+        presentedViewController.transitionCoordinator?.animate(alongsideTransition: { [weak self] _ in
             self?.dimmingView.alpha = 1.0
         }, completion: nil)
 
@@ -168,14 +160,7 @@ public final class BottomSheetPresentationController: UIPresentationController {
     }
 
     public override func dismissalTransitionWillBegin() {
-        guard let containerView = containerView, let presentedView = presentedView else {
-            return
-        }
-
-        let offSceenTransform = CGAffineTransform(translationX: 0, y: containerView.frame.maxY - presentedView.frame.origin.y)
-
-        presentingViewController.transitionCoordinator?.animate(alongsideTransition: { [weak self] _ in
-            self?.swipeHandleContainer.transform = offSceenTransform
+        presentedViewController.transitionCoordinator?.animate(alongsideTransition: { [weak self] _ in
             self?.dimmingView.alpha = 0.0
         }, completion: nil)
     }


### PR DESCRIPTION
# Why? 
Swipe handle should follow bottom sheet appearance animation

# What?
Moving the "swipe handle" of the bottom sheet to be a subview of the presented view, this makes it animate correctly on appearance. Also changed to use the transitionCoordinator of the presentedViewController as per documentation.

# Show me
Examples use "slow animations".

## Before
![swipe-handle-before](https://user-images.githubusercontent.com/3169203/47718221-20bfd900-dc48-11e8-85fc-eb79b08f8b1e.gif)

## After
![swipe-handle-after](https://user-images.githubusercontent.com/3169203/47718226-25848d00-dc48-11e8-84ba-eb6c125c8b4d.gif)

