### PR TITLE
Submarkets data

### DIFF
--- a/Charcoal.xcodeproj/project.pbxproj
+++ b/Charcoal.xcodeproj/project.pbxproj
@@ -146,6 +146,7 @@
 		9BE0A061209200410000632B /* FilterCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BE0A05F2091FFA50000632B /* FilterCell.swift */; };
 		9BE0A06520934A4B0000632B /* FilterBottomButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BE0A06420934A4B0000632B /* FilterBottomButtonView.swift */; };
 		9BE0A06A209724D70000632B /* PreferencesCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BE0A069209724D70000632B /* PreferencesCell.swift */; };
+		9BE0D54121A4509F00F0B63B /* car-abroad.json in Resources */ = {isa = PBXBuildFile; fileRef = 9BE0D54021A4509F00F0B63B /* car-abroad.json */; };
 		9BE9A060219ADC2000059C19 /* CollapsedSelectionValuesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BE9A05F219ADC2000059C19 /* CollapsedSelectionValuesView.swift */; };
 		9BE9A062219ADC4F00059C19 /* ExpandedSelectionValuesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BE9A061219ADC4F00059C19 /* ExpandedSelectionValuesView.swift */; };
 		9BFC08912134088C00AB8A11 /* ContentSizeModeTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BFC08902134088C00AB8A11 /* ContentSizeModeTest.swift */; };
@@ -331,6 +332,7 @@
 		9BE0A05F2091FFA50000632B /* FilterCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterCell.swift; sourceTree = "<group>"; };
 		9BE0A06420934A4B0000632B /* FilterBottomButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterBottomButtonView.swift; sourceTree = "<group>"; };
 		9BE0A069209724D70000632B /* PreferencesCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesCell.swift; sourceTree = "<group>"; };
+		9BE0D54021A4509F00F0B63B /* car-abroad.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "car-abroad.json"; sourceTree = "<group>"; };
 		9BE9A05F219ADC2000059C19 /* CollapsedSelectionValuesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollapsedSelectionValuesView.swift; sourceTree = "<group>"; };
 		9BE9A061219ADC4F00059C19 /* ExpandedSelectionValuesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpandedSelectionValuesView.swift; sourceTree = "<group>"; };
 		9BFC08902134088C00AB8A11 /* ContentSizeModeTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentSizeModeTest.swift; sourceTree = "<group>"; };
@@ -641,9 +643,10 @@
 		5598F20E20C008F900E148E0 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
-				55BDA77420DCCD8E00331FFC /* realestate-homes.json */,
 				55ABF8AF20CFD8A100E31229 /* bap-sale.json */,
+				9BE0D54021A4509F00F0B63B /* car-abroad.json */,
 				554D154F20C0782200FA3930 /* car-norway.json */,
+				55BDA77420DCCD8E00331FFC /* realestate-homes.json */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -1106,6 +1109,7 @@
 				9B9C16FD209AF65E007BCBBC /* CHANGELOG.md in Resources */,
 				55ABF8B020CFD8A100E31229 /* bap-sale.json in Resources */,
 				5521FB9520CEB0FF00F910D0 /* car-norway.json in Resources */,
+				9BE0D54121A4509F00F0B63B /* car-abroad.json in Resources */,
 				44ECE675208F7FD20017AC82 /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Charcoal.xcodeproj/project.pbxproj
+++ b/Charcoal.xcodeproj/project.pbxproj
@@ -147,6 +147,7 @@
 		9BE0A06520934A4B0000632B /* FilterBottomButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BE0A06420934A4B0000632B /* FilterBottomButtonView.swift */; };
 		9BE0A06A209724D70000632B /* PreferencesCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BE0A069209724D70000632B /* PreferencesCell.swift */; };
 		9BE0D54121A4509F00F0B63B /* car-abroad.json in Resources */ = {isa = PBXBuildFile; fileRef = 9BE0D54021A4509F00F0B63B /* car-abroad.json */; };
+		9BE0D54321A4552300F0B63B /* FilterMarketTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BE0D54221A4552300F0B63B /* FilterMarketTests.swift */; };
 		9BE9A060219ADC2000059C19 /* CollapsedSelectionValuesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BE9A05F219ADC2000059C19 /* CollapsedSelectionValuesView.swift */; };
 		9BE9A062219ADC4F00059C19 /* ExpandedSelectionValuesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BE9A061219ADC4F00059C19 /* ExpandedSelectionValuesView.swift */; };
 		9BFC08912134088C00AB8A11 /* ContentSizeModeTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BFC08902134088C00AB8A11 /* ContentSizeModeTest.swift */; };
@@ -333,6 +334,7 @@
 		9BE0A06420934A4B0000632B /* FilterBottomButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterBottomButtonView.swift; sourceTree = "<group>"; };
 		9BE0A069209724D70000632B /* PreferencesCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesCell.swift; sourceTree = "<group>"; };
 		9BE0D54021A4509F00F0B63B /* car-abroad.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "car-abroad.json"; sourceTree = "<group>"; };
+		9BE0D54221A4552300F0B63B /* FilterMarketTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterMarketTests.swift; sourceTree = "<group>"; };
 		9BE9A05F219ADC2000059C19 /* CollapsedSelectionValuesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollapsedSelectionValuesView.swift; sourceTree = "<group>"; };
 		9BE9A061219ADC4F00059C19 /* ExpandedSelectionValuesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpandedSelectionValuesView.swift; sourceTree = "<group>"; };
 		9BFC08902134088C00AB8A11 /* ContentSizeModeTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentSizeModeTest.swift; sourceTree = "<group>"; };
@@ -955,6 +957,7 @@
 			children = (
 				559C61FB20DA87330083A574 /* FilterDecodingTests.swift */,
 				55BDA76020DB7E8C00331FFC /* FilterInfoBuilderTests.swift */,
