### PR TITLE
Cleanup in filter selection

### DIFF
--- a/Charcoal.xcodeproj/project.pbxproj
+++ b/Charcoal.xcodeproj/project.pbxproj
@@ -127,6 +127,7 @@
 		9BE5EC6B21CBC54F009C5E1A /* MapFilterCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BE5EC6A21CBC54F009C5E1A /* MapFilterCell.swift */; };
 		9BE5EC6D21DD0AF0009C5E1A /* SearchLocationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BE5EC6C21DD0AF0009C5E1A /* SearchLocationViewController.swift */; };
 		9BE5EC6F21DE273C009C5E1A /* DemoSearchLocationDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BE5EC6E21DE273C009C5E1A /* DemoSearchLocationDataSource.swift */; };
+		9BE5EC8E21EDE83D009C5E1A /* FINNFilterSelectionData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BE5EC8D21EDE83C009C5E1A /* FINNFilterSelectionData.swift */; };
 		9BE9A060219ADC2000059C19 /* CollapsedSelectionValuesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BE9A05F219ADC2000059C19 /* CollapsedSelectionValuesView.swift */; };
 		9BE9A062219ADC4F00059C19 /* ExpandedSelectionValuesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BE9A061219ADC4F00059C19 /* ExpandedSelectionValuesView.swift */; };
 		9BF778CC21C16374006C0416 /* MapFilterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BF778CB21C16374006C0416 /* MapFilterViewController.swift */; };
@@ -313,6 +314,7 @@
 		9BE5EC6A21CBC54F009C5E1A /* MapFilterCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapFilterCell.swift; sourceTree = "<group>"; };
 		9BE5EC6C21DD0AF0009C5E1A /* SearchLocationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchLocationViewController.swift; sourceTree = "<group>"; };
 		9BE5EC6E21DE273C009C5E1A /* DemoSearchLocationDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoSearchLocationDataSource.swift; sourceTree = "<group>"; };
+		9BE5EC8D21EDE83C009C5E1A /* FINNFilterSelectionData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FINNFilterSelectionData.swift; sourceTree = "<group>"; };
 		9BE9A05F219ADC2000059C19 /* CollapsedSelectionValuesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollapsedSelectionValuesView.swift; sourceTree = "<group>"; };
 		9BE9A061219ADC4F00059C19 /* ExpandedSelectionValuesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpandedSelectionValuesView.swift; sourceTree = "<group>"; };
 		9BF778CB21C16374006C0416 /* MapFilterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapFilterViewController.swift; sourceTree = "<group>"; };
@@ -626,6 +628,7 @@
 				559C61F220DA4C3B0083A574 /* FilterBuilder */,
 				55BDA76C20DBC43F00331FFC /* FilterKey.swift */,
 				55BDA76E20DBC46800331FFC /* FilterMarket.swift */,
+				9BE5EC8D21EDE83C009C5E1A /* FINNFilterSelectionData.swift */,
 				9BC45F732153D08700727AEB /* ParameterBasedFilterInfoSelectionDataSource.swift */,
 			);
 			path = FINNFilterImplementation;
@@ -1155,6 +1158,7 @@
 				9BB827A2216C9C800014028C /* ListSelectionFilterInfo.swift in Sources */,
 				9BE0A06A209724D70000632B /* InlineFilterCell.swift in Sources */,
 				DA7FB7A821B01E33003DBBEB /* SegmentButton.swift in Sources */,
+				9BE5EC8E21EDE83D009C5E1A /* FINNFilterSelectionData.swift in Sources */,
 				9BB8279A216B57730014028C /* DebugLog.swift in Sources */,
 				5525324420A2DB73000CBD21 /* RootFilterNavigator.swift in Sources */,
 				DAF3CA7221830B1C007235B0 /* StepperFilterView.swift in Sources */,

--- a/Charcoal.xcodeproj/project.pbxproj
+++ b/Charcoal.xcodeproj/project.pbxproj
@@ -127,7 +127,8 @@
 		9BE5EC6B21CBC54F009C5E1A /* MapFilterCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BE5EC6A21CBC54F009C5E1A /* MapFilterCell.swift */; };
 		9BE5EC6D21DD0AF0009C5E1A /* SearchLocationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BE5EC6C21DD0AF0009C5E1A /* SearchLocationViewController.swift */; };
 		9BE5EC6F21DE273C009C5E1A /* DemoSearchLocationDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BE5EC6E21DE273C009C5E1A /* DemoSearchLocationDataSource.swift */; };
-		9BE5EC8E21EDE83D009C5E1A /* FINNFilterSelectionData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BE5EC8D21EDE83C009C5E1A /* FINNFilterSelectionData.swift */; };
+		9BE5EC8E21EDE83D009C5E1A /* FilterSelectionData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BE5EC8D21EDE83C009C5E1A /* FilterSelectionData.swift */; };
+		9BE5EC9021EE0BB1009C5E1A /* FilterSelectionDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BE5EC8F21EE0BB1009C5E1A /* FilterSelectionDataTests.swift */; };
 		9BE9A060219ADC2000059C19 /* CollapsedSelectionValuesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BE9A05F219ADC2000059C19 /* CollapsedSelectionValuesView.swift */; };
 		9BE9A062219ADC4F00059C19 /* ExpandedSelectionValuesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BE9A061219ADC4F00059C19 /* ExpandedSelectionValuesView.swift */; };
 		9BF778CC21C16374006C0416 /* MapFilterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BF778CB21C16374006C0416 /* MapFilterViewController.swift */; };
