### PR TITLE
Added functionality to pass on additional panning after bottom sheet …

### DIFF
--- a/Demo/Fullscreen/BottomSheetDemoViewController.swift
+++ b/Demo/Fullscreen/BottomSheetDemoViewController.swift
@@ -41,6 +41,9 @@ class BottomSheetDemoViewController: UITableViewController {
 }
 
 extension BottomSheetDemoViewController: BottomSheetPresentationControllerDelegate {
+    func bottomsheetPresentationController(_ bottomsheetPresentationController: BottomSheetPresentationController, panningBeyondExpandedState additionalVerticalPan: CGFloat) {
+    }
+
     func bottomsheetPresentationController(_ bottomsheetPresentationController: BottomSheetPresentationController, didTransitionFromContentSizeMode current: BottomSheetPresentationController.ContentSizeMode, to new: BottomSheetPresentationController.ContentSizeMode) {
     }
 

--- a/Sources/BottomSheet/BottomSheetPresentationController.swift
+++ b/Sources/BottomSheet/BottomSheetPresentationController.swift
@@ -8,6 +8,7 @@ public protocol BottomSheetPresentationControllerDelegate: UIAdaptivePresentatio
     func bottomsheetPresentationController(_ bottomsheetPresentationController: BottomSheetPresentationController, willTransitionFromContentSizeMode current: BottomSheetPresentationController.ContentSizeMode, to new: BottomSheetPresentationController.ContentSizeMode)
     func bottomsheetPresentationController(_ bottomsheetPresentationController: BottomSheetPresentationController, didTransitionFromContentSizeMode current: BottomSheetPresentationController.ContentSizeMode, to new: BottomSheetPresentationController.ContentSizeMode)
     func bottomsheetPresentationController(_ bottomsheetPresentationController: BottomSheetPresentationController, shouldBeginTransitionWithTranslation translation: CGPoint, from contentSizeMode: BottomSheetPresentationController.ContentSizeMode) -> Bool
+    func bottomsheetPresentationController(_ bottomsheetPresentationController: BottomSheetPresentationController, panningBeyondExpandedState additionalVerticalPan: CGFloat)
 }
 
 public final class BottomSheetPresentationController: UIPresentationController {
@@ -315,7 +316,9 @@ private extension BottomSheetPresentationController {
             let maxTopAnchorconstant = rect(for: .compact, in: containerView.frame).minY
             presentedViewTopAnchorConstraint?.constant = min(max(newTopAnchorConstant, minTopAnchorConstant), maxTopAnchorconstant)
             containerView.layoutIfNeeded()
-
+            if panDirection == .up && newTopAnchorConstant < minTopAnchorConstant {
+                bottomSheetPresentationControllerDelegate?.bottomsheetPresentationController(self, panningBeyondExpandedState: minTopAnchorConstant - newTopAnchorConstant)
+            }
         case .ended:
             let isTransitionHandledByInteractiveDismissal = (interactiveDismissalController?.percentComplete ?? 0.0) < 0.0
 

--- a/Sources/FilterViewController/AnyFilterViewController.swift
+++ b/Sources/FilterViewController/AnyFilterViewController.swift
@@ -48,4 +48,11 @@ public extension BottomSheetPresentationControllerDelegate where Self: AnyFilter
             }
         }
     }
+
+    func bottomsheetPresentationController(_ bottomsheetPresentationController: BottomSheetPresentationController, panningBeyondExpandedState additionalVerticalPan: CGFloat) {
+        guard let scrollView = mainScrollableContentView else {
+            return
+        }
+        scrollView.contentOffset = CGPoint(x: scrollView.contentOffset.x, y: additionalVerticalPan)
+    }
 }

--- a/Sources/Root/FilterRootViewController.swift
+++ b/Sources/Root/FilterRootViewController.swift
@@ -370,7 +370,7 @@ private extension FilterRootViewController {
         } else {
             scrollPos = (tableView.contentOffset.y + tableView.contentInset.top)
         }
-        return scrollPos < 1
+        return scrollPos <= 1
     }
 
     var isScrollEnabled: Bool {


### PR DESCRIPTION
# Why?
When panning up the bottomsheet to expanded state it is nice if you don't need to lift your finger and slide again to move the table inside.

# What?
Added functionality to pass on additional panning after bottom sheet expand state is reached to any currently shown scrollable content. Basically just calling a delegate to inform about how much above the expand state the user is moving the finger. To simplify things this implementation assumes that the scrollable content is always scrolled to the top before the bottomsheet reaches expanded state (which should always be the case here).

# Show me

### Before
![cont-scroll-before](https://user-images.githubusercontent.com/3169203/49208140-40692f00-f3b7-11e8-9a6b-8a40bed8a298.gif)


### After
![cont-scroll-after](https://user-images.githubusercontent.com/3169203/49208151-45c67980-f3b7-11e8-86e6-4be3f8cf7dc0.gif)