### PR TITLE
Don't show isSold twice. Include isPrivateBroker instead

### DIFF
--- a/Sources/FINNFilterImplementation/FilterMarket.swift
+++ b/Sources/FINNFilterImplementation/FilterMarket.swift
@@ -39,7 +39,7 @@ enum FilterMarket: FilterConfiguration {
         }
 
         var preferenceFilterKeys: [FilterKey] {
-            return [.published, .isSold, .isNewProperty, .isSold]
+            return [.published, .isSold, .isNewProperty, .isPrivateBroker]
         }
 
         var supportedFiltersKeys: [FilterKey] {


### PR DESCRIPTION
# Why?
The realestate config was wrong

# What?
Don't show isSold twice. Include isPrivateBroker.

# Show me

### Before
![simulator screen shot - ipad air 2 - 2018-12-03 at 12 48 41](https://user-images.githubusercontent.com/3169203/49372151-03c06f00-f6fa-11e8-8a65-a4c60717040c.png)

### After
![simulator screen shot - ipad air 2 - 2018-12-03 at 12 46 05](https://user-images.githubusercontent.com/3169203/49372157-08852300-f6fa-11e8-8424-60486ce32ced.png)