@@ -314,7 +315,8 @@
 		9BE5EC6A21CBC54F009C5E1A /* MapFilterCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapFilterCell.swift; sourceTree = "<group>"; };
 		9BE5EC6C21DD0AF0009C5E1A /* SearchLocationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchLocationViewController.swift; sourceTree = "<group>"; };
 		9BE5EC6E21DE273C009C5E1A /* DemoSearchLocationDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoSearchLocationDataSource.swift; sourceTree = "<group>"; };
-		9BE5EC8D21EDE83C009C5E1A /* FINNFilterSelectionData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FINNFilterSelectionData.swift; sourceTree = "<group>"; };
+		9BE5EC8D21EDE83C009C5E1A /* FilterSelectionData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterSelectionData.swift; sourceTree = "<group>"; };
+		9BE5EC8F21EE0BB1009C5E1A /* FilterSelectionDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterSelectionDataTests.swift; sourceTree = "<group>"; };
 		9BE9A05F219ADC2000059C19 /* CollapsedSelectionValuesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollapsedSelectionValuesView.swift; sourceTree = "<group>"; };
 		9BE9A061219ADC4F00059C19 /* ExpandedSelectionValuesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpandedSelectionValuesView.swift; sourceTree = "<group>"; };
 		9BF778CB21C16374006C0416 /* MapFilterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapFilterViewController.swift; sourceTree = "<group>"; };
@@ -628,7 +630,7 @@
 				559C61F220DA4C3B0083A574 /* FilterBuilder */,
 				55BDA76C20DBC43F00331FFC /* FilterKey.swift */,
 				55BDA76E20DBC46800331FFC /* FilterMarket.swift */,
-				9BE5EC8D21EDE83C009C5E1A /* FINNFilterSelectionData.swift */,
+				9BE5EC8D21EDE83C009C5E1A /* FilterSelectionData.swift */,
 				9BC45F732153D08700727AEB /* ParameterBasedFilterInfoSelectionDataSource.swift */,
 			);
 			path = FINNFilterImplementation;
