### PR TITLE
Moving "Alle" to a separate table section caused a slight off-by-one bug

### DIFF
--- a/Sources/MultiLevelListSelectionFilter/MultiLevelListSelectionFilterViewController.swift
+++ b/Sources/MultiLevelListSelectionFilter/MultiLevelListSelectionFilterViewController.swift
@@ -122,11 +122,7 @@ public final class MultiLevelListSelectionFilterViewController: UIViewController
     }
 
     private func didSelectDrillDownItem(_ listItem: MultiLevelListSelectionFilterInfoType, at indexPath: IndexPath) {
-        let filterIndex = isSelectAllIncluded ? indexPath.row - 1 : indexPath.row
-        guard let sublevelFilterInfo = filterInfo.filters[safe: filterIndex] else {
-            return
-        }
-        filterSelectionDelegate?.filterContainerViewController(filterContainerViewController: self, navigateTo: sublevelFilterInfo)
+        filterSelectionDelegate?.filterContainerViewController(filterContainerViewController: self, navigateTo: listItem)
         indexPathToRefreshOnViewWillAppear = indexPath
     }
 


### PR DESCRIPTION
# Why?
When moving the "Alle" selection item to a separate table section a slight off-by-one error was introduced. That was not intentional. 

# What?
> There are two hard things in computer science: cache invalidation, naming things, and off-by-one errors.

# Show me
I don't think anyone needs to see that 😉 