+				9BE0D54221A4552300F0B63B /* FilterMarketTests.swift */,
 				55BDA76720DB9A7300331FFC /* RangeFilterBuilderTests.swift */,
 			);
 			path = FilterBuilder;
@@ -1322,6 +1325,7 @@
 				55BDA76620DB7FC000331FFC /* TestDataDecoder.swift in Sources */,
 				55BDA76820DB9A7300331FFC /* RangeFilterBuilderTests.swift in Sources */,
 				559C61FC20DA87330083A574 /* FilterDecodingTests.swift in Sources */,
+				9BE0D54321A4552300F0B63B /* FilterMarketTests.swift in Sources */,
 				55BDA76120DB7E8C00331FFC /* FilterInfoBuilderTests.swift in Sources */,
 				9BB827B4216DF2E20014028C /* ParameterBasedFilterInfoSelectionDataSourceTests.swift in Sources */,
 			);

--- a/Demo/Resources/car-abroad.json
+++ b/Demo/Resources/car-abroad.json
@@ -1,0 +1,1321 @@
+{
+    "market": "car-abroad",
+    "hits": 222,
+    "label": "Parallelimporterte biler",
+    "type": "search",
+    "filters": [
+        "markets",
+        "q",
+        "published",
+        "make",
+        "dealer_segment",
+        "sales_form",
+        "year",
+        "mileage",
+        "leaseprice_init",
+        "leaseprice_month",
+        "price",
+        "price_changed",
+        "location",
+        "body_type",
+        "engine_fuel",
+        "exterior_colour",
+        "engine_effect",
+        "number_of_seats",
+        "wheel_drive",
+        "transmission",
+        "car_equipment",
+        "wheel_sets",
+        "warranty_insurance",
+        "condition",
+        "registration_class"
+    ],
+    "filter-data": {
+        "year": {
+            "title": "Årsmodell",
+            "range": true,
+            "name": "year"
+        },
+        "engine_effect": {
+            "title": "Hestekrefter",
+            "range": true,
+            "name": "engine_effect"
+        },
+        "mileage": {
+            "title": "Kilometerstand",
+            "range": true,
+            "name": "mileage"
+        },
+        "number_of_seats": {
+            "title": "Antall seter",
+            "range": true,
+            "name": "number_of_seats"
+        },
+        "make": {
+            "title": "Merke",
+            "name": "make",
+            "queries": [
+                {
+                    "title": "Abarth",
+                    "value": "0.8093",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "124 Spider",
+                                "value": "1.8093.2000412",
+                                "total-results": 2
+                            }
+                        ]
+                    },
+                    "total-results": 2
+                },
+                {
+                    "title": "Alfa Romeo",
+                    "value": "0.3233",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Andre",
+                                "value": "1.3233.3234",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Giulietta",
+                                "value": "1.3233.3785",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Sprint",
+                                "value": "1.3233.3237",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 3
+                },
+                {
+                    "title": "Andre",
+                    "value": "0.2252",
+                    "total-results": 1
+                },
+                {
+                    "title": "Audi",
+                    "value": "0.744",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "A4",
+                                "value": "1.744.839",
+                                "total-results": 4
+                            },
+                            {
+                                "title": "A4 allroad",
+                                "value": "1.744.2000140",
+                                "total-results": 3
+                            },
+                            {
+                                "title": "A5",
+                                "value": "1.744.8314",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "A6",
+                                "value": "1.744.840",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "A7",
+                                "value": "1.744.2000174",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Q3",
+                                "value": "1.744.2000190",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Q5",
+                                "value": "1.744.2000097",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "RS6",
+                                "value": "1.744.7709",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 14
+                },
+                {
+                    "title": "Bentley",
+                    "value": "0.7166",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Continental",
+                                "value": "1.7166.7168",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 1
+                },
+                {
+                    "title": "BMW",
+                    "value": "0.749",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "X5",
+                                "value": "1.749.6737",
+                                "total-results": 5
+                            },
+                            {
+                                "title": "1-serie",
+                                "value": "1.749.7967",
+                                "total-results": 3
+                            },
+                            {
+                                "title": "2-serie",
+                                "value": "1.749.2000283",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "3-serie",
+                                "value": "1.749.2132",
+                                "total-results": 9
+                            },
+                            {
+                                "title": "4-serie",
+                                "value": "1.749.2000265",
+                                "total-results": 3
+                            },
+                            {
+                                "title": "5-serie",
+                                "value": "1.749.2131",
+                                "total-results": 23
+                            },
+                            {
+                                "title": "6-serie",
+                                "value": "1.749.3004",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "7-serie",
+                                "value": "1.749.2130",
+                                "total-results": 8
+                            }
+                        ]
+                    },
+                    "total-results": 53
+                },
+                {
+                    "title": "Cadillac",
+                    "value": "0.752",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "SRX",
+                                "value": "1.752.7988",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 1
+                },
+                {
+                    "title": "Chevrolet",
+                    "value": "0.753",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Camaro",
+                                "value": "1.753.905",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 1
+                },
+                {
+                    "title": "Chrysler",
+                    "value": "0.754",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Voyager",
+                                "value": "1.754.928",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 1
+                },
+                {
+                    "title": "Dodge",
+                    "value": "0.764",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Andre",
+                                "value": "1.764.2073",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Challenger",
+                                "value": "1.764.2074",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 2
+                },
+                {
+                    "title": "Fiat",
+                    "value": "0.766",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Multipla",
+                                "value": "1.766.2000037",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "500",
+                                "value": "1.766.2000071",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "500L",
+                                "value": "1.766.2000241",
+                                "total-results": 2
+                            }
+                        ]
+                    },
+                    "total-results": 5
+                },
+                {
+                    "title": "Ford",
+                    "value": "0.767",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Focus",
+                                "value": "1.767.3739",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Grand C-MAX",
+                                "value": "1.767.2000218",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Mustang",
+                                "value": "1.767.1056",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Transit Connect",
+                                "value": "1.767.8191",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 4
+                },
+                {
+                    "title": "Honda",
+                    "value": "0.771",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Civic",
+                                "value": "1.771.1088",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 1
+                },
+                {
+                    "title": "Hyundai",
+                    "value": "0.772",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Ioniq",
+                                "value": "1.772.2000393",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Kona",
+                                "value": "1.772.2000438",
+                                "total-results": 2
+                            }
+                        ]
+                    },
+                    "total-results": 3
+                },
+                {
+                    "title": "Iveco",
+                    "value": "0.7280",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Daily",
+                                "value": "1.7280.7294",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 1
+                },
+                {
+                    "title": "Jaguar",
+                    "value": "0.775",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Andre",
+                                "value": "1.775.2084",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "E-TYPE",
+                                "value": "1.775.2000124",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "XF",
+                                "value": "1.775.8317",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 3
+                },
+                {
+                    "title": "Kia",
+                    "value": "0.777",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Picanto",
+                                "value": "1.777.8178",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 1
+                },
+                {
+                    "title": "Mercedes-Benz",
+                    "value": "0.785",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "AMG GT",
+                                "value": "1.785.2000369",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "A-Klasse",
+                                "value": "1.785.3777",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "CLA",
+                                "value": "1.785.2000250",
+                                "total-results": 3
+                            },
+                            {
+                                "title": "CLK",
+                                "value": "1.785.6713",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "C-Klasse",
+                                "value": "1.785.3776",
+                                "total-results": 12
+                            },
+                            {
+                                "title": "E-Klasse",
+                                "value": "1.785.3775",
+                                "total-results": 28
+                            },
+                            {
+                                "title": "E-klasse All-Terrain",
+                                "value": "1.785.2000421",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Geländewagen",
+                                "value": "1.785.2259",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "GLA",
+                                "value": "1.785.2000285",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "GLC",
+                                "value": "1.785.2000332",
+                                "total-results": 18
+                            },
+                            {
+                                "title": "GLE",
+                                "value": "1.785.2000327",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "M-Klasse",
+                                "value": "1.785.3774",
+                                "total-results": 3
+                            },
+                            {
+                                "title": "SLK",
+                                "value": "1.785.6712",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "S-Klasse",
+                                "value": "1.785.3773",
+                                "total-results": 2
+                            }
+                        ]
+                    },
+                    "total-results": 78
+                },
+                {
+                    "title": "MG",
+                    "value": "0.786",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Andre",
+                                "value": "1.786.2095",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 1
+                },
+                {
+                    "title": "Mitsubishi",
+                    "value": "0.787",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Outlander",
+                                "value": "1.787.7713",
+                                "total-results": 6
+                            },
+                            {
+                                "title": "Space Star",
+                                "value": "1.787.3752",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 7
+                },
+                {
+                    "title": "Nissan",
+                    "value": "0.792",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Leaf",
+                                "value": "1.792.2000183",
+                                "total-results": 3
+                            }
+                        ]
+                    },
+                    "total-results": 3
+                },
+                {
+                    "title": "Opel",
+                    "value": "0.795",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Astra",
+                                "value": "1.795.1247",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Combo",
+                                "value": "1.795.1252",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 2
+                },
+                {
+                    "title": "Pontiac",
+                    "value": "0.800",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Andre",
+                                "value": "1.800.2109",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 1
+                },
+                {
+                    "title": "Porsche",
+                    "value": "0.801",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Cayenne",
+                                "value": "1.801.7714",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "Panamera",
+                                "value": "1.801.2000121",
+                                "total-results": 2
+                            }
+                        ]
+                    },
+                    "total-results": 4
+                },
+                {
+                    "title": "Renault",
+                    "value": "0.804",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Grand Espace",
+                                "value": "1.804.7648",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 1
+                },
+                {
+                    "title": "Skoda",
+                    "value": "0.808",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Karoq",
+                                "value": "1.808.2000424",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Octavia",
+                                "value": "1.808.1355",
+                                "total-results": 3
+                            },
+                            {
+                                "title": "Superb",
+                                "value": "1.808.7532",
+                                "total-results": 5
+                            }
+                        ]
+                    },
+                    "total-results": 9
+                },
+                {
+                    "title": "Tesla",
+                    "value": "0.8078",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Model S",
+                                "value": "1.8078.2000138",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 1
+                },
+                {
+                    "title": "Toyota",
+                    "value": "0.813",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Auris",
+                                "value": "1.813.2000062",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "MR2",
+                                "value": "1.813.1398",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Prius",
+                                "value": "1.813.6749",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 3
+                },
+                {
+                    "title": "Volkswagen",
+                    "value": "0.817",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Caddy",
+                                "value": "1.817.6709",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Golf",
+                                "value": "1.817.1433",
+                                "total-results": 4
+                            },
+                            {
+                                "title": "Passat",
+                                "value": "1.817.1437",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Scirocco",
+                                "value": "1.817.1441",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Sharan",
+                                "value": "1.817.1442",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 8
+                },
+                {
+                    "title": "Volvo",
+                    "value": "0.818",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "V70",
+                                "value": "1.818.3077",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "V90",
+                                "value": "1.818.2000386",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "V90 Cross Country",
+                                "value": "1.818.2000390",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "XC 60",
+                                "value": "1.818.2000093",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "XC 90",
+                                "value": "1.818.7651",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 7
+                }
+            ]
+        },
+        "leaseprice_init": {
+            "title": "Innskudd",
+            "range": true,
+            "name": "leaseprice_init"
+        },
+        "registration_class": {
+            "title": "Avgiftsklasse",
+            "name": "registration_class",
+            "queries": [
+                {
+                    "title": "Annet",
+                    "value": "6",
+                    "total-results": 12
+                },
+                {
+                    "title": "Lett lastebil",
+                    "value": "5",
+                    "total-results": 1
+                },
+                {
+                    "title": "Personbil",
+                    "value": "1",
+                    "total-results": 204
+                },
+                {
+                    "title": "Varebil",
+                    "value": "2",
+                    "total-results": 5
+                }
+            ]
+        },
+        "engine_fuel": {
+            "title": "Drivstoff",
+            "name": "engine_fuel",
+            "queries": [
+                {
+                    "title": "Bensin",
+                    "value": "0/1",
+                    "total-results": 66
+                },
+                {
+                    "title": "Diesel",
+                    "value": "0/2",
+                    "total-results": 103
+                },
+                {
+                    "title": "Elektrisitet",
+                    "value": "0/4",
+                    "total-results": 12
+                },
+                {
+                    "title": "Gass",
+                    "value": "0/3",
+                    "total-results": 1
+                },
+                {
+                    "title": "Hybrid",
+                    "value": "0/11111",
+                    "total-results": 40
+                }
+            ]
+        },
+        "warranty_insurance": {
+            "title": "Garanti og forsikringer",
+            "name": "warranty_insurance",
+            "queries": [
+                {
+                    "title": "Garanti",
+                    "value": "1",
+                    "total-results": 113
+                }
+            ]
+        },
+        "wheel_sets": {
+            "title": "Hjulsett",
+            "name": "wheel_sets",
+            "queries": [
+                {
+                    "title": "Ett hjulsett",
+                    "value": "1",
+                    "total-results": 128
+                },
+                {
+                    "title": "To hjulsett",
+                    "value": "2",
+                    "total-results": 13
+                }
+            ]
+        },
+        "sales_form": {
+            "title": "Salgsform",
+            "name": "sales_form",
+            "queries": [
+                {
+                    "title": "Bruktbil til salgs",
+                    "value": "1",
+                    "total-results": 219
+                },
+                {
+                    "title": "Leasing",
+                    "value": "5",
+                    "total-results": 2
+                },
+                {
+                    "title": "Nybil til salgs",
+                    "value": "2",
+                    "total-results": 1
+                }
+            ]
+        },
+        "exterior_colour": {
+            "title": "Farge",
+            "name": "exterior_colour",
+            "queries": [
+                {
+                    "title": "Blå",
+                    "value": "2",
+                    "total-results": 16
+                },
+                {
+                    "title": "Brun",
+                    "value": "4",
+                    "total-results": 2
+                },
+                {
+                    "title": "Grønn",
+                    "value": "5",
+                    "total-results": 2
+                },
+                {
+                    "title": "Grå",
+                    "value": "6",
+                    "total-results": 40
+                },
+                {
+                    "title": "Gul",
+                    "value": "7",
+                    "total-results": 1
+                },
+                {
+                    "title": "Hvit",
+                    "value": "9",
+                    "total-results": 53
+                },
+                {
+                    "title": "Rød",
+                    "value": "13",
+                    "total-results": 15
+                },
+                {
+                    "title": "Svart",
+                    "value": "14",
+                    "total-results": 75
+                },
+                {
+                    "title": "Sølv",
+                    "value": "15",
+                    "total-results": 17
+                },
+                {
+                    "title": "Turkis",
+                    "value": "16",
+                    "total-results": 1
+                }
+            ]
+        },
+        "published": {
+            "title": "Publisert",
+            "name": "published",
+            "queries": [
+                {
+                    "title": "Nye i dag",
+                    "value": "1",
+                    "total-results": 4
+                }
+            ]
+        },
+        "leaseprice_month": {
+            "title": "Månedspris",
+            "range": true,
+            "name": "leaseprice_month"
+        },
+        "car_equipment": {
+            "title": "Utstyr",
+            "name": "car_equipment",
+            "queries": [
+                {
+                    "title": "Hengerfeste",
+                    "value": "23",
+                    "total-results": 41
+                },
+                {
+                    "title": "Motorvarmer",
+                    "value": "35",
+                    "total-results": 37
+                },
+                {
+                    "title": "Navigasjonssystem",
+                    "value": "40",
+                    "total-results": 121
+                },
+                {
+                    "title": "Radio DAB+",
+                    "value": "77",
+                    "total-results": 22
+                },
+                {
+                    "title": "Skinninteriør",
+                    "value": "12",
+                    "total-results": 109
+                }
+            ]
+        },
+        "transmission": {
+            "title": "Girkasse",
+            "name": "transmission",
+            "queries": [
+                {
+                    "title": "Automat",
+                    "value": "2",
+                    "total-results": 184
+                },
+                {
+                    "title": "Manuell",
+                    "value": "1",
+                    "total-results": 38
+                }
+            ]
+        },
+        "dealer_segment": {
+            "title": "Annonsør",
+            "name": "dealer_segment",
+            "queries": [
+                {
+                    "title": "Annet bilutsalg",
+                    "value": "2",
+                    "total-results": 191
+                },
+                {
+                    "title": "Merkeforhandler",
+                    "value": "1",
+                    "total-results": 2
+                },
+                {
+                    "title": "Privat",
+                    "value": "3",
+                    "total-results": 29
+                }
+            ]
+        },
+        "wheel_drive": {
+            "title": "Hjuldrift",
+            "name": "wheel_drive",
+            "queries": [
+                {
+                    "title": "Bakhjulsdrift",
+                    "value": "1",
+                    "total-results": 77
+                },
+                {
+                    "title": "Firehjulsdrift",
+                    "value": "2",
+                    "total-results": 106
+                },
+                {
+                    "title": "Forhjulsdrift",
+                    "value": "3",
+                    "total-results": 39
+                }
+            ]
+        },
+        "condition": {
+            "title": "Bilens tilstand",
+            "name": "condition",
+            "queries": [
+                {
+                    "title": "Service",
+                    "value": "1",
+                    "total-results": 59
+                }
+            ]
+        },
+        "motor_ad_location": {
+            "title": "Kjøretøyet står i",
+            "name": "motor_ad_location"
+        },
+        "location": {
+            "title": "Område",
+            "name": "location",
+            "queries": [
+                {
+                    "title": "Akershus",
+                    "value": "20003",
+                    "total-results": 141
+                },
+                {
+                    "title": "Aust-Agder",
+                    "value": "20010",
+                    "total-results": 1
+                },
+                {
+                    "title": "Buskerud",
+                    "value": "20007",
+                    "total-results": 6
+                },
+                {
+                    "title": "Hedmark",
+                    "value": "20005",
+                    "total-results": 1
+                },
+                {
+                    "title": "Hordaland",
+                    "value": "20013",
+                    "total-results": 3
+                },
+                {
+                    "title": "Oppland",
+                    "value": "20006",
+                    "total-results": 3
+                },
+                {
+                    "title": "Oslo",
+                    "value": "20061",
+                    "total-results": 6
+                },
+                {
+                    "title": "Rogaland",
+                    "value": "20012",
+                    "total-results": 3
+                },
+                {
+                    "title": "Trøndelag",
+                    "value": "20016",
+                    "total-results": 2
+                },
+                {
+                    "title": "Vestfold",
+                    "value": "20008",
+                    "total-results": 29
+                },
+                {
+                    "title": "Vest-Agder",
+                    "value": "20011",
+                    "total-results": 1
+                },
+                {
+                    "title": "Østfold",
+                    "value": "20002",
+                    "total-results": 4
+                }
+            ]
+        },
+        "price": {
+            "title": "Pris",
+            "range": true,
+            "name": "price",
+            "queries": [
+                {
+                    "title": "0-50000",
+                    "value": "0-50000",
+                    "total-results": 8
+                },
+                {
+                    "title": "50001-100000",
+                    "value": "50001-100000",
+                    "total-results": 9
+                },
+                {
+                    "title": "100001-150000",
+                    "value": "100001-150000",
+                    "total-results": 6
+                },
+                {
+                    "title": "150001-250000",
+                    "value": "150001-250000",
+                    "total-results": 12
+                },
+                {
+                    "title": "250001-500000",
+                    "value": "250001-500000",
+                    "total-results": 91
+                },
+                {
+                    "title": "500001-",
+                    "value": "500001-null",
+                    "total-results": 96
+                }
+            ]
+        },
+        "body_type": {
+            "title": "Karosseri",
+            "name": "body_type",
+            "queries": [
+                {
+                    "title": "Annet",
+                    "value": "11",
+                    "total-results": 5
+                },
+                {
+                    "title": "Cabriolet",
+                    "value": "7",
+                    "total-results": 8
+                },
+                {
+                    "title": "Coupe",
+                    "value": "6",
+                    "total-results": 16
+                },
+                {
+                    "title": "Flerbruksbil",
+                    "value": "5",
+                    "total-results": 4
+                },
+                {
+                    "title": "Kasse",
+                    "value": "10",
+                    "total-results": 1
+                },
+                {
+                    "title": "Kombi 3-dørs",
+                    "value": "1",
+                    "total-results": 2
+                },
+                {
+                    "title": "Kombi 5-dørs",
+                    "value": "2",
+                    "total-results": 32
+                },
+                {
+                    "title": "Pickup",
+                    "value": "8",
+                    "total-results": 1
+                },
+                {
+                    "title": "Sedan",
+                    "value": "3",
+                    "total-results": 50
+                },
+                {
+                    "title": "Stasjonsvogn",
+                    "value": "4",
+                    "total-results": 66
+                },
+                {
+                    "title": "SUV/Offroad",
+                    "value": "9",
+                    "total-results": 37
+                }
+            ]
+        },
+        "price_changed": {
+            "title": "Redusert pris",
+            "name": "price_changed"
+        }
+    },
+    "menubar": [
+        {
+            "type": "sort",
+            "label": "Sortér",
+            "data": {
+                "parameter": "sort",
+                "values": [
+                    {
+                        "label": "Publisert",
+                        "value": "0",
+                        "selected": true
+                    },
+                    {
+                        "label": "Modell",
+                        "value": "1",
+                        "selected": false
+                    },
+                    {
+                        "label": "Pris lav-høy",
+                        "value": "2",
+                        "selected": false
+                    },
+                    {
+                        "label": "Pris høy-lav",
+                        "value": "3",
+                        "selected": false
+                    },
+                    {
+                        "label": "Km lav-høy",
+                        "value": "4",
+                        "selected": false
+                    },
+                    {
+                        "label": "Km høy-lav",
+                        "value": "5",
+                        "selected": false
+                    },
+                    {
+                        "label": "År nyest-eldst",
+                        "value": "6",
+                        "selected": false
+                    },
+                    {
+                        "label": "År eldst-nyest",
+                        "value": "7",
+                        "selected": false
+                    },
+                    {
+                        "label": "Mest relevant",
+                        "value": "9",
+                        "selected": false
+                    },
+                    {
+                        "label": "Nærmest",
+                        "value": "99",
+                        "selected": false
+                    }
+                ]
+            }
+        }
+    ],
+    "sections": [
+        {
+            "cells": []
+        }
+    ],
+    "map": {
+        "parameter": "bbox",
+        "areaParameters": [
+            "location"
+        ]
+    }
+}

