### PR TITLE
Introduction of FilterRootStateController 

### DIFF
--- a/Charcoal.xcodeproj/project.pbxproj
+++ b/Charcoal.xcodeproj/project.pbxproj
@@ -95,6 +95,8 @@
 		55FFB38B20C15697002D593A /* UICollectionViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55FFB38A20C15697002D593A /* UICollectionViewExtensions.swift */; };
 		9B5A66F0219EBF79005C9118 /* NumberOfHitsCompatible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B5A66EF219EBF79005C9118 /* NumberOfHitsCompatible.swift */; };
 		9B5A66F4219EF263005C9118 /* FilterValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B5A66F3219EF263005C9118 /* FilterValue.swift */; };
+		9B5A66F621A2E122005C9118 /* LoadingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B5A66F521A2E122005C9118 /* LoadingViewController.swift */; };
+		9B5A66F821A2E26C005C9118 /* FilterRootStateController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B5A66F721A2E26C005C9118 /* FilterRootStateController.swift */; };
 		9B5E87632180708D00793A1A /* VerticalSelectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B5E87622180708D00793A1A /* VerticalSelectionCell.swift */; };
 		9B5E87692182114F00793A1A /* Layout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5589322C209C3CD500512FF8 /* Layout.swift */; };
 		9B5E876D2191CE4F00793A1A /* AnyFilterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B5E876C2191CE4F00793A1A /* AnyFilterViewController.swift */; };
