### PR TITLE
Hidden apply button should be completely hidden on all devices

### DIFF
--- a/Sources/FilterViewController/FilterViewController.swift
+++ b/Sources/FilterViewController/FilterViewController.swift
@@ -47,11 +47,25 @@ public final class FilterViewController<ChildViewController: FilterContainerView
     let filterContainerViewController: FilterContainerViewController
     weak var delegate: FilterViewControllerDelegate?
     weak var parentApplySelectionButtonOwner: ApplySelectionButtonOwner?
+    var applyButtonHiddenConstraintConstant: CGFloat {
+        return applySelectionButton.height
+    }
 
     public var showsApplySelectionButton: Bool {
         didSet {
+            guard showsApplySelectionButton != oldValue else {
+                return
+            }
             view.layoutIfNeeded()
-            applySelectionButtonBottomConstraint?.constant = showsApplySelectionButton ? 0 : applySelectionButton.height
+            applySelectionButton.alpha = showsApplySelectionButton ? 0 : 1
+            applySelectionButton.isHidden = false
+            applySelectionButtonBottomConstraint?.constant = showsApplySelectionButton ? 0 : applyButtonHiddenConstraintConstant
+            UIView.animate(withDuration: 0.25, animations: { [applySelectionButton, showsApplySelectionButton] in
+                applySelectionButton.alpha = showsApplySelectionButton ? 1 : 0
+                self.view.layoutIfNeeded()
+            }) { [applySelectionButton, showsApplySelectionButton] _ in
+                applySelectionButton.isHidden = !showsApplySelectionButton
+            }
             UIView.animate(withDuration: 0.25) {
                 self.view.layoutIfNeeded()
             }
@@ -105,7 +119,7 @@ private extension FilterViewController {
         view.addSubview(filterView)
 
         view.addSubview(applySelectionButton)
-        let applySelectionButtonBottomConstraint = applySelectionButton.bottomAnchor.constraint(equalTo: safeLayoutGuide.bottomAnchor, constant: applySelectionButton.height)
+        let applySelectionButtonBottomConstraint = applySelectionButton.bottomAnchor.constraint(equalTo: safeLayoutGuide.bottomAnchor, constant: applyButtonHiddenConstraintConstant)
         self.applySelectionButtonBottomConstraint = applySelectionButtonBottomConstraint
 
         NSLayoutConstraint.activate([
@@ -120,6 +134,8 @@ private extension FilterViewController {
 
         if showsApplySelectionButton {
             applySelectionButtonBottomConstraint.constant = 0
+        } else {
+            applySelectionButton.isHidden = true
         }
     }
 }


### PR DESCRIPTION
# Why?
The way of hiding apply button was to move it offscreen, but that didn't work so well when using safeAreaLayoutGuide and height of component when running on a X device.

# What?
When apply button should not be visible it will also be hidden, not just moved off screen (or almost off screen, which was the problem).

# Show me

### Before
![simulator screen shot - iphone xs - 2018-11-16 at 16 02 52](https://user-images.githubusercontent.com/3169203/48629267-75d64b80-e9b9-11e8-83e7-3d45b2190dc6.png)

### After
![simulator screen shot - iphone xs - 2018-11-16 at 16 02 24](https://user-images.githubusercontent.com/3169203/48629274-7b339600-e9b9-11e8-8446-42416d32f6f5.png)