--- a/Sources/FINNFilterImplementation/FilterMarket.swift
+++ b/Sources/FINNFilterImplementation/FilterMarket.swift
@@ -4,9 +4,19 @@
 
 import Foundation
 
-enum FilterMarket: VerticalConfiguration {
-    enum Bap: String, VerticalConfiguration, CaseIterable {
+protocol FilterConfiguration {
+    var verticalId: String { get }
+    var preferenceFilterKeys: [FilterKey] { get }
+    var supportedFiltersKeys: [FilterKey] { get }
+}
+
+enum FilterMarket: FilterConfiguration {
+    enum Bap: String, FilterConfiguration, CaseIterable {
         case bap = "bap-webstore"
+
+        var verticalId: String {
+            return rawValue
+        }
 
         var preferenceFilterKeys: [FilterKey] {
             return [.searchType, .segment, .condition, .published]
@@ -21,8 +31,12 @@ enum FilterMarket: VerticalConfiguration {
         }
     }
 
-    enum Realestate: String, VerticalConfiguration, CaseIterable {
+    enum Realestate: String, FilterConfiguration, CaseIterable {
         case homes = "realestate-homes"
+
+        var verticalId: String {
+            return rawValue
+        }
 
         var preferenceFilterKeys: [FilterKey] {
             return [.published, .isSold, .isNewProperty, .isSold]
@@ -48,9 +62,13 @@ enum FilterMarket: VerticalConfiguration {
         }
     }
 
-    enum Car: String, VerticalConfiguration, CaseIterable {
+    enum Car: String, FilterConfiguration, CaseIterable {
         case norway = "car-norway"
         case abroad = "car-abroad"
+
+        var verticalId: String {
+            return rawValue
+        }
 
         var preferenceFilterKeys: [FilterKey] {
             switch self {
@@ -119,37 +137,27 @@ enum FilterMarket: VerticalConfiguration {
         self = market
     }
 
-    var verticalId: String {
+    private var currentFilterConfig: FilterConfiguration {
         switch self {
         case let .bap(bap):
-            return bap.rawValue
+            return bap
         case let .realestate(realestate):
-            return realestate.rawValue
+            return realestate
         case let .car(car):
-            return car.rawValue
+            return car
         }
+    }
+
+    var verticalId: String {
+        return currentFilterConfig.verticalId
     }
 
     var preferenceFilterKeys: [FilterKey] {
-        switch self {
-        case let .bap(bap):
-            return bap.preferenceFilterKeys
-        case let .realestate(realestate):
-            return realestate.preferenceFilterKeys
-        case let .car(car):
-            return car.preferenceFilterKeys
-        }
+        return currentFilterConfig.preferenceFilterKeys
     }
 
     var supportedFiltersKeys: [FilterKey] {
-        switch self {
-        case let .bap(bap):
-            return bap.supportedFiltersKeys
-        case let .realestate(realestate):
-            return realestate.supportedFiltersKeys
-        case let .car(car):
-            return car.supportedFiltersKeys
-        }
+        return currentFilterConfig.supportedFiltersKeys
     }
 }
 
@@ -159,9 +167,4 @@ extension FilterMarket: CaseIterable {
             + Realestate.allCases.map(FilterMarket.realestate)
             + Car.allCases.map(FilterMarket.car)
     }
-}
-
-protocol VerticalConfiguration {
-    var preferenceFilterKeys: [FilterKey] { get }
-    var supportedFiltersKeys: [FilterKey] { get }
 }

--- a/Sources/FINNFilterImplementation/FilterMarket.swift
+++ b/Sources/FINNFilterImplementation/FilterMarket.swift
@@ -4,41 +4,31 @@
 
 import Foundation
 
-enum FilterMarket: String {
-    case bap, realestate, car
+enum FilterMarket: VerticalConfiguration {
+    enum Bap: String, VerticalConfiguration, CaseIterable {
+        case bap = "bap-webstore"
 
-    init?(market: String) {
-        guard let market = FilterMarket.allMarkets.first(where: { market.hasPrefix($0.rawValue) }) else {
-            return nil
-        }
-
-        self = market
-    }
-
-    static var allMarkets: [FilterMarket] {
-        return [.bap, .realestate, car]
-    }
-
-    var preferenceFilterKeys: [FilterKey] {
-        switch self {
-        case .bap:
+        var preferenceFilterKeys: [FilterKey] {
             return [.searchType, .segment, .condition, .published]
-        case .realestate:
-            return [.published, .isSold, .isNewProperty, .isSold]
-        case .car:
-            return [.condition, .published, .priceChanged, .dealerSegment]
         }
-    }
 
-    var supportedFiltersKeys: [FilterKey] {
-        switch self {
-        case .bap:
+        var supportedFiltersKeys: [FilterKey] {
             return [
                 .location,
                 .category,
                 .price,
             ]
-        case .realestate:
+        }
+    }
+
+    enum Realestate: String, VerticalConfiguration, CaseIterable {
+        case homes = "realestate-homes"
+
+        var preferenceFilterKeys: [FilterKey] {
+            return [.published, .isSold, .isNewProperty, .isSold]
+        }
+
+        var supportedFiltersKeys: [FilterKey] {
             return [
                 .location,
                 .price,
@@ -55,26 +45,123 @@ enum FilterMarket: String {
                 .energyLabel,
                 .plotArea,
             ]
-        case .car:
-            return [
-                .make,
-                .salesForm,
-                .year,
-                .mileage,
-                .price,
-                .location,
-                .bodyType,
-                .engineFuel,
-                .exteriorColour,
-                .engineEffect,
-                .numberOfSeats,
-                .wheelDrive,
-                .transmission,
-                .carEquipment,
-                .warrantyInsurance,
-                .wheelSets,
-                .registrationClass,
-            ]
         }
     }
+
+    enum Car: String, VerticalConfiguration, CaseIterable {
+        case norway = "car-norway"
+        case abroad = "car-abroad"
+
+        var preferenceFilterKeys: [FilterKey] {
+            switch self {
+            case .norway:
+                return [.condition, .published, .priceChanged, .dealerSegment]
+            case .abroad:
+                return [.condition, .published, .priceChanged, .dealerSegment]
+            }
+        }
+
+        var supportedFiltersKeys: [FilterKey] {
+            switch self {
+            case .norway:
+                return [
+                    .make,
+                    .salesForm,
+                    .year,
+                    .mileage,
+                    .price,
+                    .location,
+                    .bodyType,
+                    .engineFuel,
+                    .exteriorColour,
+                    .engineEffect,
+                    .numberOfSeats,
+                    .wheelDrive,
+                    .transmission,
+                    .carEquipment,
+                    .warrantyInsurance,
+                    .wheelSets,
+                    .registrationClass,
+                ]
+            case .abroad:
+                return [
+                    .make,
+                    .salesForm,
+                    .year,
+                    .mileage,
+                    .price,
+                    .location,
+                    .bodyType,
+                    .engineFuel,
+                    .exteriorColour,
+                    .engineEffect,
+                    .numberOfSeats,
+                    .wheelDrive,
+                    .transmission,
+                    .carEquipment,
+                    .warrantyInsurance,
+                    .wheelSets,
+                    .registrationClass,
+                ]
+            }
+        }
+    }
+
+    case bap(Bap)
+    case realestate(Realestate)
+    case car(Car)
+
+    init?(market: String) {
+        guard let market = FilterMarket.allCases.first(where: { market == $0.verticalId }) else {
+            return nil
+        }
+
+        self = market
+    }
+
+    var verticalId: String {
+        switch self {
+        case let .bap(bap):
+            return bap.rawValue
+        case let .realestate(realestate):
+            return realestate.rawValue
+        case let .car(car):
+            return car.rawValue
+        }
+    }
+
+    var preferenceFilterKeys: [FilterKey] {
+        switch self {
+        case let .bap(bap):
+            return bap.preferenceFilterKeys
+        case let .realestate(realestate):
+            return realestate.preferenceFilterKeys
+        case let .car(car):
+            return car.preferenceFilterKeys
+        }
+    }
+
+    var supportedFiltersKeys: [FilterKey] {
+        switch self {
+        case let .bap(bap):
+            return bap.supportedFiltersKeys
+        case let .realestate(realestate):
+            return realestate.supportedFiltersKeys
+        case let .car(car):
+            return car.supportedFiltersKeys
+        }
+    }
+}
+
+extension FilterMarket: CaseIterable {
+    static var allCases: [FilterMarket] {
+        return Bap.allCases.map(FilterMarket.bap)
+            + Realestate.allCases.map(FilterMarket.realestate)
+            + Car.allCases.map(FilterMarket.car)
+    }
+}
+
+protocol VerticalConfiguration {
+    var preferenceFilterKeys: [FilterKey] { get }
+    var supportedFiltersKeys: [FilterKey] { get }
 }

--- a/Sources/FINNFilterImplementation/FilterMarket.swift
+++ b/Sources/FINNFilterImplementation/FilterMarket.swift
@@ -5,17 +5,17 @@
 import Foundation
 
 protocol FilterConfiguration {
-    var verticalId: String { get }
+    func handlesVerticalId(_ vertical: String) -> Bool
     var preferenceFilterKeys: [FilterKey] { get }
     var supportedFiltersKeys: [FilterKey] { get }
 }
 
 enum FilterMarket: FilterConfiguration {
     enum Bap: String, FilterConfiguration, CaseIterable {
-        case bap = "bap-webstore"
+        case bap
 
-        var verticalId: String {
-            return rawValue
+        func handlesVerticalId(_ vertical: String) -> Bool {
+            return rawValue == vertical || vertical.hasPrefix(rawValue + "-")
         }
 
         var preferenceFilterKeys: [FilterKey] {
@@ -34,8 +34,8 @@ enum FilterMarket: FilterConfiguration {
     enum Realestate: String, FilterConfiguration, CaseIterable {
         case homes = "realestate-homes"
 
-        var verticalId: String {
-            return rawValue
+        func handlesVerticalId(_ vertical: String) -> Bool {
+            return rawValue == vertical
         }
 
         var preferenceFilterKeys: [FilterKey] {
@@ -66,8 +66,8 @@ enum FilterMarket: FilterConfiguration {
         case norway = "car-norway"
         case abroad = "car-abroad"
 
-        var verticalId: String {
-            return rawValue
+        func handlesVerticalId(_ vertical: String) -> Bool {
+            return rawValue == vertical
         }
 
         var preferenceFilterKeys: [FilterKey] {
@@ -130,7 +130,7 @@ enum FilterMarket: FilterConfiguration {
     case car(Car)
 
     init?(market: String) {
-        guard let market = FilterMarket.allCases.first(where: { market == $0.verticalId }) else {
+        guard let market = FilterMarket.allCases.first(where: { $0.handlesVerticalId(market) }) else {
             return nil
         }
 
@@ -148,8 +148,8 @@ enum FilterMarket: FilterConfiguration {
         }
     }
 
-    var verticalId: String {
-        return currentFilterConfig.verticalId
+    func handlesVerticalId(_ vertical: String) -> Bool {
+        return currentFilterConfig.handlesVerticalId(vertical)
     }
 
     var preferenceFilterKeys: [FilterKey] {

--- a/UnitTests/FilterBuilder/FilterInfoBuilderTests.swift
+++ b/UnitTests/FilterBuilder/FilterInfoBuilderTests.swift
@@ -60,7 +60,7 @@ class FilterInfoBuilderTests: XCTestCase, TestDataDecoder {
         XCTAssertNotNil(preferenceFilterInfos)
         XCTAssertNotNil(publishedFilterData)
 
-        XCTAssertEqual(preferenceFilterInfos?.count, FilterMarket.car.preferenceFilterKeys.count)
+        XCTAssertEqual(preferenceFilterInfos?.count, FilterMarket.car(.norway).preferenceFilterKeys.count)
 
         XCTAssertNotNil(publishedPreference)
         XCTAssertEqual(publishedPreference?.title, "Publisert")

--- a/UnitTests/FilterBuilder/FilterMarketTests.swift
+++ b/UnitTests/FilterBuilder/FilterMarketTests.swift
@@ -1,0 +1,25 @@
+//
+//  Copyright © FINN.no AS, Inc. All rights reserved.
+//
+
+@testable import Charcoal
+import XCTest
+
+class FilterMarketTests: NSObject {
+    func testFilterMarketAllCasesMustBeExhaustive() {
+        let results = verifyAllCasesIsExhaustive(filterMarket: .bap(.bap))
+        XCTAssertTrue(results, "If it compiles the test works...")
+    }
+}
+
+extension FilterMarketTests {
+    func verifyAllCasesIsExhaustive(filterMarket: FilterMarket) -> Bool {
+        switch filterMarket {
+        case .bap(.bap),
+             .realestate(.homes),
+             .car(.norway), .car(.abroad):
+            break
+        }
+        return true
+    }
+}


### PR DESCRIPTION
# Why?
Filter setup needs to handle submarkets.

# What?
Expand enum configuration with nested enums. This might not be the best for when all markets should be fully configured, but it gives us something to work with.

# Show me
Not much to see. 