### PR TITLE
Fix showResultsButtonView "jumping" when animating/sliding the bottom sheet

### DIFF
--- a/Sources/Root/FilterRootViewController.swift
+++ b/Sources/Root/FilterRootViewController.swift
@@ -134,6 +134,14 @@ public class FilterRootViewController: UIViewController {
         return cell
     }()
 
+    private var bottomLayoutConstant: CGFloat {
+        if #available(iOS 11.0, *) {
+            return UIApplication.shared.delegate?.window??.safeAreaInsets.bottom ?? 0
+        } else {
+            return 0
+        }
+    }
+
     public init(title: String, navigator: RootFilterNavigator, selectionDataSource: FilterSelectionDataSource, filterSelectionTitleProvider: FilterSelectionTitleProvider, delegate: FilterRootViewControllerDelegate? = nil) {
         self.navigator = navigator
         self.selectionDataSource = selectionDataSource
@@ -177,7 +185,7 @@ private extension FilterRootViewController {
             showResultsButtonView.topAnchor.constraint(equalTo: tableView.bottomAnchor),
             showResultsButtonView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             showResultsButtonView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            showResultsButtonView.bottomAnchor.constraint(equalTo: bottomLayoutGuide.topAnchor),
+            showResultsButtonView.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -bottomLayoutConstant),
         ])
     }
 

--- a/Sources/Root/FilterRootViewController.swift
+++ b/Sources/Root/FilterRootViewController.swift
@@ -134,7 +134,7 @@ public class FilterRootViewController: UIViewController {
         return cell
     }()
 
-    private var bottomLayoutConstant: CGFloat {
+    private var bottomSafeAreaInset: CGFloat {
         if #available(iOS 11.0, *) {
             return UIApplication.shared.delegate?.window??.safeAreaInsets.bottom ?? 0
         } else {
@@ -185,7 +185,7 @@ private extension FilterRootViewController {
             showResultsButtonView.topAnchor.constraint(equalTo: tableView.bottomAnchor),
             showResultsButtonView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             showResultsButtonView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            showResultsButtonView.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -bottomLayoutConstant),
+            showResultsButtonView.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -bottomSafeAreaInset),
         ])
     }
 


### PR DESCRIPTION
# Why?

`showResultsButtonView` was "jumping" when animating/sliding the bottom sheet because of updates to the safe area.

# What?

Use `safeAreaInsets` of the window to set the bottom anchor of `showResultsButtonView`. Here we access app delegate through `UIApplication.shared.delegate`, so it's not the most elegant solution. But it seems like the only way to get safe area insets before we set constraints. I also tried to use `viewDidLayoutSubviews` or `viewSafeAreaInsetsDidChange`, but it doesn't fix initial "jumping" when we open the bottom sheet with animation.

`UIApplication.shared.delegate?.window??.safeAreaInsets` could also be injected to `FilterRootViewController`, but it seems like overkill for this UI fix.

# Show me

### Before

![filter_before](https://user-images.githubusercontent.com/10529867/51114565-f4a70380-1805-11e9-80bb-a1cc1657062a.gif)

### After

![filter_after](https://user-images.githubusercontent.com/10529867/51114572-fa044e00-1805-11e9-8893-37583c62e56f.gif)