@@ -284,6 +286,8 @@
 		55FFB38A20C15697002D593A /* UICollectionViewExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UICollectionViewExtensions.swift; sourceTree = "<group>"; };
 		9B5A66EF219EBF79005C9118 /* NumberOfHitsCompatible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberOfHitsCompatible.swift; sourceTree = "<group>"; };
 		9B5A66F3219EF263005C9118 /* FilterValue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FilterValue.swift; sourceTree = "<group>"; };
+		9B5A66F521A2E122005C9118 /* LoadingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingViewController.swift; sourceTree = "<group>"; };
+		9B5A66F721A2E26C005C9118 /* FilterRootStateController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterRootStateController.swift; sourceTree = "<group>"; };
 		9B5E87622180708D00793A1A /* VerticalSelectionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerticalSelectionCell.swift; sourceTree = "<group>"; };
 		9B5E876C2191CE4F00793A1A /* AnyFilterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyFilterViewController.swift; sourceTree = "<group>"; };
 		9B5E877021998B3500793A1A /* CurrentSelectionValuesContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentSelectionValuesContainerView.swift; sourceTree = "<group>"; };
@@ -876,10 +880,12 @@
 		9BE0A0402091BE750000632B /* Root */ = {
 			isa = PBXGroup;
 			children = (
-				9BE9A05E219ADBCA00059C19 /* CurrentSelection */,
 				9BE0A068209724AF0000632B /* Cells */,
+				9BE9A05E219ADBCA00059C19 /* CurrentSelection */,
 				9BE0A06420934A4B0000632B /* FilterBottomButtonView.swift */,
+				9B5A66F721A2E26C005C9118 /* FilterRootStateController.swift */,
 				9BE0A0452091BE750000632B /* FilterRootViewController.swift */,
+				9B5A66F521A2E122005C9118 /* LoadingViewController.swift */,
 				5525324320A2DB73000CBD21 /* RootFilterNavigator.swift */,
 			);
 			path = Root;
@@ -1213,6 +1219,7 @@
 				9BBCEDFE212EEE6B00F91B5D /* SearchQuerySuggestionCell.swift in Sources */,
 				9B8D53B02153BC1800FB9573 /* FilterSelectionTitleProvider.swift in Sources */,
 				9BB827A9216CCFA10014028C /* SearchQueryFilterInfoType.swift in Sources */,
+				9B5A66F821A2E26C005C9118 /* FilterRootStateController.swift in Sources */,
 				9BE0A05A2091E7E90000632B /* SearchQueryCell.swift in Sources */,
 				9BB827B1216CD0860014028C /* RangeFilterInfoType.swift in Sources */,
 				55BDA76D20DBC43F00331FFC /* FilterKey.swift in Sources */,
@@ -1259,6 +1266,7 @@
 				4690523A217F5CD000F8E7FD /* Vertical.swift in Sources */,
 				9BE0A061209200410000632B /* FilterCell.swift in Sources */,
 				55BDA77320DBD99600331FFC /* ParameterBasedFilterInfo.swift in Sources */,
+				9B5A66F621A2E122005C9118 /* LoadingViewController.swift in Sources */,
 				55E869E220E39373008B921E /* FilterNavigator.swift in Sources */,
 				4670268F2170DD3900B9C952 /* RangeReferenceValueView.swift in Sources */,
 				DAF3CA7021830293007235B0 /* StepperFilterViewController.swift in Sources */,

--- a/Demo/Demo.swift
+++ b/Demo/Demo.swift
@@ -200,7 +200,7 @@ enum ComponentViews: String {
             return ViewController<StepperFilterDemoView>()
 
         case .searchQuery:
-            let searchQueryViewController = SearchQueryViewController(filterInfo: DemoSearchQueryFilterInfo(value: nil, placeholderText: "Søk etter ord", title: "Filtrer søket"), dataSource: DemoEmptyDataSource(), selectionDataSource: DemoEmptyFilterSelectionDataSource())!
+            let searchQueryViewController = SearchQueryViewController(filterInfo: DemoSearchQueryFilterInfo(placeholderText: "Søk etter ord", title: "Filtrer søket"), dataSource: DemoEmptyDataSource(), selectionDataSource: DemoEmptyFilterSelectionDataSource())!
             let navigationController = UINavigationController(rootViewController: searchQueryViewController)
             return navigationController
         }
@@ -266,7 +266,6 @@ extension String {
 }
 
 struct DemoSearchQueryFilterInfo: SearchQueryFilterInfoType {
-    var value: String?
     var placeholderText: String
     var title: String
 }

--- a/Sources/Dependencies/Factories/ViewControllerFactory.swift
+++ b/Sources/Dependencies/Factories/ViewControllerFactory.swift
@@ -5,7 +5,7 @@
 import UIKit
 
 public protocol ViewControllerFactory: SublevelViewControllerFactory {
-    func makeFilterRootViewController(navigator: RootFilterNavigator) -> FilterRootViewController
+    func makeFilterRootStateController(navigator: RootFilterNavigator) -> FilterRootStateController
     func makeVerticalListViewController(with verticals: [Vertical], delegate: VerticalListViewControllerDelegate) -> VerticalListViewController?
     func makeRangeFilterViewController(with filterInfo: RangeFilterInfoType, navigator: FilterNavigator, delegate: FilterViewControllerDelegate) -> FilterViewController<RangeFilterViewController>?
     func makeListSelectionFilterViewController(from listSelectionListFilterInfo: ListSelectionFilterInfoType, navigator: FilterNavigator, delegate: FilterViewControllerDelegate?) -> FilterViewController<ListSelectionFilterViewController>?

--- a/Sources/Dependencies/FilterDependencyContainer.swift
+++ b/Sources/Dependencies/FilterDependencyContainer.swift
@@ -8,14 +8,14 @@ public class FilterDependencyContainer {
     private let dataSource: FilterDataSource
     private let selectionDataSource: FilterSelectionDataSource
     private let searchQuerySuggestionsDataSource: SearchQuerySuggestionsDataSource?
-    private weak var filterRootViewControllerDelegate: FilterRootViewControllerDelegate?
+    private weak var filterRootStateControllerDelegate: FilterRootStateControllerDelegate?
     private let filterSelectionTitleProvider: FilterSelectionTitleProvider
 
-    public init(dataSource: FilterDataSource, selectionDataSource: FilterSelectionDataSource, searchQuerySuggestionsDataSource: SearchQuerySuggestionsDataSource?, filterDelegate: FilterRootViewControllerDelegate?, filterSelectionTitleProvider: FilterSelectionTitleProvider) {
+    public init(dataSource: FilterDataSource, selectionDataSource: FilterSelectionDataSource, searchQuerySuggestionsDataSource: SearchQuerySuggestionsDataSource?, filterDelegate: FilterRootStateControllerDelegate?, filterSelectionTitleProvider: FilterSelectionTitleProvider) {
         self.dataSource = dataSource
         self.selectionDataSource = selectionDataSource
         self.searchQuerySuggestionsDataSource = searchQuerySuggestionsDataSource
-        filterRootViewControllerDelegate = filterDelegate
+        filterRootStateControllerDelegate = filterDelegate
         self.filterSelectionTitleProvider = filterSelectionTitleProvider
     }
 }
@@ -31,6 +31,13 @@ extension FilterDependencyContainer: NavigatorFactory {
 }
 
 extension FilterDependencyContainer: ViewControllerFactory {
+    public func makeFilterRootStateController(navigator: RootFilterNavigator) -> FilterRootStateController {
+        let rootStateController = FilterRootStateController(navigator: navigator, selectionDataSource: selectionDataSource, filterSelectionTitleProvider: filterSelectionTitleProvider)
+        rootStateController.delegate = filterRootStateControllerDelegate
+        rootStateController.state = .filtersLoaded(filter: dataSource) // TODO: This should not happen here, will be refactored
+        return rootStateController
+    }
+
     public func makeListSelectionFilterViewController(from listSelectionListFilterInfo: ListSelectionFilterInfoType, navigator: FilterNavigator, delegate: FilterViewControllerDelegate?) -> FilterViewController<ListSelectionFilterViewController>? {
         let filterViewController = FilterViewController<ListSelectionFilterViewController>(filterInfo: listSelectionListFilterInfo, dataSource: dataSource, selectionDataSource: selectionDataSource, navigator: navigator)
         filterViewController?.delegate = delegate
@@ -61,12 +68,6 @@ extension FilterDependencyContainer: ViewControllerFactory {
         let verticalListViewController = VerticalListViewController(verticals: verticals)
         verticalListViewController.delegate = delegate
         return verticalListViewController
-    }
-
-    public func makeFilterRootViewController(navigator: RootFilterNavigator) -> FilterRootViewController {
-        let rootViewController = FilterRootViewController(title: dataSource.filterTitle, navigator: navigator, dataSource: dataSource, selectionDataSource: selectionDataSource, filterSelectionTitleProvider: filterSelectionTitleProvider)
-        rootViewController.delegate = filterRootViewControllerDelegate
-        return rootViewController
     }
 
     public func makeSearchQueryFilterViewController(from searchQueryFilterInfo: SearchQueryFilterInfoType, navigator: FilterNavigator, delegate: FilterViewControllerDelegate?) -> UIViewController? {

--- a/Sources/FINNFilterImplementation/FilterBuilder/FilterInfoBuilder.swift
+++ b/Sources/FINNFilterImplementation/FilterBuilder/FilterInfoBuilder.swift
@@ -46,7 +46,7 @@ public final class FilterInfoBuilder {
 
 private extension FilterInfoBuilder {
     func buildSearchQueryFilterInfo() -> SearchQueryFilterInfoType {
-        return SearchQueryFilterInfo(parameterName: "q", value: nil, placeholderText: "Ord i annonsen", title: "Filtrer søket")
+        return SearchQueryFilterInfo(parameterName: "q", placeholderText: "Ord i annonsen", title: "Filtrer søket")
     }
 
     func buildStepperFilterInfo(from filterData: FilterData) -> StepperFilterInfoType {

--- a/Sources/FINNFilterImplementation/FilterInfo/SearchQueryFilterInfo.swift
+++ b/Sources/FINNFilterImplementation/FilterInfo/SearchQueryFilterInfo.swift
@@ -4,13 +4,11 @@
 
 class SearchQueryFilterInfo: SearchQueryFilterInfoType, ParameterBasedFilterInfo {
     let parameterName: String
-    var value: String?
     var placeholderText: String
     var title: String
 
-    init(parameterName: String, value: String?, placeholderText: String, title: String) {
+    init(parameterName: String, placeholderText: String, title: String) {
         self.parameterName = parameterName
-        self.value = value
         self.placeholderText = placeholderText
         self.title = title
     }

--- a/Sources/FilterInfoType/SearchQueryFilterInfoType.swift
+++ b/Sources/FilterInfoType/SearchQueryFilterInfoType.swift
@@ -3,6 +3,5 @@
 //
 
 public protocol SearchQueryFilterInfoType: FilterInfoType {
-    var value: String? { get }
     var placeholderText: String { get }
 }

--- a/Sources/Resources/en.lproj/Localizable.strings
+++ b/Sources/Resources/en.lproj/Localizable.strings
@@ -14,3 +14,5 @@
 "apply_button_title" = "Bruk";
 "opens_in_browser" = "Åpnes i nettleseren";
 "all_items_title" = "Alle";
+"show_hits_button_title" = "Vis treff";
+"show_x_hits_button_title" = "Vis %i treff";

--- a/Sources/Root/Cells/PreferencesCell.swift
+++ b/Sources/Root/Cells/PreferencesCell.swift
@@ -33,7 +33,7 @@ class PreferencesCell: UITableViewCell {
         preferenceSelectionView.load(verticals: [], preferences: [])
     }
 
-    func setupWith(verticals: [Vertical], preferences: [PreferenceFilterInfoType], delegate: PreferenceSelectionViewDelegate, selectionDataSource: FilterSelectionDataSource) {
+    func setupWith(verticals: [Vertical], preferences: [PreferenceFilterInfoType], delegate: PreferenceSelectionViewDelegate, selectionDataSource: FilterSelectionDataSource?) {
         preferenceSelectionView.delegate = delegate
         preferenceSelectionView.selectionDataSource = selectionDataSource
 

--- a/Sources/Root/FilterRootStateController.swift
+++ b/Sources/Root/FilterRootStateController.swift
@@ -1,0 +1,115 @@
+//
+//  Copyright © FINN.no AS, Inc. All rights reserved.
+//
+
+import UIKit
+
+public protocol FilterRootStateControllerDelegate: AnyObject {
+    func filterRootStateController(_: FilterRootStateController, shouldChangeVertical vertical: Vertical)
+    func filterRootStateControllerShouldShowResults(_: FilterRootStateController)
+}
+
+public class FilterRootStateController: UIViewController {
+    enum State {
+        case loading
+        case filtersLoaded(filter: FilterDataSource)
+        case failed(error: FilterRootError)
+    }
+
+    private let navigator: RootFilterNavigator
+    private let selectionDataSource: FilterSelectionDataSource
+    private let filterSelectionTitleProvider: FilterSelectionTitleProvider
+    weak var delegate: FilterRootStateControllerDelegate?
+
+    private lazy var loadingViewController = LoadingViewController(backgroundColor: .white, presentationDelay: 0)
+
+    private lazy var filterRootViewController: FilterRootViewController = {
+        let vc = FilterRootViewController(title: "", navigator: navigator, selectionDataSource: selectionDataSource, filterSelectionTitleProvider: filterSelectionTitleProvider)
+        vc.delegate = self
+        return vc
+    }()
+
+    var state = State.loading {
+        didSet {
+            if isViewLoaded {
+                configure(for: state)
+            }
+        }
+    }
+
+    public init(navigator: RootFilterNavigator, selectionDataSource: FilterSelectionDataSource, filterSelectionTitleProvider: FilterSelectionTitleProvider) {
+        self.navigator = navigator
+        self.selectionDataSource = selectionDataSource
+        self.filterSelectionTitleProvider = filterSelectionTitleProvider
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    public required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+        configure(for: state)
+    }
+
+    // MARK: - State handling
+
+    private func configure(for state: State) {
+        loadingViewController.remove()
+
+        switch state {
+        case .loading:
+            add(loadingViewController)
+        case let .filtersLoaded(dataSource):
+            add(filterRootViewController)
+            filterRootViewController.searchQueryFilter = dataSource.searchQuery
+            filterRootViewController.preferenceFilters = dataSource.preferences
+            filterRootViewController.filters = dataSource.filters
+            filterRootViewController.numberOfHits = dataSource.numberOfHits
+            filterRootViewController.title = dataSource.filterTitle
+            filterRootViewController.verticalsFilters = dataSource.verticals
+        case let .failed(error):
+            handleError(error)
+        }
+    }
+
+    private func handleError(_ error: FilterRootError) {
+        DebugLog.write("Filter root error: \(error)")
+        // TODO:
+    }
+}
+
+extension FilterRootStateController: FilterRootViewControllerDelegate {
+    public func filterRootViewController(_: FilterRootViewController, didChangeVertical vertical: Vertical) {
+        state = .loading
+        delegate?.filterRootStateController(self, shouldChangeVertical: vertical)
+    }
+
+    public func filterRootViewControllerShouldShowResults(_: FilterRootViewController) {
+        delegate?.filterRootStateControllerShouldShowResults(self)
+    }
+}
+
+private extension UIViewController {
+    func add(_ childViewController: UIViewController) {
+        guard childViewController.parent == nil else { return }
+
+        addChild(childViewController)
+        childViewController.view.frame = view.bounds
+        childViewController.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        view.addSubview(childViewController.view)
+        childViewController.didMove(toParent: self)
+    }
+
+    func remove() {
+        guard parent != nil else { return }
+
+        willMove(toParent: nil)
+        removeFromParent()
+        view.removeFromSuperview()
+    }
+}
+
+enum FilterRootError: Error {
+}

--- a/Sources/Root/LoadingViewController.swift
+++ b/Sources/Root/LoadingViewController.swift
@@ -1,0 +1,56 @@
+//
+//  Copyright © FINN.no AS, Inc. All rights reserved.
+//
+
+import UIKit
+
+final class LoadingViewController: UIViewController {
+    private let backgroundColor: UIColor
+    private var presentationDelay = 0.5
+
+    private lazy var loadingIndicatorView: UIActivityIndicatorView = {
+        let activityIndicator = UIActivityIndicatorView(style: .white)
+        activityIndicator.translatesAutoresizingMaskIntoConstraints = false
+        return activityIndicator
+    }()
+
+    // MARK: - Init
+
+    init(backgroundColor: UIColor = UIColor.milk.withAlphaComponent(0.8), presentationDelay: Double = 0.5) {
+        self.backgroundColor = backgroundColor
+        self.presentationDelay = presentationDelay
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.backgroundColor = backgroundColor
+        view.addSubview(loadingIndicatorView)
+
+        NSLayoutConstraint.activate([
+            loadingIndicatorView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            loadingIndicatorView.centerYAnchor.constraint(equalTo: view.centerYAnchor, constant: -.mediumSpacing),
+        ])
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        loadingIndicatorView.stopAnimating()
+        DispatchQueue.main.asyncAfter(deadline: .now() + presentationDelay) { [weak self] in
+            self?.loadingIndicatorView.startAnimating()
+        }
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        loadingIndicatorView.stopAnimating()
+    }
+}

--- a/Sources/Root/RootFilterNavigator.swift
+++ b/Sources/Root/RootFilterNavigator.swift
@@ -28,8 +28,8 @@ public class RootFilterNavigator: NSObject, Navigator {
     }
 
     public func start() {
-        let filterRootViewController = factory.makeFilterRootViewController(navigator: self)
-        navigationController.setViewControllers([filterRootViewController], animated: false)
+        let filterRootStateController = factory.makeFilterRootStateController(navigator: self)
+        navigationController.setViewControllers([filterRootStateController], animated: false)
     }
 
     public func navigate(to destination: RootFilterNavigator.Destination) {

--- a/Sources/SearchQuery/SearchQueryViewController.swift
+++ b/Sources/SearchQuery/SearchQueryViewController.swift
@@ -59,7 +59,7 @@ public class SearchQueryViewController: UIViewController, FilterContainerViewCon
         self.searchQueryFilterInfo = searchQueryFilterInfo
         self.dataSource = dataSource
         self.selectionDataSource = selectionDataSource
-        startText = searchQueryFilterInfo.value
+        startText = selectionDataSource.value(for: searchQueryFilterInfo)?.first
         placeholder = searchQueryFilterInfo.placeholderText
         super.init(nibName: nil, bundle: nil)
         title = searchQueryFilterInfo.title
@@ -74,6 +74,7 @@ public class SearchQueryViewController: UIViewController, FilterContainerViewCon
 
         if let selectionValue = selectionDataSource.value(for: searchQueryFilterInfo) {
             setSelectionValue(selectionValue)
+            startText = searchText
         }
 
         setup()


### PR DESCRIPTION
# Why?
We need to handle loading state (among other things) soon, so this is a first step towards new NavigationController -> StateController -> ViewController pattern.

# What?
Start with introduction of FilterRootStateController as parent of FilterRootViewController. Also added some basic support for different parts of the filter changing at different times in FilterRootViewController (mainly for later use, but no need for it to use FilterDataSource directly anymore). Removed `value` property from SearchQueryFilterInfo since it is not used.

Making PR before everything is ready so the state controller can be used in other tasks. 

# Show me
No UI changes. Everything should be the same as before