### PR TITLE
Removes scrollable container protocol

### DIFF
--- a/Sources/FilterViewController/FilterContainerViewController.swift
+++ b/Sources/FilterViewController/FilterContainerViewController.swift
@@ -4,23 +4,6 @@
 
 import Foundation
 
-public protocol ScrollableContainerViewController: AnyObject {
-    var mainScrollableView: UIScrollView { get }
-    var isMainScrollableViewScrolledToTop: Bool { get }
-}
-
-public extension ScrollableContainerViewController {
-    var isMainScrollableViewScrolledToTop: Bool {
-        let scrollPos: CGFloat
-        if #available(iOS 11.0, *) {
-            scrollPos = (mainScrollableView.contentOffset.y + mainScrollableView.adjustedContentInset.top)
-        } else {
-            scrollPos = (mainScrollableView.contentOffset.y + mainScrollableView.contentInset.top)
-        }
-        return scrollPos < 1
-    }
-}
-
 public protocol FilterContainerViewControllerDelegate: AnyObject {
     func filterContainerViewController(filterContainerViewController: FilterContainerViewController, navigateTo filterInfo: FilterInfoType)
     func filterContainerViewControllerDidChangeSelection(filterContainerViewController: FilterContainerViewController)

--- a/Sources/FilterViewController/FilterViewController.swift
+++ b/Sources/FilterViewController/FilterViewController.swift
@@ -73,14 +73,6 @@ public final class FilterViewController<ChildViewController: FilterContainerView
         }
     }
 
-    public var mainScrollableContentView: UIScrollView? {
-        return (filterContainerViewController as? ScrollableContainerViewController)?.mainScrollableView
-    }
-
-    public var isMainScrollableViewScrolledToTop: Bool {
-        return (filterContainerViewController as? ScrollableContainerViewController)?.isMainScrollableViewScrolledToTop ?? true
-    }
-
     public required init?(filterInfo: FilterInfoType, dataSource: FilterDataSource, selectionDataSource: FilterSelectionDataSource, navigator: FilterNavigator) {
         guard let child = ChildViewController(filterInfo: filterInfo, dataSource: dataSource, selectionDataSource: selectionDataSource) else {
             return nil

--- a/Sources/ListSelectionFilter/ListSelectionFilterViewController.swift
+++ b/Sources/ListSelectionFilter/ListSelectionFilterViewController.swift
@@ -134,9 +134,3 @@ extension ListSelectionFilterViewController: UITableViewDelegate {
         return type(of: self).rowHeight
     }
 }
-
-extension ListSelectionFilterViewController: ScrollableContainerViewController {
-    public var mainScrollableView: UIScrollView {
-        return tableView
-    }
-}

--- a/Sources/MultiLevelListSelectionFilter/MultiLevelListSelectionFilterViewController.swift
+++ b/Sources/MultiLevelListSelectionFilter/MultiLevelListSelectionFilterViewController.swift
@@ -259,12 +259,6 @@ extension MultiLevelListSelectionFilterViewController: UITableViewDelegate {
     }
 }
 
-extension MultiLevelListSelectionFilterViewController: ScrollableContainerViewController {
-    public var mainScrollableView: UIScrollView {
-        return tableView
-    }
-}
-
 private extension MultiLevelListSelectionFilterInfoType {
     var showDisclosureIndicator: Bool {
         return filters.count > 0

--- a/Sources/Vertical/VerticalListViewController.swift
+++ b/Sources/Vertical/VerticalListViewController.swift
@@ -86,9 +86,3 @@ extension VerticalListViewController: UITableViewDelegate {
         return type(of: self).rowHeight
     }
 }
-
-extension VerticalListViewController: ScrollableContainerViewController {
-    public var mainScrollableView: UIScrollView {
-        return tableView
-    }
-}


### PR DESCRIPTION
# Why?

We don't need this anymore now that the bottom sheet is in finnivers kit

# What?

- Removes protocols used with previous bottom sheet implementation

# Show me
