### PR TITLE
Remove double scrolling when panning up bottom sheet while viewing ro…

### DIFF
--- a/Sources/BottomSheet/BottomSheetPresentationController.swift
+++ b/Sources/BottomSheet/BottomSheetPresentationController.swift
@@ -365,6 +365,14 @@ extension BottomSheetPresentationController: UIGestureRecognizerDelegate {
     public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
         if gestureRecognizer === panGestureRecognizer {
             let translation = panGestureRecognizer.translation(in: containerView)
+
+            // Let's only recognize if the user seems to be panning in y mainly
+            if translation.y == 0 {
+                return false
+            } else if abs(translation.x) > abs(translation.y) {
+                return false
+            }
+
             return bottomSheetPresentationControllerDelegate?.bottomsheetPresentationController(self, shouldBeginTransitionWithTranslation: translation, from: currentContentSizeMode) ?? true
         }
 

--- a/Sources/Root/FilterRootStateController.swift
+++ b/Sources/Root/FilterRootStateController.swift
@@ -133,6 +133,22 @@ extension FilterRootStateController: FilterRootViewControllerDelegate {
     }
 }
 
+extension FilterRootStateController: AnyFilterViewController {
+    public var mainScrollableContentView: UIScrollView? {
+        guard state == .filter else {
+            return nil
+        }
+        return filterRootViewController.mainScrollableContentView
+    }
+
+    public var isMainScrollableViewScrolledToTop: Bool {
+        guard state == .filter else {
+            return true
+        }
+        return filterRootViewController.isMainScrollableViewScrolledToTop
+    }
+}
+
 public enum FilterRootError: Error {
     case unableToLoadFilterData
     case undefined


### PR DESCRIPTION
# Why?
After adding `FilterRootStateController` as parent of `FilterRootViewController` scrolling started to occur in the view at the same time as the user was moving the bottom sheet to expanded state.

# What?
Add the missing/forgotten implementation in `FilterRootStateController`.

# Show me

### Before
![double-scroll-fix-before](https://user-images.githubusercontent.com/3169203/49088402-7ee8d780-f259-11e8-8673-3774d1b3c28a.gif)

### After
![double-scroll-fix-after](https://user-images.githubusercontent.com/3169203/49088408-83ad8b80-f259-11e8-881a-6dce85ad0c7a.gif)
