### PR TITLE
Make range control work when all the way to left side

### DIFF
--- a/Sources/NavigationController/FilterNavigationController.swift
+++ b/Sources/NavigationController/FilterNavigationController.swift
@@ -8,4 +8,18 @@ public class FilterNavigationController: UINavigationController {
     public var currentFilterViewController: AnyFilterViewController? {
         return topViewController as? AnyFilterViewController
     }
+
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+        interactivePopGestureRecognizer?.delegate = self
+    }
+}
+
+extension FilterNavigationController: UIGestureRecognizerDelegate {
+    public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
+        if let slider = touch.view as? UISlider, slider.isEnabled, !slider.isHidden {
+            return false
+        }
+        return true
+    }
 }


### PR DESCRIPTION
# Why?
It was impossible to slide a range control that was all the way to the left side.

# What?
After experimenting a bit I determined it was the interactive pop gesture that was "stealing" the touch, so now made the general rule that it should never be used when the touch is inside an enabled and visible UISlider control. 

# Show me
UI looks the same.