@@ -760,6 +762,7 @@
 		9BB827B2216DF2C40014028C /* FilterSelectionDataSource */ = {
 			isa = PBXGroup;
 			children = (
+				9BE5EC8F21EE0BB1009C5E1A /* FilterSelectionDataTests.swift */,
 				9BB827B3216DF2E20014028C /* ParameterBasedFilterInfoSelectionDataSourceTests.swift */,
 			);
 			path = FilterSelectionDataSource;
@@ -1158,7 +1161,7 @@
 				9BB827A2216C9C800014028C /* ListSelectionFilterInfo.swift in Sources */,
 				9BE0A06A209724D70000632B /* InlineFilterCell.swift in Sources */,
 				DA7FB7A821B01E33003DBBEB /* SegmentButton.swift in Sources */,
-				9BE5EC8E21EDE83D009C5E1A /* FINNFilterSelectionData.swift in Sources */,
+				9BE5EC8E21EDE83D009C5E1A /* FilterSelectionData.swift in Sources */,
 				9BB8279A216B57730014028C /* DebugLog.swift in Sources */,
 				5525324420A2DB73000CBD21 /* RootFilterNavigator.swift in Sources */,
 				DAF3CA7221830B1C007235B0 /* StepperFilterView.swift in Sources */,
@@ -1225,6 +1228,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				55BDA76620DB7FC000331FFC /* TestDataDecoder.swift in Sources */,
+				9BE5EC9021EE0BB1009C5E1A /* FilterSelectionDataTests.swift in Sources */,
 				55BDA76820DB9A7300331FFC /* RangeFilterBuilderTests.swift in Sources */,
 				559C61FC20DA87330083A574 /* FilterDecodingTests.swift in Sources */,
 				9BE0D54321A4552300F0B63B /* FilterMarketTests.swift in Sources */,

--- a/Demo/Demo.swift
+++ b/Demo/Demo.swift
@@ -203,6 +203,9 @@ struct DemoSearchQueryFilterInfo: SearchQueryFilterInfoType {
 }
 
 class DemoEmptyFilterSelectionDataSource: FilterSelectionDataSource {
+    func setValueAndClearValueForChildren(_ value: String?, for filterInfo: MultiLevelListSelectionFilterInfoType) {
+    }
+
     func clearValueAndValueForChildren(for filterInfo: MultiLevelListSelectionFilterInfoType) {
     }
 

--- a/Demo/ListSelectionViewControllerDemoModels.swift
+++ b/Demo/ListSelectionViewControllerDemoModels.swift
@@ -64,6 +64,9 @@ class DemoListItem: FilterValueType, NumberOfHitsCompatible {
 }
 
 class DemoListFilterSelectionDataSource: FilterSelectionDataSource {
+    func setValueAndClearValueForChildren(_ value: String?, for filterInfo: MultiLevelListSelectionFilterInfoType) {
+    }
+
     var filterValues: [DemoListItem] = DemoListSelectionFilterInfo.listItems
 
     func clearValueAndValueForChildren(for filterInfo: MultiLevelListSelectionFilterInfoType) {

--- a/Demo/Root/DemoFilterRootViewControllerHelper.swift
+++ b/Demo/Root/DemoFilterRootViewControllerHelper.swift
@@ -55,6 +55,7 @@ class DemoFilter {
     func loadFilterSetup(_ filterSetup: FilterSetup) {
         filterData = filterSetup
         selectionDataSource = ParameterBasedFilterInfoSelectionDataSource()
+        selectionDataSource.delegate = self
         let filterInfoBuilder = FilterInfoBuilder(filter: filterData, selectionDataSource: selectionDataSource)
         loadedFilter = filterInfoBuilder.build()
     }
@@ -127,5 +128,11 @@ extension DemoFilter: FilterRootStateControllerDelegate {
 
     func filterRootStateControllerShouldShowResults(_: FilterRootStateController) {
         // Let user close in other ways
+    }
+}
+
+extension DemoFilter: ParameterBasedFilterInfoSelectionDataSourceDelegate {
+    func parameterBasedFilterInfoSelectionDataSourceDidChange(_ selectionDataSource: ParameterBasedFilterInfoSelectionDataSource) {
+        print("Filter selection changed: \(selectionDataSource)")
     }
 }

--- a/Sources/Dependencies/FilterSelectionDataSource.swift
+++ b/Sources/Dependencies/FilterSelectionDataSource.swift
@@ -84,6 +84,7 @@ public protocol FilterSelectionDataSource: AnyObject {
     func addValue(_ value: String, for filterInfo: FilterInfoType)
     func clearAll(for filterInfo: FilterInfoType)
     func clearValue(_ value: String, for filterInfo: FilterInfoType)
+    func setValueAndClearValueForChildren(_ value: String?, for filterInfo: MultiLevelListSelectionFilterInfoType)
     func clearValueAndValueForChildren(for filterInfo: MultiLevelListSelectionFilterInfoType)
     func clearSelection(at selectionValueIndex: Int, in selectionInfo: FilterSelectionInfo)
 

--- a/Sources/FINNFilterImplementation/FINNFilterSelectionData.swift
+++ b/Sources/FINNFilterImplementation/FINNFilterSelectionData.swift
@@ -1,0 +1,219 @@
+//
+//  Copyright © FINN.no AS, Inc. All rights reserved.
+//
+
+import Foundation
+
+class FINNFilterSelectionData: NSObject {
+    private struct GeoKey {
+        static let latitude = "lat"
+        static let longitude = "lon"
+        static let radius = "radius"
+        static let locationName = "geoLocationName"
+    }
+
+    private(set) var selectionValues: [String: [String]]
+
+    init(selectionValues: [String: [String]]) {
+        self.selectionValues = selectionValues
+    }
+
+    convenience override init() {
+        self.init(selectionValues: [:])
+    }
+}
+
+extension FINNFilterSelectionData {
+    func setSelectionValues(_ values: [String], for key: String) {
+        selectionValues[key] = values
+    }
+
+    func setSelectionValue(_ value: String, for key: String) {
+        setSelectionValues([value], for: key)
+    }
+
+    func addSelectionValue(_ value: String, for key: String) {
+        var values: [String]
+        if let previousValues = selectionValues[key] {
+            values = previousValues
+        } else {
+            values = []
+        }
+        values.append(value)
+        setSelectionValues(values, for: key)
+    }
+
+    func removeSelectionValue(_ value: String, for key: String) {
+        if let previousValues = selectionValues[key] {
+            setSelectionValues(previousValues.filter({ $0 != value }), for: key)
+        }
+    }
+
+    func removeSelectionValues(_ key: String) {
+        selectionValues.removeValue(forKey: key)
+    }
+
+    func selectionValues(for name: String) -> [String] {
+        return selectionValues[name] ?? []
+    }
+
+    func filterParameter(for filterInfo: FilterInfoType) -> String? {
+        if let filter = filterInfo as? ParameterBasedFilterInfo {
+            return filter.parameterName
+        }
+        return nil
+    }
+
+    func setStringValue(_ value: String, for key: String) {
+        setSelectionValue(value, for: key)
+    }
+
+    func setRangeSelectionValue(_ range: RangeValue, for key: String) {
+        let lowKey = rangeFilterKeyLow(fromBaseKey: key)
+        let highKey = rangeFilterKeyHigh(fromBaseKey: key)
+        switch range {
+        case let .minimum(lowValue):
+            setStringValue(lowValue.description, for: lowKey)
+            removeSelectionValues(highKey)
+        case let .maximum(highValue):
+            removeSelectionValues(lowKey)
+            setStringValue(highValue.description, for: highKey)
+        case let .closed(lowValue, highValue):
+            setStringValue(lowValue.description, for: lowKey)
+            setStringValue(highValue.description, for: highKey)
+        }
+    }
+
+    func setGeoLocation(latitude: Double, longitude: Double, radius: Int, locationName: String?) {
+        setStringValue(latitude.description, for: GeoKey.latitude)
+        setStringValue(longitude.description, for: GeoKey.longitude)
+        setStringValue(radius.description, for: GeoKey.radius)
+        if let locationName = locationName {
+            setStringValue(locationName, for: GeoKey.locationName)
+        } else {
+            removeSelectionValues(GeoKey.locationName)
+        }
+    }
+
+    func geoLocation() -> GeoFilterValue? {
+        guard let latitudeStr = selectionValues[GeoKey.latitude]?.first,
+            let longitudeStr = selectionValues[GeoKey.longitude]?.first,
+            let radiusStr = selectionValues[GeoKey.radius]?.first else {
+            return nil
+        }
+        guard let latitude = Double(latitudeStr), let longitude = Double(longitudeStr), let radius = Int(radiusStr) else {
+            return nil
+        }
+        let locationName = selectionValues[GeoKey.locationName]?.first
+        return GeoFilterValue(latitude: latitude, longitude: longitude, radius: radius, locationName: locationName)
+    }
+
+    func intOrNil(from value: String?) -> Int? {
+        guard let value = value else {
+            return nil
+        }
+        return Int(value)
+    }
+
+    func updateSelectionStateForAncestors(of multiLevelFilter: MultiLevelListSelectionFilterInfo) {
+        guard let parent = multiLevelFilter.parent as? MultiLevelListSelectionFilterInfo else {
+            return
+        }
+        if let selectionStateOfChildren = parent.selectionStateOfChildren() {
+            parent.selectionState = selectionStateOfChildren
+            if selectionStateOfChildren == .none {
+                removeValue(parent.value, for: parent)
+            }
+        }
+        updateSelectionStateForAncestors(of: parent)
+    }
+
+    func isAncestor(_ ancestor: MultiLevelListSelectionFilterInfo, to multiLevelFilter: MultiLevelListSelectionFilterInfoType?) -> Bool {
+        guard let multiLevelFilter = multiLevelFilter as? MultiLevelListSelectionFilterInfo else {
+            return false
+        }
+        guard let multiLevelFilterParent = multiLevelFilter.parent as? MultiLevelListSelectionFilterInfo else {
+            return false
+        }
+        if multiLevelFilterParent === ancestor {
+            return true
+        }
+        return isAncestor(ancestor, to: multiLevelFilterParent)
+    }
+
+    func rangeFilterKeyLow(fromBaseKey filterKey: String) -> String {
+        return filterKey + "_from"
+    }
+
+    func rangeFilterKeyHigh(fromBaseKey filterKey: String) -> String {
+        return filterKey + "_to"
+    }
+
+    func removeValueAndValueForChildren(for filterInfo: MultiLevelListSelectionFilterInfoType, updateSelectionStateForParent: Bool) {
+        for childFilter in filterInfo.filters {
+            removeValueAndValueForChildren(for: childFilter, updateSelectionStateForParent: false)
+            if let filterKey = filterParameter(for: childFilter) {
+                removeSelectionValue(childFilter.value, for: filterKey)
+            }
+        }
+
+        if let multiLevelFilter = filterInfo as? MultiLevelListSelectionFilterInfo {
+            multiLevelFilter.selectionState = .none
+            removeValue(multiLevelFilter.value, for: multiLevelFilter)
+
+            if updateSelectionStateForParent {
+                updateSelectionStateForAncestors(of: multiLevelFilter)
+            }
+        }
+    }
+
+    func removeValue(_ value: String, for filterInfo: FilterInfoType) {
+        guard let filterKey = filterParameter(for: filterInfo) else {
+            return
+        }
+        removeSelectionValue(value, for: filterKey)
+
+        if let multiLevelFilter = filterInfo as? MultiLevelListSelectionFilterInfo {
+            multiLevelFilter.selectionState = .none
+            if let selectionStateOfChildren = multiLevelFilter.selectionStateOfChildren() {
+                multiLevelFilter.selectionState = selectionStateOfChildren
+            }
+
+            updateSelectionStateForAncestors(of: multiLevelFilter)
+        }
+    }
+
+    func addValue(_ value: String, for filterInfo: FilterInfoType) {
+        guard let filterKey = filterParameter(for: filterInfo) else {
+            return
+        }
+        addSelectionValue(value, for: filterKey)
+
+        if let multiLevelFilter = filterInfo as? MultiLevelListSelectionFilterInfo {
+            multiLevelFilter.selectionState = .selected
+            if let parent = multiLevelFilter.parent as? MultiLevelListSelectionFilterInfo, parent.hasParent, parent.selectionState == .none {
+                addValue(parent.value, for: parent)
+            }
+            updateSelectionStateForAncestors(of: multiLevelFilter)
+        }
+    }
+
+    func clearAll(for filterInfo: FilterInfoType) {
+        guard let filterKey = filterParameter(for: filterInfo) else {
+            return
+        }
+        if filterInfo is RangeFilterInfoType {
+            removeSelectionValues(rangeFilterKeyLow(fromBaseKey: filterKey))
+            removeSelectionValues(rangeFilterKeyHigh(fromBaseKey: filterKey))
+        } else if filterInfo is StepperFilterInfoType {
+            removeSelectionValues(rangeFilterKeyLow(fromBaseKey: filterKey))
+        } else {
+            removeSelectionValues(filterKey)
+
+            if let multiLevelFilter = filterInfo as? MultiLevelListSelectionFilterInfo {
+                multiLevelFilter.selectionState = .none
+                updateSelectionStateForAncestors(of: multiLevelFilter)
+            }
+        }
+    }
+}

--- a/Sources/FINNFilterImplementation/FilterSelectionData.swift
+++ b/Sources/FINNFilterImplementation/FilterSelectionData.swift
@@ -4,26 +4,15 @@
 
 import Foundation
 
-class FINNFilterSelectionData: NSObject {
-    private struct GeoKey {
-        static let latitude = "lat"
-        static let longitude = "lon"
-        static let radius = "radius"
-        static let locationName = "geoLocationName"
-    }
-
+class FilterSelectionData {
     private(set) var selectionValues: [String: [String]]
 
     init(selectionValues: [String: [String]]) {
         self.selectionValues = selectionValues
     }
-
-    convenience override init() {
-        self.init(selectionValues: [:])
-    }
 }
 
-extension FINNFilterSelectionData {
+extension FilterSelectionData {
     func setSelectionValues(_ values: [String], for key: String) {
         selectionValues[key] = values
     }
@@ -53,8 +42,8 @@ extension FINNFilterSelectionData {
         selectionValues.removeValue(forKey: key)
     }
 
-    func selectionValues(for name: String) -> [String] {
-        return selectionValues[name] ?? []
+    func selectionValues(for key: String) -> [String] {
+        return selectionValues[key] ?? []
     }
 
     func filterParameter(for filterInfo: FilterInfoType) -> String? {
@@ -66,53 +55,6 @@ extension FINNFilterSelectionData {
 
     func setStringValue(_ value: String, for key: String) {
         setSelectionValue(value, for: key)
-    }
-
-    func setRangeSelectionValue(_ range: RangeValue, for key: String) {
-        let lowKey = rangeFilterKeyLow(fromBaseKey: key)
-        let highKey = rangeFilterKeyHigh(fromBaseKey: key)
-        switch range {
-        case let .minimum(lowValue):
-            setStringValue(lowValue.description, for: lowKey)
-            removeSelectionValues(highKey)
-        case let .maximum(highValue):
-            removeSelectionValues(lowKey)
-            setStringValue(highValue.description, for: highKey)
-        case let .closed(lowValue, highValue):
-            setStringValue(lowValue.description, for: lowKey)
-            setStringValue(highValue.description, for: highKey)
-        }
-    }
-
-    func setGeoLocation(latitude: Double, longitude: Double, radius: Int, locationName: String?) {
-        setStringValue(latitude.description, for: GeoKey.latitude)
-        setStringValue(longitude.description, for: GeoKey.longitude)
-        setStringValue(radius.description, for: GeoKey.radius)
-        if let locationName = locationName {
-            setStringValue(locationName, for: GeoKey.locationName)
-        } else {
-            removeSelectionValues(GeoKey.locationName)
-        }
-    }
-
-    func geoLocation() -> GeoFilterValue? {
-        guard let latitudeStr = selectionValues[GeoKey.latitude]?.first,
-            let longitudeStr = selectionValues[GeoKey.longitude]?.first,
-            let radiusStr = selectionValues[GeoKey.radius]?.first else {
-            return nil
-        }
-        guard let latitude = Double(latitudeStr), let longitude = Double(longitudeStr), let radius = Int(radiusStr) else {
-            return nil
-        }
-        let locationName = selectionValues[GeoKey.locationName]?.first
-        return GeoFilterValue(latitude: latitude, longitude: longitude, radius: radius, locationName: locationName)
-    }
-
-    func intOrNil(from value: String?) -> Int? {
-        guard let value = value else {
-            return nil
-        }
-        return Int(value)
     }
 
     func updateSelectionStateForAncestors(of multiLevelFilter: MultiLevelListSelectionFilterInfo) {
@@ -139,14 +81,6 @@ extension FINNFilterSelectionData {
             return true
         }
         return isAncestor(ancestor, to: multiLevelFilterParent)
-    }
-
-    func rangeFilterKeyLow(fromBaseKey filterKey: String) -> String {
-        return filterKey + "_from"
-    }
-
-    func rangeFilterKeyHigh(fromBaseKey filterKey: String) -> String {
-        return filterKey + "_to"
     }
 
     func removeValueAndValueForChildren(for filterInfo: MultiLevelListSelectionFilterInfoType, updateSelectionStateForParent: Bool) {
@@ -195,25 +129,6 @@ extension FINNFilterSelectionData {
                 addValue(parent.value, for: parent)
             }
             updateSelectionStateForAncestors(of: multiLevelFilter)
-        }
-    }
-
-    func clearAll(for filterInfo: FilterInfoType) {
-        guard let filterKey = filterParameter(for: filterInfo) else {
-            return
-        }
-        if filterInfo is RangeFilterInfoType {
-            removeSelectionValues(rangeFilterKeyLow(fromBaseKey: filterKey))
-            removeSelectionValues(rangeFilterKeyHigh(fromBaseKey: filterKey))
-        } else if filterInfo is StepperFilterInfoType {
-            removeSelectionValues(rangeFilterKeyLow(fromBaseKey: filterKey))
-        } else {
-            removeSelectionValues(filterKey)
-
-            if let multiLevelFilter = filterInfo as? MultiLevelListSelectionFilterInfo {
-                multiLevelFilter.selectionState = .none
-                updateSelectionStateForAncestors(of: multiLevelFilter)
-            }
         }
     }
 }

--- a/Sources/FINNFilterImplementation/ParameterBasedFilterInfoSelectionDataSource.swift
+++ b/Sources/FINNFilterImplementation/ParameterBasedFilterInfoSelectionDataSource.swift
@@ -3,21 +3,17 @@
 //
 
 import Foundation
-import MapKit
 
 public protocol ParameterBasedFilterInfoSelectionDataSourceDelegate: AnyObject {
     func parameterBasedFilterInfoSelectionDataSourceDidChange(_: ParameterBasedFilterInfoSelectionDataSource)
 }
 
 public class ParameterBasedFilterInfoSelectionDataSource: NSObject {
-    private struct GeoKey {
-        static let latitude = "lat"
-        static let longitude = "lon"
-        static let radius = "radius"
-        static let locationName = "geoLocationName"
+    private let selectionDataSource: FINNFilterSelectionData
+    public var selectionValues: [String: [String]] {
+        return selectionDataSource.selectionValues
     }
 
-    public private(set) var selectionValues: [String: [String]]
     var multiLevelFilterLookup: [FilterValueUniqueKey: FilterValueWithNumberOfHitsType] = [:]
     public weak var delegate: ParameterBasedFilterInfoSelectionDataSourceDelegate?
 
@@ -33,7 +29,7 @@ public class ParameterBasedFilterInfoSelectionDataSource: NSObject {
                 selectionValues[qi.name] = [value]
             }
         }
-        self.selectionValues = selectionValues
+        selectionDataSource = FINNFilterSelectionData(selectionValues: selectionValues)
     }
 
     public convenience override init() {
@@ -70,174 +66,6 @@ public class ParameterBasedFilterInfoSelectionDataSource: NSObject {
     }
 }
 
-private extension ParameterBasedFilterInfoSelectionDataSource {
-    func setSelectionValues(_ values: [String], for key: String, callDelegate: Bool = true) {
-        selectionValues[key] = values
-        if callDelegate {
-            delegate?.parameterBasedFilterInfoSelectionDataSourceDidChange(self)
-        }
-    }
-
-    func setSelectionValue(_ value: String, for key: String, callDelegate: Bool = true) {
-        setSelectionValues([value], for: key, callDelegate: callDelegate)
-    }
-
-    func addSelectionValue(_ value: String, for key: String) {
-        var values: [String]
-        if let previousValues = selectionValues[key] {
-            values = previousValues
-        } else {
-            values = []
-        }
-        values.append(value)
-        setSelectionValues(values, for: key)
-    }
-
-    func removeSelectionValue(_ value: String, for key: String, callDelegate: Bool = true) {
-        if let previousValues = selectionValues[key] {
-            setSelectionValues(previousValues.filter({ $0 != value }), for: key, callDelegate: callDelegate)
-        }
-    }
-
-    func removeSelectionValues(_ key: String, callDelegate: Bool = true) {
-        selectionValues.removeValue(forKey: key)
-        if callDelegate {
-            delegate?.parameterBasedFilterInfoSelectionDataSourceDidChange(self)
-        }
-    }
-
-    func selectionValues(for name: String) -> [String] {
-        return selectionValues[name] ?? []
-    }
-
-    func filterParameter(for filterInfo: FilterInfoType) -> String? {
-        if let filter = filterInfo as? ParameterBasedFilterInfo {
-            return filter.parameterName
-        }
-        return nil
-    }
-
-    func setStringValue(_ value: String, for key: String, callDelegate: Bool = true) {
-        setSelectionValue(value, for: key, callDelegate: callDelegate)
-    }
-
-    func setRangeSelectionValue(_ range: RangeValue, for key: String) {
-        let lowKey = rangeFilterKeyLow(fromBaseKey: key)
-        let highKey = rangeFilterKeyHigh(fromBaseKey: key)
-        switch range {
-        case let .minimum(lowValue):
-            setStringValue(lowValue.description, for: lowKey)
-            removeSelectionValues(highKey)
-        case let .maximum(highValue):
-            removeSelectionValues(lowKey)
-            setStringValue(highValue.description, for: highKey)
-        case let .closed(lowValue, highValue):
-            setStringValue(lowValue.description, for: lowKey)
-            setStringValue(highValue.description, for: highKey)
-        }
-    }
-
-    func setGeoLocation(latitude: Double, longitude: Double, radius: Int, locationName: String?) {
-        setStringValue(latitude.description, for: GeoKey.latitude, callDelegate: false)
-        setStringValue(longitude.description, for: GeoKey.longitude, callDelegate: false)
-        setStringValue(radius.description, for: GeoKey.radius, callDelegate: false)
-        if let locationName = locationName {
-            setStringValue(locationName, for: GeoKey.locationName, callDelegate: true)
-        } else {
-            removeSelectionValues(GeoKey.locationName, callDelegate: true)
-        }
-    }
-
-    func geoLocation() -> GeoFilterValue? {
-        guard let latitudeStr = selectionValues[GeoKey.latitude]?.first,
-            let longitudeStr = selectionValues[GeoKey.longitude]?.first,
-            let radiusStr = selectionValues[GeoKey.radius]?.first else {
-            return nil
-        }
-        guard let latitude = Double(latitudeStr), let longitude = Double(longitudeStr), let radius = Int(radiusStr) else {
-            return nil
-        }
-        let locationName = selectionValues[GeoKey.locationName]?.first
-        return GeoFilterValue(latitude: latitude, longitude: longitude, radius: radius, locationName: locationName)
-    }
-
-    func intOrNil(from value: String?) -> Int? {
-        guard let value = value else {
-            return nil
-        }
-        return Int(value)
-    }
-
-    func updateSelectionStateForAncestors(of multiLevelFilter: MultiLevelListSelectionFilterInfo) {
-        guard let parent = multiLevelFilter.parent as? MultiLevelListSelectionFilterInfo else {
-            return
-        }
-        if let selectionStateOfChildren = parent.selectionStateOfChildren() {
-            parent.selectionState = selectionStateOfChildren
-            if selectionStateOfChildren == .none {
-                clearValue(parent.value, for: parent)
-            }
-        }
-        updateSelectionStateForAncestors(of: parent)
-    }
-
-    func isAncestor(_ ancestor: MultiLevelListSelectionFilterInfo, to multiLevelFilter: MultiLevelListSelectionFilterInfoType?) -> Bool {
-        guard let multiLevelFilter = multiLevelFilter as? MultiLevelListSelectionFilterInfo else {
-            return false
-        }
-        guard let multiLevelFilterParent = multiLevelFilter.parent as? MultiLevelListSelectionFilterInfo else {
-            return false
-        }
-        if multiLevelFilterParent === ancestor {
-            return true
-        }
-        return isAncestor(ancestor, to: multiLevelFilterParent)
-    }
-
-    func rangeFilterKeyLow(fromBaseKey filterKey: String) -> String {
-        return filterKey + "_from"
-    }
-
-    func rangeFilterKeyHigh(fromBaseKey filterKey: String) -> String {
-        return filterKey + "_to"
-    }
-
-    func removeValueAndValueForChildren(for filterInfo: MultiLevelListSelectionFilterInfoType, updateSelectionStateForParent: Bool) {
-        for childFilter in filterInfo.filters {
-            removeValueAndValueForChildren(for: childFilter, updateSelectionStateForParent: false)
-            if let filterKey = filterParameter(for: childFilter) {
-                removeSelectionValue(childFilter.value, for: filterKey, callDelegate: false)
-            }
-        }
-
-        if let multiLevelFilter = filterInfo as? MultiLevelListSelectionFilterInfo {
-            multiLevelFilter.selectionState = .none
-            removeValue(multiLevelFilter.value, for: multiLevelFilter)
-
-            if updateSelectionStateForParent {
-                updateSelectionStateForAncestors(of: multiLevelFilter)
-            }
-        }
-        delegate?.parameterBasedFilterInfoSelectionDataSourceDidChange(self)
-    }
-
-    func removeValue(_ value: String, for filterInfo: FilterInfoType) {
-        guard let filterKey = filterParameter(for: filterInfo) else {
-            return
-        }
-        removeSelectionValue(value, for: filterKey)
-
-        if let multiLevelFilter = filterInfo as? MultiLevelListSelectionFilterInfo {
-            multiLevelFilter.selectionState = .none
-            if let selectionStateOfChildren = multiLevelFilter.selectionStateOfChildren() {
-                multiLevelFilter.selectionState = selectionStateOfChildren
-            }
-
-            updateSelectionStateForAncestors(of: multiLevelFilter)
-        }
-    }
-}
-
 extension ParameterBasedFilterInfoSelectionDataSource: FilterSelectionDataSource {
     public func selectionState(_ filterInfo: MultiLevelListSelectionFilterInfoType) -> MultiLevelListItemSelectionState {
         guard let filter = filterInfo as? MultiLevelListSelectionFilterInfo else {
@@ -262,7 +90,7 @@ extension ParameterBasedFilterInfoSelectionDataSource: FilterSelectionDataSource
                         if let parent = selectedFilterInfo.parent as? MultiLevelListSelectionFilterInfo, parent.selectionState == .selected {
                             return
                         }
-                        if selectedFilterInfo === multiLevelFilterInfo || isAncestor(multiLevelFilterInfo, to: selectedFilterInfo) {
+                        if selectedFilterInfo === multiLevelFilterInfo || selectionDataSource.isAncestor(multiLevelFilterInfo, to: selectedFilterInfo) {
                             values.append(FilterSelectionDataInfo(filter: selectedFilterInfo, value: selectedFilterInfo.value))
                         }
                     }
@@ -281,12 +109,12 @@ extension ParameterBasedFilterInfoSelectionDataSource: FilterSelectionDataSource
     }
 
     public func value(for filterInfo: FilterInfoType) -> [String]? {
-        guard let filterKey = filterParameter(for: filterInfo) else {
+        guard let filterKey = selectionDataSource.filterParameter(for: filterInfo) else {
             return nil
         }
         if filterInfo is RangeFilterInfoType {
         } else {
-            let values = selectionValues(for: filterKey)
+            let values = selectionDataSource.selectionValues(for: filterKey)
 
             if values.count < 1 {
                 return nil
@@ -303,13 +131,14 @@ extension ParameterBasedFilterInfoSelectionDataSource: FilterSelectionDataSource
     }
 
     public func setValue(_ filterSelectionValue: [String]?, for filterInfo: FilterInfoType) {
-        guard let filterKey = filterParameter(for: filterInfo) else {
+        guard let filterKey = selectionDataSource.filterParameter(for: filterInfo) else {
             return
         }
+
         if let filterSelectionValue = filterSelectionValue {
-            setSelectionValues(filterSelectionValue, for: filterKey)
+            selectionDataSource.setSelectionValues(filterSelectionValue, for: filterKey)
         } else {
-            removeSelectionValues(filterKey)
+            selectionDataSource.removeSelectionValues(filterKey)
         }
 
         if let multiLevelFilter = filterInfo as? MultiLevelListSelectionFilterInfo {
@@ -317,75 +146,56 @@ extension ParameterBasedFilterInfoSelectionDataSource: FilterSelectionDataSource
                 addValue(parent.value, for: parent)
             }
             multiLevelFilter.selectionState = .selected
-            updateSelectionStateForAncestors(of: multiLevelFilter)
+            selectionDataSource.updateSelectionStateForAncestors(of: multiLevelFilter)
         }
-
-        DebugLog.write(self)
+        delegate?.parameterBasedFilterInfoSelectionDataSourceDidChange(self)
     }
 
     public func addValue(_ value: String, for filterInfo: FilterInfoType) {
-        guard let filterKey = filterParameter(for: filterInfo) else {
-            return
-        }
-        addSelectionValue(value, for: filterKey)
-
-        if let multiLevelFilter = filterInfo as? MultiLevelListSelectionFilterInfo {
-            multiLevelFilter.selectionState = .selected
-            if let parent = multiLevelFilter.parent as? MultiLevelListSelectionFilterInfo, parent.hasParent, parent.selectionState == .none {
-                addValue(parent.value, for: parent)
-            }
-            updateSelectionStateForAncestors(of: multiLevelFilter)
-        }
-
-        DebugLog.write(self)
+        selectionDataSource.addValue(value, for: filterInfo)
+        delegate?.parameterBasedFilterInfoSelectionDataSourceDidChange(self)
     }
 
     public func clearAll(for filterInfo: FilterInfoType) {
-        guard let filterKey = filterParameter(for: filterInfo) else {
-            return
-        }
-        if filterInfo is RangeFilterInfoType {
-            removeSelectionValues(rangeFilterKeyLow(fromBaseKey: filterKey))
-            removeSelectionValues(rangeFilterKeyHigh(fromBaseKey: filterKey))
-        } else if filterInfo is StepperFilterInfoType {
-            removeSelectionValues(rangeFilterKeyLow(fromBaseKey: filterKey))
-        } else {
-            removeSelectionValues(filterKey)
-
-            if let multiLevelFilter = filterInfo as? MultiLevelListSelectionFilterInfo {
-                multiLevelFilter.selectionState = .none
-                updateSelectionStateForAncestors(of: multiLevelFilter)
-            }
-        }
-        DebugLog.write(self)
+        selectionDataSource.clearAll(for: filterInfo)
+        delegate?.parameterBasedFilterInfoSelectionDataSourceDidChange(self)
     }
 
     public func clearValue(_ value: String, for filterInfo: FilterInfoType) {
-        removeValue(value, for: filterInfo)
-        DebugLog.write(self)
+        selectionDataSource.removeValue(value, for: filterInfo)
+        delegate?.parameterBasedFilterInfoSelectionDataSourceDidChange(self)
     }
 
     public func clearValueAndValueForChildren(for filterInfo: MultiLevelListSelectionFilterInfoType) {
-        removeValueAndValueForChildren(for: filterInfo, updateSelectionStateForParent: true)
-        DebugLog.write(self)
+        selectionDataSource.removeValueAndValueForChildren(for: filterInfo, updateSelectionStateForParent: true)
+        delegate?.parameterBasedFilterInfoSelectionDataSourceDidChange(self)
+    }
+
+    public func setValueAndClearValueForChildren(_ value: String?, for filterInfo: MultiLevelListSelectionFilterInfoType) {
+        selectionDataSource.removeValueAndValueForChildren(for: filterInfo, updateSelectionStateForParent: true)
+        if let value = value {
+            selectionDataSource.addValue(value, for: filterInfo)
+        }
+        delegate?.parameterBasedFilterInfoSelectionDataSourceDidChange(self)
     }
 
     public func clearSelection(at selectionValueIndex: Int, in selectionInfo: FilterSelectionInfo) {
         if let selectionData = selectionInfo as? FilterSelectionDataInfo {
-            clearValue(selectionData.value, for: selectionData.filter)
+            selectionDataSource.removeValue(selectionData.value, for: selectionData.filter)
         } else if let selectionData = selectionInfo as? FilterRangeSelectionInfo {
-            clearAll(for: selectionData.filter)
+            selectionDataSource.clearAll(for: selectionData.filter)
         } else if let selectionData = selectionInfo as? FilterStepperSelectionInfo {
-            clearAll(for: selectionData.filter)
+            selectionDataSource.clearAll(for: selectionData.filter)
         }
+        delegate?.parameterBasedFilterInfoSelectionDataSourceDidChange(self)
     }
 
     public func rangeValue(for filterInfo: RangeFilterInfoType) -> RangeValue? {
-        guard let filterKey = filterParameter(for: filterInfo) else {
+        guard let filterKey = selectionDataSource.filterParameter(for: filterInfo) else {
             return nil
         }
-        let low = intOrNil(from: selectionValues(for: rangeFilterKeyLow(fromBaseKey: filterKey)).first)
-        let high = intOrNil(from: selectionValues(for: rangeFilterKeyHigh(fromBaseKey: filterKey)).first)
+        let low = selectionDataSource.intOrNil(from: selectionDataSource.selectionValues(for: selectionDataSource.rangeFilterKeyLow(fromBaseKey: filterKey)).first)
+        let high = selectionDataSource.intOrNil(from: selectionDataSource.selectionValues(for: selectionDataSource.rangeFilterKeyHigh(fromBaseKey: filterKey)).first)
         if let low = low, let high = high {
             return .closed(lowValue: low, highValue: high)
         } else if let low = low {
@@ -398,32 +208,34 @@ extension ParameterBasedFilterInfoSelectionDataSource: FilterSelectionDataSource
     }
 
     public func setValue(_ range: RangeValue, for filterInfo: FilterInfoType) {
-        guard let filterKey = filterParameter(for: filterInfo) else {
+        guard let filterKey = selectionDataSource.filterParameter(for: filterInfo) else {
             return
         }
-        setRangeSelectionValue(range, for: filterKey)
-        DebugLog.write(self)
+        selectionDataSource.setRangeSelectionValue(range, for: filterKey)
+        delegate?.parameterBasedFilterInfoSelectionDataSourceDidChange(self)
     }
 
     public func stepperValue(for filterInfo: StepperFilterInfoType) -> Int? {
-        guard let filterKey = filterParameter(for: filterInfo) else {
+        guard let filterKey = selectionDataSource.filterParameter(for: filterInfo) else {
             return nil
         }
-        let low = intOrNil(from: selectionValues(for: rangeFilterKeyLow(fromBaseKey: filterKey)).first)
+        let low = selectionDataSource.intOrNil(from: selectionDataSource.selectionValues(for: selectionDataSource.rangeFilterKeyLow(fromBaseKey: filterKey)).first)
         return low
     }
 
     public func setValue(latitude: Double, longitude: Double, radius: Int, locationName: String?, for filterInfo: FilterInfoType) {
-        clearAll(for: filterInfo)
-        setGeoLocation(latitude: latitude, longitude: longitude, radius: radius, locationName: locationName)
-        DebugLog.write(self)
+        selectionDataSource.clearAll(for: filterInfo)
+        selectionDataSource.setGeoLocation(latitude: latitude, longitude: longitude, radius: radius, locationName: locationName)
+        delegate?.parameterBasedFilterInfoSelectionDataSourceDidChange(self)
     }
 
     public func setValue(geoFilterValue: GeoFilterValue, for filterInfo: FilterInfoType) {
-        setValue(latitude: geoFilterValue.latitude, longitude: geoFilterValue.longitude, radius: geoFilterValue.radius, locationName: geoFilterValue.locationName, for: filterInfo)
+        selectionDataSource.clearAll(for: filterInfo)
+        selectionDataSource.setGeoLocation(latitude: geoFilterValue.latitude, longitude: geoFilterValue.longitude, radius: geoFilterValue.radius, locationName: geoFilterValue.locationName)
+        delegate?.parameterBasedFilterInfoSelectionDataSourceDidChange(self)
     }
 
     public func geoValue(for filterInfo: FilterInfoType) -> GeoFilterValue? {
-        return geoLocation()
+        return selectionDataSource.geoLocation()
     }
 }

--- a/Sources/MultiLevelListSelectionFilter/MultiLevelListSelectionFilterViewController.swift
+++ b/Sources/MultiLevelListSelectionFilter/MultiLevelListSelectionFilterViewController.swift
@@ -133,8 +133,7 @@ public final class MultiLevelListSelectionFilterViewController: UIViewController
         if wasItemPreviouslySelected {
             selectionDataSource.clearValue(filterInfo.value, for: filterInfo)
         } else {
-            selectionDataSource.clearValueAndValueForChildren(for: filterInfo)
-            selectionDataSource.addValue(filterInfo.value, for: filterInfo)
+            selectionDataSource.setValueAndClearValueForChildren(filterInfo.value, for: filterInfo)
         }
         filterSelectionDelegate?.filterContainerViewControllerDidChangeSelection(filterContainerViewController: self)
     }

--- a/UnitTests/FilterSelectionDataSource/FilterSelectionDataTests.swift
+++ b/UnitTests/FilterSelectionDataSource/FilterSelectionDataTests.swift
@@ -1,0 +1,74 @@
+//
+//  Copyright © FINN.no AS, Inc. All rights reserved.
+//
+
+@testable import Charcoal
+import XCTest
+
+class FilterSelectionDataTests: XCTestCase {
+    func testSelectionDataShouldPreserveInitValues() {
+        let filter = MockFilterInfo(parameterName: "test", title: "Test")
+
+        let selectionData = FilterSelectionData(selectionValues: [filter.parameterName: ["value"], "foo": ["bar"]])
+
+        let values = selectionData.selectionValues(for: filter.parameterName)
+
+        XCTAssertEqual(1, values.count)
+        XCTAssertEqual("value", values.first)
+    }
+
+    func testSelectionDataShouldSupportMultipleValuesForFilterAtInit() {
+        let filter = MockFilterInfo(parameterName: "test", title: "Test")
+
+        let selectionData = FilterSelectionData(selectionValues: [filter.parameterName: ["value", "value2"], "foo": ["bar"]])
+
+        let values = selectionData.selectionValues(for: filter.parameterName)
+        XCTAssertEqual(2, values.count)
+        XCTAssertTrue(values.contains("value"))
+        XCTAssertTrue(values.contains("value2"))
+    }
+
+    func testSelectionDataShouldSupportRemovingOnly1SelectionValue() {
+        let filter = MockFilterInfo(parameterName: "test", title: "Test")
+        let selectionData = FilterSelectionData(selectionValues: [filter.parameterName: ["value", "value2"], "foo": ["bar"]])
+
+        selectionData.removeValue("value", for: filter)
+
+        let values = selectionData.selectionValues(for: filter.parameterName)
+        XCTAssertEqual(1, values.count)
+        XCTAssertEqual("value2", values.first)
+    }
+
+    func testSelectionDataShouldSupportOverridingMultipleValuesWithNewValues() {
+        let filter = MockFilterInfo(parameterName: "test", title: "Test")
+        let selectionData = FilterSelectionData(selectionValues: [filter.parameterName: ["value", "value2"], "foo": ["bar"]])
+
+        selectionData.setSelectionValues(["new", "new2"], for: filter.parameterName)
+
+        let values = selectionData.selectionValues(for: filter.parameterName)
+        XCTAssertEqual(2, values.count)
+        XCTAssertTrue(values.contains("new"))
+        XCTAssertTrue(values.contains("new2"))
+    }
+
+    func testSelectionDataShouldSupportAddingToExistingValues() {
+        let filter = MockFilterInfo(parameterName: "test", title: "Test")
+        let selectionData = FilterSelectionData(selectionValues: [filter.parameterName: ["value", "value2"], "foo": ["bar"]])
+
+        selectionData.addValue("new", for: filter)
+
+        let values = selectionData.selectionValues(for: filter.parameterName)
+        XCTAssertEqual(3, values.count)
+        XCTAssertTrue(values.contains("new"))
+    }
+}
+
+private class MockFilterInfo: ParameterBasedFilterInfo {
+    var parameterName: String
+    var title: String
+
+    init(parameterName: String, title: String) {
+        self.parameterName = parameterName
+        self.title = title
+    }
+}


### PR DESCRIPTION
# Why?
When integrating with main app there was a lot of unnecessary searches being performed, this was due to excessive calls to inform that selection had changed.

# What?
Separates the internal representation of filter selection and the external api for selection data source. This should remove a lot of unnecessary calls to ParameterBasedFilterInfoSelectionDataSource delegate, there should max be 1 call for each function call in FilterSelectionDataSource-implementation.
