### PR TITLE
Tweaks for switching submarkets

### DIFF
--- a/Sources/Root/FilterRootStateController.swift
+++ b/Sources/Root/FilterRootStateController.swift
@@ -21,11 +21,12 @@ public class FilterRootStateController: UIViewController {
         case filters
         case filtersUpdated(data: FilterDataSource)
         case loadFreshFilters(data: FilterDataSource)
+        case newSelectionDataSource(data: FilterSelectionDataSource)
         case failed(error: FilterRootError, action: FilterRootErrorAction)
     }
 
     private let navigator: RootFilterNavigator
-    private let selectionDataSource: FilterSelectionDataSource
+    private var selectionDataSource: FilterSelectionDataSource
     private let filterSelectionTitleProvider: FilterSelectionTitleProvider
     weak var delegate: FilterRootStateControllerDelegate?
 
@@ -73,14 +74,6 @@ public class FilterRootStateController: UIViewController {
         configure(for: state)
     }
 
-    // MARK: -
-
-    private func createFilterRootViewController() -> FilterRootViewController {
-        let vc = FilterRootViewController(title: "", navigator: navigator, selectionDataSource: selectionDataSource, filterSelectionTitleProvider: filterSelectionTitleProvider)
-        vc.delegate = self
-        return vc
-    }
-
     // MARK: - State handling
 
     public func change(to change: StateChange) {
@@ -97,6 +90,9 @@ public class FilterRootStateController: UIViewController {
             filterRootViewController = FilterRootViewController(title: "", navigator: navigator, selectionDataSource: selectionDataSource, filterSelectionTitleProvider: filterSelectionTitleProvider, delegate: self)
             currentFilterDataSource = dataSource
             state = .filter
+        case let .newSelectionDataSource(newSelectionDataSource):
+            selectionDataSource = newSelectionDataSource
+            filterRootViewController.selectionDataSource = newSelectionDataSource
         case let .failed(error, action):
             errorViewController.showError(error.errorMessage, actionTitle: action.title, actionCallback: action.action)
             state = .error

--- a/Sources/Root/FilterRootViewController.swift
+++ b/Sources/Root/FilterRootViewController.swift
@@ -285,7 +285,8 @@ extension FilterRootViewController: UITableViewDataSource {
         case .searchQuery:
             return searchQueryFilter != nil ? 1 : 0
         case .preferences:
-            return preferenceFilters.count > 0 ? 1 : 0
+            let hasData = !verticalsFilters.isEmpty || !preferenceFilters.isEmpty
+            return hasData ? 1 : 0
         case .filters:
             return filters.count
         }

--- a/Sources/Root/RootFilterNavigator.swift
+++ b/Sources/Root/RootFilterNavigator.swift
@@ -108,7 +108,17 @@ private extension RootFilterNavigator {
 
         filterRootViewController.popoverPresentationTransitioningDelegate = transitioningDelegate
 
-        preferencelistViewController.preferredContentSize = CGSize(width: filterRootViewController.view.frame.size.width, height: 144)
+        let sourceViewBottom = filterRootViewController.view.convert(CGPoint(x: 0, y: sourceView.bounds.maxY), from: sourceView).y
+        let popoverHeight: CGFloat
+        let maxHeightForPopover = filterRootViewController.view.bounds.height - sourceViewBottom - 20
+        let numberOfRowsFitting = maxHeightForPopover / VerticalListViewController.rowHeight
+        if numberOfRowsFitting < CGFloat(verticals.count) {
+            popoverHeight = (floor(numberOfRowsFitting) - 0.5) * VerticalListViewController.rowHeight
+        } else {
+            popoverHeight = CGFloat(verticals.count) * VerticalListViewController.rowHeight
+        }
+
+        preferencelistViewController.preferredContentSize = CGSize(width: filterRootViewController.view.frame.size.width, height: popoverHeight)
         preferencelistViewController.modalPresentationStyle = .custom
         preferencelistViewController.transitioningDelegate = transitioningDelegate
 

--- a/Sources/Vertical/VerticalListViewController.swift
+++ b/Sources/Vertical/VerticalListViewController.swift
@@ -9,7 +9,7 @@ public protocol VerticalListViewControllerDelegate: AnyObject {
 }
 
 public class VerticalListViewController: UIViewController {
-    private static var rowHeight: CGFloat = 48.0
+    static let rowHeight: CGFloat = 48.0
 
     private lazy var tableView: UITableView = {
         let tableView = UITableView(frame: .zero, style: .plain)


### PR DESCRIPTION
# Why?
Some additional fixes made when integrating with the main app

# What?
- API for switching to a new selection data source.
- Tweaked the verticals popover so it tries to fit as many items as possible while still showing below the button. Also making sure to show half of the first incomplete item if all doesn't fit on screen.
- Root view will now show verticals even if there are no preference filters.

# Show me
Change for the verticals popover:

### Before
![simulator screen shot - iphone 6s - 2018-11-23 at 09 45 13](https://user-images.githubusercontent.com/3169203/48934488-82502c00-ef04-11e8-9f33-b4bd6dd1dd90.png)


### After
![simulator screen shot - iphone 6s - 2018-11-23 at 09 43 06](https://user-images.githubusercontent.com/3169203/48934422-4cab4300-ef04-11e8-8088-e17bd3dce5e5.png)
