### PR TITLE
Configure market B2B

### DIFF
--- a/Charcoal.xcodeproj/project.pbxproj
+++ b/Charcoal.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		08716B6721FB108D003180D8 /* realestate-leisure-sale-abroad.json in Resources */ = {isa = PBXBuildFile; fileRef = 08716B5A21FB108D003180D8 /* realestate-leisure-sale-abroad.json */; };
 		08716B6821FB108D003180D8 /* realestate-plot.json in Resources */ = {isa = PBXBuildFile; fileRef = 08716B5B21FB108D003180D8 /* realestate-plot.json */; };
 		08716B6921FB108D003180D8 /* realestate-leisure-plot.json in Resources */ = {isa = PBXBuildFile; fileRef = 08716B5C21FB108D003180D8 /* realestate-leisure-plot.json */; };
+		08716B9521FF2CE4003180D8 /* FilterMarketB2B.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08716B9421FF2CE4003180D8 /* FilterMarketB2B.swift */; };
 		088C090F21F5C3AA00983132 /* job-full-time.json in Resources */ = {isa = PBXBuildFile; fileRef = 088C090E21F5C3AA00983132 /* job-full-time.json */; };
 		088C091121F5CE4200983132 /* job-part-time.json in Resources */ = {isa = PBXBuildFile; fileRef = 088C091021F5CE4200983132 /* job-part-time.json */; };
 		088C091321F5CE4C00983132 /* job-management.json in Resources */ = {isa = PBXBuildFile; fileRef = 088C091221F5CE4C00983132 /* job-management.json */; };
@@ -257,6 +258,7 @@
 		08716B5A21FB108D003180D8 /* realestate-leisure-sale-abroad.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "realestate-leisure-sale-abroad.json"; sourceTree = "<group>"; };
 		08716B5B21FB108D003180D8 /* realestate-plot.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "realestate-plot.json"; sourceTree = "<group>"; };
 		08716B5C21FB108D003180D8 /* realestate-leisure-plot.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "realestate-leisure-plot.json"; sourceTree = "<group>"; };
+		08716B9421FF2CE4003180D8 /* FilterMarketB2B.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterMarketB2B.swift; sourceTree = "<group>"; };
 		088C090E21F5C3AA00983132 /* job-full-time.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "job-full-time.json"; sourceTree = "<group>"; };
 		088C091021F5CE4200983132 /* job-part-time.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "job-part-time.json"; sourceTree = "<group>"; };
 		088C091221F5CE4C00983132 /* job-management.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "job-management.json"; sourceTree = "<group>"; };
@@ -446,6 +448,7 @@
 				08716B3021F73D2D003180D8 /* FilterMarketRealestate.swift */,
 				08716B3221F73D92003180D8 /* FilterMarketBap.swift */,
 				08716B3421F73DDE003180D8 /* FilterMarketBoat.swift */,
+				08716B9421FF2CE4003180D8 /* FilterMarketB2B.swift */,
 			);
 			path = FilterMarkets;
 			sourceTree = "<group>";
@@ -1379,6 +1382,7 @@
 				9BB8279A216B57730014028C /* DebugLog.swift in Sources */,
 				5525324420A2DB73000CBD21 /* RootFilterNavigator.swift in Sources */,
 				08716B3121F73D2D003180D8 /* FilterMarketRealestate.swift in Sources */,
+				08716B9521FF2CE4003180D8 /* FilterMarketB2B.swift in Sources */,
 				DAF3CA7221830B1C007235B0 /* StepperFilterView.swift in Sources */,
 				9B741D1A21B6990800D18097 /* ValueSliderView.swift in Sources */,
 				465F616F219B7B8B00CF568B /* FilterDataQuery.swift in Sources */,

--- a/Charcoal.xcodeproj/project.pbxproj
+++ b/Charcoal.xcodeproj/project.pbxproj
@@ -35,6 +35,15 @@
 		08716B6721FB108D003180D8 /* realestate-leisure-sale-abroad.json in Resources */ = {isa = PBXBuildFile; fileRef = 08716B5A21FB108D003180D8 /* realestate-leisure-sale-abroad.json */; };
 		08716B6821FB108D003180D8 /* realestate-plot.json in Resources */ = {isa = PBXBuildFile; fileRef = 08716B5B21FB108D003180D8 /* realestate-plot.json */; };
 		08716B6921FB108D003180D8 /* realestate-leisure-plot.json in Resources */ = {isa = PBXBuildFile; fileRef = 08716B5C21FB108D003180D8 /* realestate-leisure-plot.json */; };
+		08716B8B21FF2CCA003180D8 /* bus.json in Resources */ = {isa = PBXBuildFile; fileRef = 08716B8221FF2CCA003180D8 /* bus.json */; };
+		08716B8C21FF2CCA003180D8 /* truck.json in Resources */ = {isa = PBXBuildFile; fileRef = 08716B8321FF2CCA003180D8 /* truck.json */; };
+		08716B8D21FF2CCA003180D8 /* van-norway.json in Resources */ = {isa = PBXBuildFile; fileRef = 08716B8421FF2CCA003180D8 /* van-norway.json */; };
+		08716B8E21FF2CCA003180D8 /* truck-abroad.json in Resources */ = {isa = PBXBuildFile; fileRef = 08716B8521FF2CCA003180D8 /* truck-abroad.json */; };
+		08716B8F21FF2CCA003180D8 /* agriculture-tractor.json in Resources */ = {isa = PBXBuildFile; fileRef = 08716B8621FF2CCA003180D8 /* agriculture-tractor.json */; };
+		08716B9021FF2CCA003180D8 /* agriculture-thresher.json in Resources */ = {isa = PBXBuildFile; fileRef = 08716B8721FF2CCA003180D8 /* agriculture-thresher.json */; };
+		08716B9121FF2CCA003180D8 /* agriculture-tools.json in Resources */ = {isa = PBXBuildFile; fileRef = 08716B8821FF2CCA003180D8 /* agriculture-tools.json */; };
+		08716B9221FF2CCA003180D8 /* van-abroad.json in Resources */ = {isa = PBXBuildFile; fileRef = 08716B8921FF2CCA003180D8 /* van-abroad.json */; };
+		08716B9321FF2CCA003180D8 /* construction.json in Resources */ = {isa = PBXBuildFile; fileRef = 08716B8A21FF2CCA003180D8 /* construction.json */; };
 		08716B9521FF2CE4003180D8 /* FilterMarketB2B.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08716B9421FF2CE4003180D8 /* FilterMarketB2B.swift */; };
 		088C090F21F5C3AA00983132 /* job-full-time.json in Resources */ = {isa = PBXBuildFile; fileRef = 088C090E21F5C3AA00983132 /* job-full-time.json */; };
 		088C091121F5CE4200983132 /* job-part-time.json in Resources */ = {isa = PBXBuildFile; fileRef = 088C091021F5CE4200983132 /* job-part-time.json */; };
@@ -258,6 +267,15 @@
 		08716B5A21FB108D003180D8 /* realestate-leisure-sale-abroad.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "realestate-leisure-sale-abroad.json"; sourceTree = "<group>"; };
 		08716B5B21FB108D003180D8 /* realestate-plot.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "realestate-plot.json"; sourceTree = "<group>"; };
 		08716B5C21FB108D003180D8 /* realestate-leisure-plot.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "realestate-leisure-plot.json"; sourceTree = "<group>"; };
+		08716B8221FF2CCA003180D8 /* bus.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = bus.json; sourceTree = "<group>"; };
+		08716B8321FF2CCA003180D8 /* truck.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = truck.json; sourceTree = "<group>"; };
+		08716B8421FF2CCA003180D8 /* van-norway.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "van-norway.json"; sourceTree = "<group>"; };
+		08716B8521FF2CCA003180D8 /* truck-abroad.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "truck-abroad.json"; sourceTree = "<group>"; };
+		08716B8621FF2CCA003180D8 /* agriculture-tractor.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "agriculture-tractor.json"; sourceTree = "<group>"; };
+		08716B8721FF2CCA003180D8 /* agriculture-thresher.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "agriculture-thresher.json"; sourceTree = "<group>"; };
+		08716B8821FF2CCA003180D8 /* agriculture-tools.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "agriculture-tools.json"; sourceTree = "<group>"; };
+		08716B8921FF2CCA003180D8 /* van-abroad.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "van-abroad.json"; sourceTree = "<group>"; };
+		08716B8A21FF2CCA003180D8 /* construction.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = construction.json; sourceTree = "<group>"; };
 		08716B9421FF2CE4003180D8 /* FilterMarketB2B.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterMarketB2B.swift; sourceTree = "<group>"; };
 		088C090E21F5C3AA00983132 /* job-full-time.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "job-full-time.json"; sourceTree = "<group>"; };
 		088C091021F5CE4200983132 /* job-part-time.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "job-part-time.json"; sourceTree = "<group>"; };
@@ -525,6 +543,22 @@
 			path = car;
 			sourceTree = "<group>";
 		};
+		08716B8121FF2CBE003180D8 /* b2b */ = {
+			isa = PBXGroup;
+			children = (
+				08716B8721FF2CCA003180D8 /* agriculture-thresher.json */,
+				08716B8821FF2CCA003180D8 /* agriculture-tools.json */,
+				08716B8621FF2CCA003180D8 /* agriculture-tractor.json */,
+				08716B8221FF2CCA003180D8 /* bus.json */,
+				08716B8A21FF2CCA003180D8 /* construction.json */,
+				08716B8521FF2CCA003180D8 /* truck-abroad.json */,
+				08716B8321FF2CCA003180D8 /* truck.json */,
+				08716B8921FF2CCA003180D8 /* van-abroad.json */,
+				08716B8421FF2CCA003180D8 /* van-norway.json */,
+			);
+			path = b2b;
+			sourceTree = "<group>";
+		};
 		44ECE645208F7F7B0017AC82 = {
 			isa = PBXGroup;
 			children = (
@@ -764,6 +798,7 @@
 		5598F20E20C008F900E148E0 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
+				08716B8121FF2CBE003180D8 /* b2b */,
 				08716B3B21F89BA6003180D8 /* bap */,
 				08716B3821F89B80003180D8 /* boat */,
 				08716B3D21F89BB4003180D8 /* car */,
@@ -1188,23 +1223,32 @@
 			buildActionMask = 2147483647;
 			files = (
 				088C091321F5CE4C00983132 /* job-management.json in Resources */,
+				08716B8F21FF2CCA003180D8 /* agriculture-tractor.json in Resources */,
+				08716B8D21FF2CCA003180D8 /* van-norway.json in Resources */,
 				08716B4921F89D83003180D8 /* boat-motor.json in Resources */,
 				08716B4121F89CD6003180D8 /* boat-used-wanted.json in Resources */,
+				08716B9021FF2CCA003180D8 /* agriculture-thresher.json in Resources */,
 				08716B4321F89CE0003180D8 /* boat-rent.json in Resources */,
 				08716B6021FB108D003180D8 /* realestate-letting.json in Resources */,
 				088C090F21F5C3AA00983132 /* job-full-time.json in Resources */,
 				44ECE678208F7FD20017AC82 /* LaunchScreen.storyboard in Resources */,
+				08716B9321FF2CCA003180D8 /* construction.json in Resources */,
 				08716B6721FB108D003180D8 /* realestate-leisure-sale-abroad.json in Resources */,
 				08716B4F21F89DE5003180D8 /* boat-dock-wanted.json in Resources */,
 				08716B6821FB108D003180D8 /* realestate-plot.json in Resources */,
+				08716B9221FF2CCA003180D8 /* van-abroad.json in Resources */,
+				08716B8C21FF2CCA003180D8 /* truck.json in Resources */,
 				088C091921F5E63800983132 /* snowmobile.json in Resources */,
 				088C091721F5E5EE00983132 /* moped-scooter.json in Resources */,
 				9B9C16FD209AF65E007BCBBC /* CHANGELOG.md in Resources */,
 				08716B6921FB108D003180D8 /* realestate-leisure-plot.json in Resources */,
 				55ABF8B020CFD8A100E31229 /* bap-sale.json in Resources */,
+				08716B9121FF2CCA003180D8 /* agriculture-tools.json in Resources */,
 				08716B4B21F89DBB003180D8 /* boat-parts-motor-wanted.json in Resources */,
 				5521FB9520CEB0FF00F910D0 /* car-norway.json in Resources */,
+				08716B8E21FF2CCA003180D8 /* truck-abroad.json in Resources */,
 				08716B3F21F89C7C003180D8 /* boat-sale.json in Resources */,
+				08716B8B21FF2CCA003180D8 /* bus.json in Resources */,
 				9BE0D54121A4509F00F0B63B /* car-abroad.json in Resources */,
 				08716B4D21F89DDE003180D8 /* boat-dock.json in Resources */,
 				08716B6521FB108D003180D8 /* realestate-business-letting.json in Resources */,

--- a/Demo/Demo.swift
+++ b/Demo/Demo.swift
@@ -77,7 +77,7 @@ enum Sections: String, CaseIterable {
         case .fullscreen:
             let selectedView = FullscreenViews.allCases[indexPath.row]
             switch selectedView {
-            case .torget, .bil, .eiendom, .job, .mc, .boat:
+            case .torget, .bil, .eiendom, .job, .mc, .boat, .b2b:
                 return .bottomSheet
             }
         }
@@ -164,6 +164,7 @@ enum FullscreenViews: String, CaseIterable {
     case mc
     case job
     case boat
+    case b2b
 
     var viewController: UIViewController {
         let filter: FilterSetup
@@ -181,6 +182,8 @@ enum FullscreenViews: String, CaseIterable {
             filter = DemoFilter.filterDataFromJSONFile(named: "job-full-time")
         case .boat:
             filter = DemoFilter.filterDataFromJSONFile(named: "boat-sale")
+        case .b2b:
+            filter = DemoFilter.filterDataFromJSONFile(named: "truck")
         }
 
         let demoFilter = DemoFilter(filter: filter)

--- a/Demo/Resources/b2b/agriculture-thresher.json
+++ b/Demo/Resources/b2b/agriculture-thresher.json
@@ -1,0 +1,168 @@
+{
+    "market": "agriculture-thresher",
+    "hits": 60,
+    "label": "Tresker",
+    "type": "search",
+    "filters": [
+        "markets",
+        "q",
+        "published",
+        "location",
+        "make",
+        "price",
+        "year",
+        "engine_effect",
+        "dealer_segment"
+    ],
+    "filter-data": {
+        "price": {
+            "title": "Pris",
+            "range": true,
+            "name": "price"
+        },
+        "year": {
+            "title": "Årsmodell",
+            "range": true,
+            "name": "year"
+        },
+        "engine_effect": {
+            "title": "Hestekrefter",
+            "range": true,
+            "name": "engine_effect"
+        },
+        "make": {
+            "title": "Merke",
+            "name": "make",
+            "queries": [
+                {
+                    "title": "Andre",
+                    "value": "0/200",
+                    "total-results": 1
+                },
+                {
+                    "title": "Case",
+                    "value": "0/8016",
+                    "total-results": 1
+                },
+                {
+                    "title": "CLAAS",
+                    "value": "0/310",
+                    "total-results": 17
+                },
+                {
+                    "title": "Deutz Fahr",
+                    "value": "0/10",
+                    "total-results": 2
+                },
+                {
+                    "title": "Fendt",
+                    "value": "0/8017",
+                    "total-results": 1
+                },
+                {
+                    "title": "John Deere",
+                    "value": "0/30",
+                    "total-results": 6
+                },
+                {
+                    "title": "Massey Ferguson",
+                    "value": "0/40",
+                    "total-results": 13
+                },
+                {
+                    "title": "New Holland",
+                    "value": "0/170",
+                    "total-results": 14
+                },
+                {
+                    "title": "Sampo",
+                    "value": "0/330",
+                    "total-results": 5
+                }
+            ]
+        },
+        "motor_ad_location": {
+            "title": "Kjøretøyet står i",
+            "name": "motor_ad_location"
+        },
+        "location": {
+            "title": "Område",
+            "name": "location",
+            "queries": [
+                {
+                    "title": "Akershus",
+                    "value": "20003",
+                    "total-results": 5
+                },
+                {
+                    "title": "Buskerud",
+                    "value": "20007",
+                    "total-results": 1
+                },
+                {
+                    "title": "Hedmark",
+                    "value": "20005",
+                    "total-results": 12
+                },
+                {
+                    "title": "Oppland",
+                    "value": "20006",
+                    "total-results": 1
+                },
+                {
+                    "title": "Telemark",
+                    "value": "20009",
+                    "total-results": 2
+                },
+                {
+                    "title": "Trøndelag",
+                    "value": "20016",
+                    "total-results": 13
+                },
+                {
+                    "title": "Vestfold",
+                    "value": "20008",
+                    "total-results": 9
+                },
+                {
+                    "title": "Østfold",
+                    "value": "20002",
+                    "total-results": 15
+                }
+            ]
+        },
+        "dealer_segment": {
+            "title": "Annonsør",
+            "name": "dealer_segment",
+            "queries": [
+                {
+                    "title": "Forhandler",
+                    "value": "0",
+                    "total-results": 59
+                },
+                {
+                    "title": "Privat",
+                    "value": "1",
+                    "total-results": 1
+                }
+            ]
+        },
+        "published": {
+            "title": "Publisert",
+            "name": "published",
+            "queries": [
+                {
+                    "title": "Nye i dag",
+                    "value": "1",
+                    "total-results": 1
+                }
+            ]
+        }
+    },
+    "map": {
+        "parameter": "bbox",
+        "areaParameters": [
+            "location"
+        ]
+    }
+}

--- a/Demo/Resources/b2b/agriculture-tools.json
+++ b/Demo/Resources/b2b/agriculture-tools.json
@@ -1,0 +1,232 @@
+{
+    "market": "agriculture-tools",
+    "hits": 3851,
+    "label": "Redskap",
+    "type": "search",
+    "filters": [
+        "markets",
+        "q",
+        "published",
+        "location",
+        "category",
+        "price",
+        "year",
+        "dealer_segment"
+    ],
+    "filter-data": {
+        "price": {
+            "title": "Pris",
+            "range": true,
+            "name": "price"
+        },
+        "year": {
+            "title": "Årsmodell",
+            "range": true,
+            "name": "year"
+        },
+        "engine_effect": {
+            "title": "Hestekrefter",
+            "range": true,
+            "name": "engine_effect"
+        },
+        "motor_ad_location": {
+            "title": "Kjøretøyet står i",
+            "name": "motor_ad_location"
+        },
+        "location": {
+            "title": "Område",
+            "name": "location",
+            "queries": [
+                {
+                    "title": "Akershus",
+                    "value": "20003",
+                    "total-results": 300
+                },
+                {
+                    "title": "Aust-Agder",
+                    "value": "20010",
+                    "total-results": 53
+                },
+                {
+                    "title": "Buskerud",
+                    "value": "20007",
+                    "total-results": 129
+                },
+                {
+                    "title": "Finnmark",
+                    "value": "20020",
+                    "total-results": 22
+                },
+                {
+                    "title": "Hedmark",
+                    "value": "20005",
+                    "total-results": 230
+                },
+                {
+                    "title": "Hordaland",
+                    "value": "20013",
+                    "total-results": 76
+                },
+                {
+                    "title": "Møre og Romsdal",
+                    "value": "20015",
+                    "total-results": 249
+                },
+                {
+                    "title": "Nordland",
+                    "value": "20018",
+                    "total-results": 129
+                },
+                {
+                    "title": "Oppland",
+                    "value": "20006",
+                    "total-results": 234
+                },
+                {
+                    "title": "Oslo",
+                    "value": "20061",
+                    "total-results": 7
+                },
+                {
+                    "title": "Rogaland",
+                    "value": "20012",
+                    "total-results": 868
+                },
+                {
+                    "title": "Sogn og Fjordane",
+                    "value": "20014",
+                    "total-results": 73
+                },
+                {
+                    "title": "Telemark",
+                    "value": "20009",
+                    "total-results": 113
+                },
+                {
+                    "title": "Troms",
+                    "value": "20019",
+                    "total-results": 47
+                },
+                {
+                    "title": "Trøndelag",
+                    "value": "20016",
+                    "total-results": 452
+                },
+                {
+                    "title": "Vestfold",
+                    "value": "20008",
+                    "total-results": 266
+                },
+                {
+                    "title": "Vest-Agder",
+                    "value": "20011",
+                    "total-results": 228
+                },
+                {
+                    "title": "Østfold",
+                    "value": "20002",
+                    "total-results": 365
+                }
+            ]
+        },
+        "category": {
+            "title": "Type",
+            "name": "category",
+            "queries": [
+                {
+                    "title": "Andre redskap",
+                    "value": "100",
+                    "total-results": 403
+                },
+                {
+                    "title": "Gressmaskiner",
+                    "value": "20",
+                    "total-results": 568
+                },
+                {
+                    "title": "Innendørs mekanisering",
+                    "value": "90",
+                    "total-results": 179
+                },
+                {
+                    "title": "Jordbearbeiding",
+                    "value": "10",
+                    "total-results": 216
+                },
+                {
+                    "title": "Plen- og parkmaskiner",
+                    "value": "101",
+                    "total-results": 58
+                },
+                {
+                    "title": "Potetmaskiner",
+                    "value": "30",
+                    "total-results": 20
+                },
+                {
+                    "title": "Skog og vedutstyr",
+                    "value": "70",
+                    "total-results": 443
+                },
+                {
+                    "title": "Sprøyteutstyr",
+                    "value": "40",
+                    "total-results": 59
+                },
+                {
+                    "title": "Så og gjødsel",
+                    "value": "80",
+                    "total-results": 316
+                },
+                {
+                    "title": "Tilbehør",
+                    "value": "102",
+                    "total-results": 165
+                },
+                {
+                    "title": "Transportutstyr",
+                    "value": "50",
+                    "total-results": 596
+                },
+                {
+                    "title": "Veiutstyr",
+                    "value": "60",
+                    "total-results": 827
+                }
+            ]
+        },
+        "dealer_segment": {
+            "title": "Annonsør",
+            "name": "dealer_segment",
+            "queries": [
+                {
+                    "title": "Forhandler",
+                    "value": "0",
+                    "total-results": 3476
+                },
+                {
+                    "title": "Privat",
+                    "value": "1",
+                    "total-results": 375
+                }
+            ]
+        },
+        "published": {
+            "title": "Publisert",
+            "name": "published",
+            "queries": [
+                {
+                    "title": "Nye i dag",
+                    "value": "1",
+                    "total-results": 60
+                }
+            ]
+        }
+    },
+    "map": {
+        "parameter": "bbox",
+        "areaParameters": [
+            "location"
+        ]
+    }
+}

--- a/Demo/Resources/b2b/agriculture-tractor.json
+++ b/Demo/Resources/b2b/agriculture-tractor.json
@@ -1,0 +1,408 @@
+{
+    "market": "agriculture-tractor",
+    "hits": 1395,
+    "label": "Traktor",
+    "type": "search",
+    "filters": [
+        "markets",
+        "q",
+        "published",
+        "location",
+        "make",
+        "price",
+        "year",
+        "engine_effect",
+        "dealer_segment"
+    ],
+    "filter-data": {
+        "price": {
+            "title": "Pris",
+            "range": true,
+            "name": "price"
+        },
+        "year": {
+            "title": "Årsmodell",
+            "range": true,
+            "name": "year"
+        },
+        "engine_effect": {
+            "title": "Hestekrefter",
+            "range": true,
+            "name": "engine_effect"
+        },
+        "make": {
+            "title": "Merke",
+            "name": "make",
+            "queries": [
+                {
+                    "title": "Aebi",
+                    "value": "0/300",
+                    "total-results": 2
+                },
+                {
+                    "title": "AGT",
+                    "value": "0/8178",
+                    "total-results": 1
+                },
+                {
+                    "title": "Andre",
+                    "value": "0/200",
+                    "total-results": 102
+                },
+                {
+                    "title": "Antonio Carraro",
+                    "value": "0/310",
+                    "total-results": 8
+                },
+                {
+                    "title": "Attack",
+                    "value": "0/8175",
+                    "total-results": 2
+                },
+                {
+                    "title": "Belarus",
+                    "value": "0/70",
+                    "total-results": 3
+                },
+                {
+                    "title": "Branson",
+                    "value": "0/8176",
+                    "total-results": 4
+                },
+                {
+                    "title": "CASE IH",
+                    "value": "0/150",
+                    "total-results": 82
+                },
+                {
+                    "title": "CLAAS",
+                    "value": "0/8151",
+                    "total-results": 50
+                },
+                {
+                    "title": "David Brown",
+                    "value": "0/130",
+                    "total-results": 8
+                },
+                {
+                    "title": "Deutz Fahr",
+                    "value": "0/10",
+                    "total-results": 74
+                },
+                {
+                    "title": "Dong Feng",
+                    "value": "0/8174",
+                    "total-results": 9
+                },
+                {
+                    "title": "Fendt",
+                    "value": "0/80",
+                    "total-results": 100
+                },
+                {
+                    "title": "Ferrari",
+                    "value": "0/8153",
+                    "total-results": 15
+                },
+                {
+                    "title": "Fiat",
+                    "value": "0/140",
+                    "total-results": 10
+                },
+                {
+                    "title": "Ford",
+                    "value": "0/20",
+                    "total-results": 29
+                },
+                {
+                    "title": "Giant",
+                    "value": "0/8172",
+                    "total-results": 4
+                },
+                {
+                    "title": "Iseki",
+                    "value": "0/8149",
+                    "total-results": 9
+                },
+                {
+                    "title": "JCB",
+                    "value": "0/8029",
+                    "total-results": 15
+                },
+                {
+                    "title": "Jinma",
+                    "value": "0/360",
+                    "total-results": 1
+                },
+                {
+                    "title": "Job-Man",
+                    "value": "0/8171",
+                    "total-results": 5
+                },
+                {
+                    "title": "John Deere",
+                    "value": "0/30",
+                    "total-results": 234
+                },
+                {
+                    "title": "Kärcher",
+                    "value": "0/8179",
+                    "total-results": 1
+                },
+                {
+                    "title": "Kioti",
+                    "value": "0/8167",
+                    "total-results": 1
+                },
+                {
+                    "title": "Kubota",
+                    "value": "0/8034",
+                    "total-results": 26
+                },
+                {
+                    "title": "Lamborghini",
+                    "value": "0/160",
+                    "total-results": 4
+                },
+                {
+                    "title": "Landini",
+                    "value": "0/320",
+                    "total-results": 2
+                },
+                {
+                    "title": "Lovol",
+                    "value": "0/8192",
+                    "total-results": 10
+                },
+                {
+                    "title": "Massey Ferguson",
+                    "value": "0/40",
+                    "total-results": 225
+                },
+                {
+                    "title": "MB Trac",
+                    "value": "0/100",
+                    "total-results": 1
+                },
+                {
+                    "title": "McCormick",
+                    "value": "0/8148",
+                    "total-results": 16
+                },
+                {
+                    "title": "New Holland",
+                    "value": "0/170",
+                    "total-results": 121
+                },
+                {
+                    "title": "Pronar",
+                    "value": "0/8160",
+                    "total-results": 1
+                },
+                {
+                    "title": "Reform",
+                    "value": "0/8180",
+                    "total-results": 1
+                },
+                {
+                    "title": "Same",
+                    "value": "0/180",
+                    "total-results": 3
+                },
+                {
+                    "title": "Schäffer",
+                    "value": "0/8177",
+                    "total-results": 3
+                },
+                {
+                    "title": "SHIBAURA",
+                    "value": "0/8182",
+                    "total-results": 2
+                },
+                {
+                    "title": "Solis",
+                    "value": "0/8198",
+                    "total-results": 5
+                },
+                {
+                    "title": "Thaler",
+                    "value": "0/8197",
+                    "total-results": 9
+                },
+                {
+                    "title": "TYM",
+                    "value": "0/8162",
+                    "total-results": 1
+                },
+                {
+                    "title": "Ursus",
+                    "value": "0/110",
+                    "total-results": 2
+                },
+                {
+                    "title": "Valmet",
+                    "value": "0/8056",
+                    "total-results": 7
+                },
+                {
+                    "title": "Valtra",
+                    "value": "0/8057",
+                    "total-results": 133
+                },
+                {
+                    "title": "Volvo",
+                    "value": "0/190",
+                    "total-results": 16
+                },
+                {
+                    "title": "Weidemann",
+                    "value": "0/8154",
+                    "total-results": 10
+                },
+                {
+                    "title": "Yanmar",
+                    "value": "0/8152",
+                    "total-results": 1
+                },
+                {
+                    "title": "Zetor",
+                    "value": "0/60",
+                    "total-results": 23
+                }
+            ]
+        },
+        "motor_ad_location": {
+            "title": "Kjøretøyet står i",
+            "name": "motor_ad_location"
+        },
+        "location": {
+            "title": "Område",
+            "name": "location",
+            "queries": [
+                {
+                    "title": "Akershus",
+                    "value": "20003",
+                    "total-results": 80
+                },
+                {
+                    "title": "Aust-Agder",
+                    "value": "20010",
+                    "total-results": 26
+                },
+                {
+                    "title": "Buskerud",
+                    "value": "20007",
+                    "total-results": 113
+                },
+                {
+                    "title": "Finnmark",
+                    "value": "20020",
+                    "total-results": 8
+                },
+                {
+                    "title": "Hedmark",
+                    "value": "20005",
+                    "total-results": 122
+                },
+                {
+                    "title": "Hordaland",
+                    "value": "20013",
+                    "total-results": 56
+                },
+                {
+                    "title": "Møre og Romsdal",
+                    "value": "20015",
+                    "total-results": 76
+                },
+                {
+                    "title": "Nordland",
+                    "value": "20018",
+                    "total-results": 71
+                },
+                {
+                    "title": "Oppland",
+                    "value": "20006",
+                    "total-results": 78
+                },
+                {
+                    "title": "Oslo",
+                    "value": "20061",
+                    "total-results": 1
+                },
+                {
+                    "title": "Rogaland",
+                    "value": "20012",
+                    "total-results": 220
+                },
+                {
+                    "title": "Sogn og Fjordane",
+                    "value": "20014",
+                    "total-results": 71
+                },
+                {
+                    "title": "Telemark",
+                    "value": "20009",
+                    "total-results": 33
+                },
+                {
+                    "title": "Troms",
+                    "value": "20019",
+                    "total-results": 23
+                },
+                {
+                    "title": "Trøndelag",
+                    "value": "20016",
+                    "total-results": 203
+                },
+                {
+                    "title": "Vestfold",
+                    "value": "20008",
+                    "total-results": 87
+                },
+                {
+                    "title": "Vest-Agder",
+                    "value": "20011",
+                    "total-results": 50
+                },
+                {
+                    "title": "Østfold",
+                    "value": "20002",
+                    "total-results": 73
+                }
+            ]
+        },
+        "dealer_segment": {
+            "title": "Annonsør",
+            "name": "dealer_segment",
+            "queries": [
+                {
+                    "title": "Forhandler",
+                    "value": "0",
+                    "total-results": 1119
+                },
+                {
+                    "title": "Privat",
+                    "value": "1",
+                    "total-results": 276
+                }
+            ]
+        },
+        "published": {
+            "title": "Publisert",
+            "name": "published",
+            "queries": [
+                {
+                    "title": "Nye i dag",
+                    "value": "1",
+                    "total-results": 42
+                }
+            ]
+        }
+    },
+    "map": {
+        "parameter": "bbox",
+        "areaParameters": [
+            "location"
+        ]
+    }
+}

--- a/Demo/Resources/b2b/bus.json
+++ b/Demo/Resources/b2b/bus.json
@@ -1,0 +1,285 @@
+{
+    "market": "bus",
+    "hits": 202,
+    "label": "Buss og minibuss",
+    "type": "search",
+    "filters": [
+        "markets",
+        "q",
+        "published",
+        "location",
+        "bus_segment",
+        "make",
+        "price",
+        "year",
+        "engine_effect",
+        "dealer_segment"
+    ],
+    "filter-data": {
+        "price": {
+            "title": "Pris",
+            "range": true,
+            "name": "price"
+        },
+        "year": {
+            "title": "Årsmodell",
+            "range": true,
+            "name": "year"
+        },
+        "engine_effect": {
+            "title": "Hestekrefter",
+            "range": true,
+            "name": "engine_effect"
+        },
+        "make": {
+            "title": "Merke",
+            "name": "make",
+            "queries": [
+                {
+                    "title": "Annet",
+                    "value": "1",
+                    "total-results": 3
+                },
+                {
+                    "title": "DAF",
+                    "value": "2",
+                    "total-results": 1
+                },
+                {
+                    "title": "Ford",
+                    "value": "14",
+                    "total-results": 10
+                },
+                {
+                    "title": "Hino",
+                    "value": "16",
+                    "total-results": 1
+                },
+                {
+                    "title": "Irisbus Iveco",
+                    "value": "3",
+                    "total-results": 1
+                },
+                {
+                    "title": "Irizar",
+                    "value": "22",
+                    "total-results": 1
+                },
+                {
+                    "title": "Isuzu",
+                    "value": "21",
+                    "total-results": 2
+                },
+                {
+                    "title": "Iveco",
+                    "value": "19",
+                    "total-results": 9
+                },
+                {
+                    "title": "MAN",
+                    "value": "13",
+                    "total-results": 14
+                },
+                {
+                    "title": "Mercedes-Benz",
+                    "value": "4",
+                    "total-results": 68
+                },
+                {
+                    "title": "Neoplan",
+                    "value": "17",
+                    "total-results": 6
+                },
+                {
+                    "title": "Peugeot",
+                    "value": "18",
+                    "total-results": 1
+                },
+                {
+                    "title": "Renault",
+                    "value": "6",
+                    "total-results": 3
+                },
+                {
+                    "title": "Scania",
+                    "value": "7",
+                    "total-results": 28
+                },
+                {
+                    "title": "Setra",
+                    "value": "8",
+                    "total-results": 8
+                },
+                {
+                    "title": "Temsa",
+                    "value": "9",
+                    "total-results": 1
+                },
+                {
+                    "title": "Van Hool",
+                    "value": "10",
+                    "total-results": 2
+                },
+                {
+                    "title": "VDL",
+                    "value": "11",
+                    "total-results": 1
+                },
+                {
+                    "title": "Volkswagen",
+                    "value": "20",
+                    "total-results": 1
+                },
+                {
+                    "title": "Volvo",
+                    "value": "12",
+                    "total-results": 41
+                }
+            ]
+        },
+        "dealer_segment": {
+            "title": "Annonsør",
+            "name": "dealer_segment",
+            "queries": [
+                {
+                    "title": "Annet bilutsalg",
+                    "value": "2",
+                    "total-results": 150
+                },
+                {
+                    "title": "Privat",
+                    "value": "3",
+                    "total-results": 52
+                }
+            ]
+        },
+        "motor_ad_location": {
+            "title": "Kjøretøyet står i",
+            "name": "motor_ad_location"
+        },
+        "location": {
+            "title": "Område",
+            "name": "location",
+            "queries": [
+                {
+                    "title": "Akershus",
+                    "value": "20003",
+                    "total-results": 45
+                },
+                {
+                    "title": "Aust-Agder",
+                    "value": "20010",
+                    "total-results": 9
+                },
+                {
+                    "title": "Buskerud",
+                    "value": "20007",
+                    "total-results": 11
+                },
+                {
+                    "title": "Finnmark",
+                    "value": "20020",
+                    "total-results": 2
+                },
+                {
+                    "title": "Hedmark",
+                    "value": "20005",
+                    "total-results": 9
+                },
+                {
+                    "title": "Hordaland",
+                    "value": "20013",
+                    "total-results": 10
+                },
+                {
+                    "title": "Nordland",
+                    "value": "20018",
+                    "total-results": 7
+                },
+                {
+                    "title": "Oppland",
+                    "value": "20006",
+                    "total-results": 10
+                },
+                {
+                    "title": "Oslo",
+                    "value": "20061",
+                    "total-results": 11
+                },
+                {
+                    "title": "Rogaland",
+                    "value": "20012",
+                    "total-results": 15
+                },
+                {
+                    "title": "Sogn og Fjordane",
+                    "value": "20014",
+                    "total-results": 7
+                },
+                {
+                    "title": "Telemark",
+                    "value": "20009",
+                    "total-results": 1
+                },
+                {
+                    "title": "Trøndelag",
+                    "value": "20016",
+                    "total-results": 26
+                },
+                {
+                    "title": "Vestfold",
+                    "value": "20008",
+                    "total-results": 7
+                },
+                {
+                    "title": "Vest-Agder",
+                    "value": "20011",
+                    "total-results": 5
+                },
+                {
+                    "title": "Østfold",
+                    "value": "20002",
+                    "total-results": 23
+                }
+            ]
+        },
+        "bus_segment": {
+            "title": "Kjøretøygruppe",
+            "name": "bus_segment",
+            "queries": [
+                {
+                    "title": "Annet",
+                    "value": "1",
+                    "total-results": 3
+                },
+                {
+                    "title": "Buss",
+                    "value": "2",
+                    "total-results": 120
+                },
+                {
+                    "title": "Minibuss",
+                    "value": "3",
+                    "total-results": 79
+                }
+            ]
+        },
+        "published": {
+            "title": "Publisert",
+            "name": "published",
+            "queries": [
+                {
+                    "title": "Nye i dag",
+                    "value": "1",
+                    "total-results": 0
+                }
+            ]
+        }
+    },
+    "map": {
+        "parameter": "bbox",
+        "areaParameters": [
+            "location"
+        ]
+    }
+}

--- a/Demo/Resources/b2b/construction.json
+++ b/Demo/Resources/b2b/construction.json
@@ -1,0 +1,765 @@
+{
+    "market": "construction",
+    "hits": 4442,
+    "label": "Bygg og anlegg",
+    "type": "search",
+    "filters": [
+        "markets",
+        "q",
+        "published",
+        "location",
+        "construction_segment",
+        "make",
+        "price",
+        "year",
+        "engine_effect",
+        "dealer_segment"
+    ],
+    "filter-data": {
+        "price": {
+            "title": "Pris",
+            "range": true,
+            "name": "price"
+        },
+        "year": {
+            "title": "Årsmodell",
+            "range": true,
+            "name": "year"
+        },
+        "engine_effect": {
+            "title": "Hestekrefter",
+            "range": true,
+            "name": "engine_effect"
+        },
+        "make": {
+            "title": "Merke",
+            "name": "make",
+            "queries": [
+                {
+                    "title": "ABS",
+                    "value": "8010",
+                    "total-results": 4
+                },
+                {
+                    "title": "Airman",
+                    "value": "8011",
+                    "total-results": 12
+                },
+                {
+                    "title": "Almac",
+                    "value": "8426",
+                    "total-results": 3
+                },
+                {
+                    "title": "AMMANN",
+                    "value": "8308",
+                    "total-results": 12
+                },
+                {
+                    "title": "Andre",
+                    "value": "200",
+                    "total-results": 1885
+                },
+                {
+                    "title": "Atlas",
+                    "value": "8013",
+                    "total-results": 26
+                },
+                {
+                    "title": "Atlas Copco",
+                    "value": "8403",
+                    "total-results": 57
+                },
+                {
+                    "title": "Atlet",
+                    "value": "8262",
+                    "total-results": 16
+                },
+                {
+                    "title": "Attack",
+                    "value": "8395",
+                    "total-results": 21
+                },
+                {
+                    "title": "Bergmann",
+                    "value": "8405",
+                    "total-results": 4
+                },
+                {
+                    "title": "Bobcat",
+                    "value": "8015",
+                    "total-results": 33
+                },
+                {
+                    "title": "Bomag",
+                    "value": "8358",
+                    "total-results": 6
+                },
+                {
+                    "title": "BT",
+                    "value": "410",
+                    "total-results": 121
+                },
+                {
+                    "title": "Case",
+                    "value": "560",
+                    "total-results": 36
+                },
+                {
+                    "title": "Cat",
+                    "value": "8017",
+                    "total-results": 143
+                },
+                {
+                    "title": "Cesab",
+                    "value": "8345",
+                    "total-results": 10
+                },
+                {
+                    "title": "Clark",
+                    "value": "420",
+                    "total-results": 4
+                },
+                {
+                    "title": "Crown",
+                    "value": "8302",
+                    "total-results": 6
+                },
+                {
+                    "title": "Daewoo",
+                    "value": "8018",
+                    "total-results": 3
+                },
+                {
+                    "title": "Dan Truck",
+                    "value": "500",
+                    "total-results": 4
+                },
+                {
+                    "title": "Dieci",
+                    "value": "8373",
+                    "total-results": 11
+                },
+                {
+                    "title": "Dingli",
+                    "value": "8414",
+                    "total-results": 10
+                },
+                {
+                    "title": "Dino",
+                    "value": "8369",
+                    "total-results": 8
+                },
+                {
+                    "title": "Doosan",
+                    "value": "8340",
+                    "total-results": 43
+                },
+                {
+                    "title": "Dynapac",
+                    "value": "8402",
+                    "total-results": 8
+                },
+                {
+                    "title": "Eurocomach",
+                    "value": "8434",
+                    "total-results": 11
+                },
+                {
+                    "title": "Fiat-Hitachi",
+                    "value": "8020",
+                    "total-results": 5
+                },
+                {
+                    "title": "Ford",
+                    "value": "20",
+                    "total-results": 2
+                },
+                {
+                    "title": "Gehl",
+                    "value": "8021",
+                    "total-results": 6
+                },
+                {
+                    "title": "Genie",
+                    "value": "8344",
+                    "total-results": 14
+                },
+                {
+                    "title": "Giant",
+                    "value": "8389",
+                    "total-results": 13
+                },
+                {
+                    "title": "Grove",
+                    "value": "8380",
+                    "total-results": 3
+                },
+                {
+                    "title": "Hangcha",
+                    "value": "520",
+                    "total-results": 20
+                },
+                {
+                    "title": "Hanix",
+                    "value": "8023",
+                    "total-results": 5
+                },
+                {
+                    "title": "Hardlife",
+                    "value": "8431",
+                    "total-results": 216
+                },
+                {
+                    "title": "Haulotte",
+                    "value": "8392",
+                    "total-results": 18
+                },
+                {
+                    "title": "HeatWork",
+                    "value": "8435",
+                    "total-results": 4
+                },
+                {
+                    "title": "Heli",
+                    "value": "8342",
+                    "total-results": 25
+                },
+                {
+                    "title": "Hinowa",
+                    "value": "8370",
+                    "total-results": 8
+                },
+                {
+                    "title": "Hitachi",
+                    "value": "8025",
+                    "total-results": 97
+                },
+                {
+                    "title": "Hydrema",
+                    "value": "8026",
+                    "total-results": 12
+                },
+                {
+                    "title": "Hymax",
+                    "value": "8027",
+                    "total-results": 3
+                },
+                {
+                    "title": "Hyundai",
+                    "value": "8028",
+                    "total-results": 37
+                },
+                {
+                    "title": "Haahjem",
+                    "value": "8422",
+                    "total-results": 13
+                },
+                {
+                    "title": "IHI",
+                    "value": "8151",
+                    "total-results": 5
+                },
+                {
+                    "title": "JAC",
+                    "value": "8418",
+                    "total-results": 3
+                },
+                {
+                    "title": "JCB",
+                    "value": "8029",
+                    "total-results": 39
+                },
+                {
+                    "title": "JLG",
+                    "value": "8371",
+                    "total-results": 27
+                },
+                {
+                    "title": "Job-Man",
+                    "value": "8388",
+                    "total-results": 5
+                },
+                {
+                    "title": "Jungheinrich",
+                    "value": "8263",
+                    "total-results": 30
+                },
+                {
+                    "title": "Kaeser",
+                    "value": "8353",
+                    "total-results": 15
+                },
+                {
+                    "title": "Kalmar",
+                    "value": "450",
+                    "total-results": 7
+                },
+                {
+                    "title": "Kato",
+                    "value": "8030",
+                    "total-results": 13
+                },
+                {
+                    "title": "Kärcher",
+                    "value": "8407",
+                    "total-results": 3
+                },
+                {
+                    "title": "Keestrack",
+                    "value": "8381",
+                    "total-results": 17
+                },
+                {
+                    "title": "Kleemann",
+                    "value": "8409",
+                    "total-results": 7
+                },
+                {
+                    "title": "Kobelco",
+                    "value": "8031",
+                    "total-results": 56
+                },
+                {
+                    "title": "Komatsu",
+                    "value": "8033",
+                    "total-results": 86
+                },
+                {
+                    "title": "KramerAllrad",
+                    "value": "8145",
+                    "total-results": 50
+                },
+                {
+                    "title": "Kubota",
+                    "value": "8034",
+                    "total-results": 71
+                },
+                {
+                    "title": "Liebherr",
+                    "value": "8036",
+                    "total-results": 7
+                },
+                {
+                    "title": "Liftstar",
+                    "value": "8413",
+                    "total-results": 13
+                },
+                {
+                    "title": "Linde",
+                    "value": "460",
+                    "total-results": 9
+                },
+                {
+                    "title": "Ljungby",
+                    "value": "8037",
+                    "total-results": 3
+                },
+                {
+                    "title": "Logitrans",
+                    "value": "400",
+                    "total-results": 4
+                },
+                {
+                    "title": "Lundberg",
+                    "value": "8038",
+                    "total-results": 13
+                },
+                {
+                    "title": "Magni",
+                    "value": "8398",
+                    "total-results": 9
+                },
+                {
+                    "title": "Manitou",
+                    "value": "580",
+                    "total-results": 76
+                },
+                {
+                    "title": "Maximal",
+                    "value": "8397",
+                    "total-results": 65
+                },
+                {
+                    "title": "Messersi",
+                    "value": "210",
+                    "total-results": 4
+                },
+                {
+                    "title": "Mitsubishi",
+                    "value": "430",
+                    "total-results": 22
+                },
+                {
+                    "title": "Moxy",
+                    "value": "8040",
+                    "total-results": 10
+                },
+                {
+                    "title": "Mustang",
+                    "value": "8041",
+                    "total-results": 8
+                },
+                {
+                    "title": "Neuson",
+                    "value": "8042",
+                    "total-results": 9
+                },
+                {
+                    "title": "New Holland",
+                    "value": "170",
+                    "total-results": 17
+                },
+                {
+                    "title": "Niftylift",
+                    "value": "8332",
+                    "total-results": 6
+                },
+                {
+                    "title": "Nissan",
+                    "value": "370",
+                    "total-results": 5
+                },
+                {
+                    "title": "Omme",
+                    "value": "8372",
+                    "total-results": 7
+                },
+                {
+                    "title": "Powerscreen",
+                    "value": "8424",
+                    "total-results": 18
+                },
+                {
+                    "title": "Sandvik",
+                    "value": "8374",
+                    "total-results": 65
+                },
+                {
+                    "title": "Schaeff",
+                    "value": "8049",
+                    "total-results": 3
+                },
+                {
+                    "title": "Sino",
+                    "value": "8425",
+                    "total-results": 9
+                },
+                {
+                    "title": "SkyJack",
+                    "value": "8335",
+                    "total-results": 4
+                },
+                {
+                    "title": "Snorkel",
+                    "value": "8334",
+                    "total-results": 5
+                },
+                {
+                    "title": "Still",
+                    "value": "530",
+                    "total-results": 22
+                },
+                {
+                    "title": "Sunward",
+                    "value": "8415",
+                    "total-results": 8
+                },
+                {
+                    "title": "Tadano",
+                    "value": "8377",
+                    "total-results": 3
+                },
+                {
+                    "title": "Takeuchi",
+                    "value": "8051",
+                    "total-results": 15
+                },
+                {
+                    "title": "Tamrock",
+                    "value": "8348",
+                    "total-results": 19
+                },
+                {
+                    "title": "Terex",
+                    "value": "8053",
+                    "total-results": 45
+                },
+                {
+                    "title": "Thaler",
+                    "value": "8432",
+                    "total-results": 6
+                },
+                {
+                    "title": "Toyota",
+                    "value": "8264",
+                    "total-results": 81
+                },
+                {
+                    "title": "Trevi Benne",
+                    "value": "8429",
+                    "total-results": 6
+                },
+                {
+                    "title": "Volvo",
+                    "value": "190",
+                    "total-results": 248
+                },
+                {
+                    "title": "Wacker",
+                    "value": "8354",
+                    "total-results": 38
+                },
+                {
+                    "title": "Weidemann",
+                    "value": "8309",
+                    "total-results": 12
+                },
+                {
+                    "title": "Wille",
+                    "value": "8339",
+                    "total-results": 4
+                },
+                {
+                    "title": "Yanmar",
+                    "value": "8058",
+                    "total-results": 38
+                },
+                {
+                    "title": "Yuchai",
+                    "value": "8396",
+                    "total-results": 9
+                },
+                {
+                    "title": "Åkerman",
+                    "value": "8012",
+                    "total-results": 10
+                }
+            ]
+        },
+        "dealer_segment": {
+            "title": "Annonsør",
+            "name": "dealer_segment",
+            "queries": [
+                {
+                    "title": "Annet bilutsalg",
+                    "value": "2",
+                    "total-results": 4208
+                },
+                {
+                    "title": "Privat",
+                    "value": "3",
+                    "total-results": 234
+                }
+            ]
+        },
+        "motor_ad_location": {
+            "title": "Kjøretøyet står i",
+            "name": "motor_ad_location"
+        },
+        "location": {
+            "title": "Område",
+            "name": "location",
+            "queries": [
+                {
+                    "title": "Akershus",
+                    "value": "20003",
+                    "total-results": 517
+                },
+                {
+                    "title": "Aust-Agder",
+                    "value": "20010",
+                    "total-results": 57
+                },
+                {
+                    "title": "Buskerud",
+                    "value": "20007",
+                    "total-results": 194
+                },
+                {
+                    "title": "Finnmark",
+                    "value": "20020",
+                    "total-results": 50
+                },
+                {
+                    "title": "Hedmark",
+                    "value": "20005",
+                    "total-results": 129
+                },
+                {
+                    "title": "Hordaland",
+                    "value": "20013",
+                    "total-results": 501
+                },
+                {
+                    "title": "Møre og Romsdal",
+                    "value": "20015",
+                    "total-results": 173
+                },
+                {
+                    "title": "Nordland",
+                    "value": "20018",
+                    "total-results": 110
+                },
+                {
+                    "title": "Oppland",
+                    "value": "20006",
+                    "total-results": 167
+                },
+                {
+                    "title": "Oslo",
+                    "value": "20061",
+                    "total-results": 152
+                },
+                {
+                    "title": "Rogaland",
+                    "value": "20012",
+                    "total-results": 445
+                },
+                {
+                    "title": "Sogn og Fjordane",
+                    "value": "20014",
+                    "total-results": 39
+                },
+                {
+                    "title": "Telemark",
+                    "value": "20009",
+                    "total-results": 85
+                },
+                {
+                    "title": "Troms",
+                    "value": "20019",
+                    "total-results": 180
+                },
+                {
+                    "title": "Trøndelag",
+                    "value": "20016",
+                    "total-results": 603
+                },
+                {
+                    "title": "Vestfold",
+                    "value": "20008",
+                    "total-results": 284
+                },
+                {
+                    "title": "Vest-Agder",
+                    "value": "20011",
+                    "total-results": 218
+                },
+                {
+                    "title": "Østfold",
+                    "value": "20002",
+                    "total-results": 343
+                }
+            ]
+        },
+        "construction_segment": {
+            "title": "Kjøretøygruppe",
+            "name": "construction_segment",
+            "queries": [
+                {
+                    "title": "Andre kjøretøygrupper",
+                    "value": "30",
+                    "total-results": 244
+                },
+                {
+                    "title": "Borutstyr",
+                    "value": "8008",
+                    "total-results": 140
+                },
+                {
+                    "title": "Dumper",
+                    "value": "8002",
+                    "total-results": 128
+                },
+                {
+                    "title": "Gravemaskin",
+                    "value": "8003",
+                    "total-results": 695
+                },
+                {
+                    "title": "Hjullaster",
+                    "value": "8001",
+                    "total-results": 318
+                },
+                {
+                    "title": "Industrimaskin",
+                    "value": "8305",
+                    "total-results": 9
+                },
+                {
+                    "title": "Knuse -og sikteutstyr",
+                    "value": "8007",
+                    "total-results": 321
+                },
+                {
+                    "title": "Kompaktlaster",
+                    "value": "8012",
+                    "total-results": 62
+                },
+                {
+                    "title": "Komprimeringsmaskin",
+                    "value": "8014",
+                    "total-results": 59
+                },
+                {
+                    "title": "Kraner",
+                    "value": "8006",
+                    "total-results": 41
+                },
+                {
+                    "title": "Lift",
+                    "value": "8015",
+                    "total-results": 169
+                },
+                {
+                    "title": "Minigraver",
+                    "value": "8004",
+                    "total-results": 349
+                },
+                {
+                    "title": "Redskapsbærer",
+                    "value": "8016",
+                    "total-results": 36
+                },
+                {
+                    "title": "Teleskoptruck",
+                    "value": "8013",
+                    "total-results": 97
+                },
+                {
+                    "title": "Tilbehør",
+                    "value": "8009",
+                    "total-results": 1151
+                },
+                {
+                    "title": "Traktorgraver",
+                    "value": "8011",
+                    "total-results": 17
+                },
+                {
+                    "title": "Truck",
+                    "value": "8005",
+                    "total-results": 606
+                }
+            ]
+        },
+        "published": {
+            "title": "Publisert",
+            "name": "published",
+            "queries": [
+                {
+                    "title": "Nye i dag",
+                    "value": "1",
+                    "total-results": 73
+                }
+            ]
+        }
+    },
+    "map": {
+        "parameter": "bbox",
+        "areaParameters": [
+            "location"
+        ]
+    }
+}

--- a/Demo/Resources/b2b/truck-abroad.json
+++ b/Demo/Resources/b2b/truck-abroad.json
@@ -1,0 +1,166 @@
+{
+    "market": "truck-abroad",
+    "hits": 18,
+    "label": "Lastebil og henger utland",
+    "type": "search",
+    "filters": [
+        "markets",
+        "q",
+        "published",
+        "location",
+        "truck_segment",
+        "make",
+        "price",
+        "year",
+        "engine_effect",
+        "weight",
+        "dealer_segment"
+    ],
+    "filter-data": {
+        "price": {
+            "title": "Pris",
+            "range": true,
+            "name": "price"
+        },
+        "year": {
+            "title": "Årsmodell",
+            "range": true,
+            "name": "year"
+        },
+        "engine_effect": {
+            "title": "Hestekrefter",
+            "range": true,
+            "name": "engine_effect"
+        },
+        "weight": {
+            "title": "Vekt",
+            "range": true,
+            "name": "weight"
+        },
+        "make": {
+            "title": "Merke",
+            "name": "make",
+            "queries": [
+                {
+                    "title": "MAN",
+                    "value": "150",
+                    "total-results": 2
+                },
+                {
+                    "title": "Mercedes-Benz",
+                    "value": "20",
+                    "total-results": 7
+                },
+                {
+                    "title": "Renault",
+                    "value": "160",
+                    "total-results": 3
+                },
+                {
+                    "title": "Scania",
+                    "value": "30",
+                    "total-results": 2
+                },
+                {
+                    "title": "Volkswagen",
+                    "value": "8139",
+                    "total-results": 1
+                },
+                {
+                    "title": "Volvo",
+                    "value": "180",
+                    "total-results": 3
+                }
+            ]
+        },
+        "truck_segment": {
+            "title": "Kjøretøygruppe",
+            "name": "truck_segment",
+            "queries": [
+                {
+                    "title": "Annet",
+                    "value": "10",
+                    "total-results": 1
+                },
+                {
+                    "title": "Betongbil",
+                    "value": "321",
+                    "total-results": 1
+                },
+                {
+                    "title": "Dyretransport",
+                    "value": "330",
+                    "total-results": 12
+                },
+                {
+                    "title": "Krokløft",
+                    "value": "130",
+                    "total-results": 1
+                },
+                {
+                    "title": "Liftdumper",
+                    "value": "140",
+                    "total-results": 1
+                },
+                {
+                    "title": "Planbil",
+                    "value": "280",
+                    "total-results": 1
+                },
+                {
+                    "title": "Renovasjonsbil",
+                    "value": "170",
+                    "total-results": 1
+                }
+            ]
+        },
+        "dealer_segment": {
+            "title": "Annonsør",
+            "name": "dealer_segment",
+            "queries": [
+                {
+                    "title": "Annet bilutsalg",
+                    "value": "2",
+                    "total-results": 16
+                },
+                {
+                    "title": "Privat",
+                    "value": "3",
+                    "total-results": 2
+                }
+            ]
+        },
+        "motor_ad_location": {
+            "title": "Kjøretøyet står i",
+            "name": "motor_ad_location"
+        },
+        "location": {
+            "title": "Område",
+            "name": "location",
+            "queries": [
+                {
+                    "title": "Østfold",
+                    "value": "20002",
+                    "total-results": 4
+                }
+            ]
+        },
+        "published": {
+            "title": "Publisert",
+            "name": "published",
+            "queries": [
+                {
+                    "title": "Nye i dag",
+                    "value": "1",
+                    "total-results": 0
+                }
+            ]
+        }
+    },
+    "map": {
+        "parameter": "bbox",
+        "areaParameters": [
+            "location"
+        ]
+    }
+}

--- a/Demo/Resources/b2b/truck.json
+++ b/Demo/Resources/b2b/truck.json
@@ -1,0 +1,591 @@
+{
+    "market": "truck",
+    "hits": 2031,
+    "label": "Lastebil og henger",
+    "type": "search",
+    "filters": [
+        "markets",
+        "q",
+        "published",
+        "location",
+        "truck_segment",
+        "make",
+        "price",
+        "year",
+        "engine_effect",
+        "weight",
+        "dealer_segment"
+    ],
+    "filter-data": {
+        "price": {
+            "title": "Pris",
+            "range": true,
+            "name": "price"
+        },
+        "year": {
+            "title": "Årsmodell",
+            "range": true,
+            "name": "year"
+        },
+        "engine_effect": {
+            "title": "Hestekrefter",
+            "range": true,
+            "name": "engine_effect"
+        },
+        "weight": {
+            "title": "Vekt",
+            "range": true,
+            "name": "weight"
+        },
+        "make": {
+            "title": "Merke",
+            "name": "make",
+            "queries": [
+                {
+                    "title": "AMT Trailer",
+                    "value": "8189",
+                    "total-results": 1
+                },
+                {
+                    "title": "Andre",
+                    "value": "220",
+                    "total-results": 336
+                },
+                {
+                    "title": "Bedford",
+                    "value": "8137",
+                    "total-results": 2
+                },
+                {
+                    "title": "Broshuis",
+                    "value": "8149",
+                    "total-results": 14
+                },
+                {
+                    "title": "Bussbygg",
+                    "value": "8167",
+                    "total-results": 3
+                },
+                {
+                    "title": "Carnehl",
+                    "value": "8179",
+                    "total-results": 15
+                },
+                {
+                    "title": "Chereau",
+                    "value": "8147",
+                    "total-results": 8
+                },
+                {
+                    "title": "DAF",
+                    "value": "10",
+                    "total-results": 25
+                },
+                {
+                    "title": "Damm",
+                    "value": "240",
+                    "total-results": 12
+                },
+                {
+                    "title": "Ekeri",
+                    "value": "70",
+                    "total-results": 33
+                },
+                {
+                    "title": "Equi-Trek",
+                    "value": "8185",
+                    "total-results": 5
+                },
+                {
+                    "title": "Faymonville",
+                    "value": "8192",
+                    "total-results": 10
+                },
+                {
+                    "title": "Fiat",
+                    "value": "80",
+                    "total-results": 3
+                },
+                {
+                    "title": "Fliegl",
+                    "value": "8151",
+                    "total-results": 6
+                },
+                {
+                    "title": "Ford",
+                    "value": "100",
+                    "total-results": 11
+                },
+                {
+                    "title": "Fuso",
+                    "value": "8188",
+                    "total-results": 10
+                },
+                {
+                    "title": "Hammar",
+                    "value": "8156",
+                    "total-results": 2
+                },
+                {
+                    "title": "HFR",
+                    "value": "8154",
+                    "total-results": 17
+                },
+                {
+                    "title": "HM",
+                    "value": "8191",
+                    "total-results": 2
+                },
+                {
+                    "title": "HRD",
+                    "value": "8165",
+                    "total-results": 29
+                },
+                {
+                    "title": "Humbaur",
+                    "value": "8184",
+                    "total-results": 3
+                },
+                {
+                    "title": "Istrail",
+                    "value": "8146",
+                    "total-results": 22
+                },
+                {
+                    "title": "Isuzu",
+                    "value": "8187",
+                    "total-results": 2
+                },
+                {
+                    "title": "Iveco",
+                    "value": "130",
+                    "total-results": 69
+                },
+                {
+                    "title": "JPM",
+                    "value": "8190",
+                    "total-results": 2
+                },
+                {
+                    "title": "Kel-Berg",
+                    "value": "8181",
+                    "total-results": 40
+                },
+                {
+                    "title": "Knapen",
+                    "value": "8183",
+                    "total-results": 7
+                },
+                {
+                    "title": "Kögel",
+                    "value": "8143",
+                    "total-results": 7
+                },
+                {
+                    "title": "KRONE",
+                    "value": "8148",
+                    "total-results": 16
+                },
+                {
+                    "title": "Langendorf",
+                    "value": "8166",
+                    "total-results": 6
+                },
+                {
+                    "title": "Leci-trailer",
+                    "value": "8159",
+                    "total-results": 6
+                },
+                {
+                    "title": "Limetec",
+                    "value": "8182",
+                    "total-results": 1
+                },
+                {
+                    "title": "Magirus Deutz",
+                    "value": "140",
+                    "total-results": 1
+                },
+                {
+                    "title": "MAN",
+                    "value": "150",
+                    "total-results": 129
+                },
+                {
+                    "title": "Maur Bilpåbygg",
+                    "value": "8162",
+                    "total-results": 20
+                },
+                {
+                    "title": "Mercedes-Benz",
+                    "value": "20",
+                    "total-results": 202
+                },
+                {
+                    "title": "Mitsubishi",
+                    "value": "260",
+                    "total-results": 16
+                },
+                {
+                    "title": "Närko",
+                    "value": "8141",
+                    "total-results": 24
+                },
+                {
+                    "title": "NC Maskinhenger",
+                    "value": "8177",
+                    "total-results": 7
+                },
+                {
+                    "title": "Nissan",
+                    "value": "210",
+                    "total-results": 5
+                },
+                {
+                    "title": "Nooteboom",
+                    "value": "8157",
+                    "total-results": 2
+                },
+                {
+                    "title": "Nor Slep",
+                    "value": "230",
+                    "total-results": 70
+                },
+                {
+                    "title": "Pacton",
+                    "value": "8150",
+                    "total-results": 4
+                },
+                {
+                    "title": "Peugeot",
+                    "value": "8186",
+                    "total-results": 3
+                },
+                {
+                    "title": "Red River",
+                    "value": "8193",
+                    "total-results": 3
+                },
+                {
+                    "title": "Renault",
+                    "value": "160",
+                    "total-results": 54
+                },
+                {
+                    "title": "Scania",
+                    "value": "30",
+                    "total-results": 320
+                },
+                {
+                    "title": "Scanslep",
+                    "value": "8169",
+                    "total-results": 9
+                },
+                {
+                    "title": "Schmitz",
+                    "value": "8155",
+                    "total-results": 9
+                },
+                {
+                    "title": "Sisu",
+                    "value": "190",
+                    "total-results": 2
+                },
+                {
+                    "title": "Toyota",
+                    "value": "200",
+                    "total-results": 1
+                },
+                {
+                    "title": "Trail King",
+                    "value": "8164",
+                    "total-results": 1
+                },
+                {
+                    "title": "Trio-Lift",
+                    "value": "8152",
+                    "total-results": 5
+                },
+                {
+                    "title": "Tyllis",
+                    "value": "8145",
+                    "total-results": 10
+                },
+                {
+                    "title": "Vang",
+                    "value": "8180",
+                    "total-results": 12
+                },
+                {
+                    "title": "Van Hool",
+                    "value": "8175",
+                    "total-results": 5
+                },
+                {
+                    "title": "Volkswagen",
+                    "value": "8139",
+                    "total-results": 10
+                },
+                {
+                    "title": "Volvo",
+                    "value": "180",
+                    "total-results": 377
+                },
+                {
+                    "title": "Wilco",
+                    "value": "8161",
+                    "total-results": 5
+                }
+            ]
+        },
+        "truck_segment": {
+            "title": "Kjøretøygruppe",
+            "name": "truck_segment",
+            "queries": [
+                {
+                    "title": "Annet",
+                    "value": "10",
+                    "total-results": 145
+                },
+                {
+                    "title": "Bergingsbil",
+                    "value": "90",
+                    "total-results": 44
+                },
+                {
+                    "title": "Betongbil",
+                    "value": "321",
+                    "total-results": 27
+                },
+                {
+                    "title": "Bilfrakter",
+                    "value": "100",
+                    "total-results": 9
+                },
+                {
+                    "title": "Brannbil",
+                    "value": "110",
+                    "total-results": 6
+                },
+                {
+                    "title": "Chassis",
+                    "value": "70",
+                    "total-results": 29
+                },
+                {
+                    "title": "Containerbil",
+                    "value": "300",
+                    "total-results": 41
+                },
+                {
+                    "title": "Dyretransport",
+                    "value": "330",
+                    "total-results": 59
+                },
+                {
+                    "title": "Henger",
+                    "value": "180",
+                    "total-results": 594
+                },
+                {
+                    "title": "Kranbil",
+                    "value": "120",
+                    "total-results": 111
+                },
+                {
+                    "title": "Krokløft",
+                    "value": "130",
+                    "total-results": 87
+                },
+                {
+                    "title": "Liftdumper",
+                    "value": "140",
+                    "total-results": 8
+                },
+                {
+                    "title": "Planbil",
+                    "value": "280",
+                    "total-results": 51
+                },
+                {
+                    "title": "Renovasjonsbil",
+                    "value": "170",
+                    "total-results": 13
+                },
+                {
+                    "title": "Skapbil",
+                    "value": "310",
+                    "total-results": 228
+                },
+                {
+                    "title": "Spesialkjøretøy",
+                    "value": "210",
+                    "total-results": 46
+                },
+                {
+                    "title": "Tankbil",
+                    "value": "50",
+                    "total-results": 16
+                },
+                {
+                    "title": "Tippbil",
+                    "value": "230",
+                    "total-results": 230
+                },
+                {
+                    "title": "Trekkvogn",
+                    "value": "250",
+                    "total-results": 265
+                },
+                {
+                    "title": "Tømmerbil",
+                    "value": "260",
+                    "total-results": 7
+                },
+                {
+                    "title": "Veteranbil",
+                    "value": "150",
+                    "total-results": 11
+                }
+            ]
+        },
+        "dealer_segment": {
+            "title": "Annonsør",
+            "name": "dealer_segment",
+            "queries": [
+                {
+                    "title": "Annet bilutsalg",
+                    "value": "2",
+                    "total-results": 1451
+                },
+                {
+                    "title": "Merkeforhandler",
+                    "value": "1",
+                    "total-results": 274
+                },
+                {
+                    "title": "Privat",
+                    "value": "3",
+                    "total-results": 306
+                }
+            ]
+        },
+        "motor_ad_location": {
+            "title": "Kjøretøyet står i",
+            "name": "motor_ad_location"
+        },
+        "location": {
+            "title": "Område",
+            "name": "location",
+            "queries": [
+                {
+                    "title": "Akershus",
+                    "value": "20003",
+                    "total-results": 286
+                },
+                {
+                    "title": "Aust-Agder",
+                    "value": "20010",
+                    "total-results": 18
+                },
+                {
+                    "title": "Buskerud",
+                    "value": "20007",
+                    "total-results": 85
+                },
+                {
+                    "title": "Finnmark",
+                    "value": "20020",
+                    "total-results": 52
+                },
+                {
+                    "title": "Hedmark",
+                    "value": "20005",
+                    "total-results": 61
+                },
+                {
+                    "title": "Hordaland",
+                    "value": "20013",
+                    "total-results": 109
+                },
+                {
+                    "title": "Møre og Romsdal",
+                    "value": "20015",
+                    "total-results": 69
+                },
+                {
+                    "title": "Nordland",
+                    "value": "20018",
+                    "total-results": 93
+                },
+                {
+                    "title": "Oppland",
+                    "value": "20006",
+                    "total-results": 134
+                },
+                {
+                    "title": "Oslo",
+                    "value": "20061",
+                    "total-results": 60
+                },
+                {
+                    "title": "Rogaland",
+                    "value": "20012",
+                    "total-results": 124
+                },
+                {
+                    "title": "Sogn og Fjordane",
+                    "value": "20014",
+                    "total-results": 24
+                },
+                {
+                    "title": "Telemark",
+                    "value": "20009",
+                    "total-results": 50
+                },
+                {
+                    "title": "Troms",
+                    "value": "20019",
+                    "total-results": 120
+                },
+                {
+                    "title": "Trøndelag",
+                    "value": "20016",
+                    "total-results": 383
+                },
+                {
+                    "title": "Vestfold",
+                    "value": "20008",
+                    "total-results": 171
+                },
+                {
+                    "title": "Vest-Agder",
+                    "value": "20011",
+                    "total-results": 28
+                },
+                {
+                    "title": "Østfold",
+                    "value": "20002",
+                    "total-results": 160
+                }
+            ]
+        },
+        "published": {
+            "title": "Publisert",
+            "name": "published",
+            "queries": [
+                {
+                    "title": "Nye i dag",
+                    "value": "1",
+                    "total-results": 28
+                }
+            ]
+        }
+    },
+    "map": {
+        "parameter": "bbox",
+        "areaParameters": [
+            "location"
+        ]
+    }
+}

--- a/Demo/Resources/b2b/van-abroad.json
+++ b/Demo/Resources/b2b/van-abroad.json
@@ -1,0 +1,277 @@
+{
+    "market": "van-abroad",
+    "hits": 1,
+    "label": "Varebiler i utlandet",
+    "type": "search",
+    "filters": [
+        "markets",
+        "q",
+        "published",
+        "make",
+        "year",
+        "mileage",
+        "price",
+        "body_type",
+        "location",
+        "engine_fuel",
+        "exterior_colour",
+        "engine_effect",
+        "number_of_seats",
+        "wheel_drive",
+        "dealer_segment",
+        "transmission",
+        "wheel_sets",
+        "warranty_insurance",
+        "condition",
+        "sales_form"
+    ],
+    "filter-data": {
+        "year": {
+            "title": "Årsmodell",
+            "range": true,
+            "name": "year"
+        },
+        "engine_effect": {
+            "title": "Hestekrefter",
+            "range": true,
+            "name": "engine_effect"
+        },
+        "mileage": {
+            "title": "Kilometerstand",
+            "range": true,
+            "name": "mileage"
+        },
+        "number_of_seats": {
+            "title": "Antall seter",
+            "range": true,
+            "name": "number_of_seats"
+        },
+        "make": {
+            "title": "Merke",
+            "name": "make",
+            "queries": [
+                {
+                    "title": "Mercedes-Benz",
+                    "value": "0.785",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Geländewagen",
+                                "value": "1.785.2259",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 1
+                }
+            ]
+        },
+        "leaseprice_init": {
+            "title": "Innskudd",
+            "range": true,
+            "name": "leaseprice_init"
+        },
+        "registration_class": {
+            "title": "Avgiftsklasse",
+            "name": "registration_class",
+            "queries": [
+                {
+                    "title": "Varebil",
+                    "value": "2",
+                    "total-results": 1
+                }
+            ]
+        },
+        "engine_fuel": {
+            "title": "Drivstoff",
+            "name": "engine_fuel",
+            "queries": [
+                {
+                    "title": "Diesel",
+                    "value": "0/2",
+                    "total-results": 1
+                }
+            ]
+        },
+        "warranty_insurance": {
+            "title": "Garanti og forsikringer",
+            "name": "warranty_insurance",
+            "queries": [
+                {
+                    "title": "Garanti",
+                    "value": "1",
+                    "total-results": 1
+                }
+            ]
+        },
+        "wheel_sets": {
+            "title": "Hjulsett",
+            "name": "wheel_sets",
+            "queries": [
+                {
+                    "title": "Ett hjulsett",
+                    "value": "1",
+                    "total-results": 1
+                }
+            ]
+        },
+        "sales_form": {
+            "title": "Salgsform",
+            "name": "sales_form",
+            "queries": [
+                {
+                    "title": "Bruktbil til salgs",
+                    "value": "1",
+                    "total-results": 1
+                }
+            ]
+        },
+        "exterior_colour": {
+            "title": "Farge",
+            "name": "exterior_colour",
+            "queries": [
+                {
+                    "title": "Svart",
+                    "value": "14",
+                    "total-results": 1
+                }
+            ]
+        },
+        "published": {
+            "title": "Publisert",
+            "name": "published",
+            "queries": [
+                {
+                    "title": "Nye i dag",
+                    "value": "1",
+                    "total-results": 0
+                }
+            ]
+        },
+        "leaseprice_month": {
+            "title": "Månedspris",
+            "range": true,
+            "name": "leaseprice_month"
+        },
+        "car_equipment": {
+            "title": "Utstyr",
+            "name": "car_equipment",
+            "queries": [
+                {
+                    "title": "Hengerfeste",
+                    "value": "23",
+                    "total-results": 1
+                },
+                {
+                    "title": "Motorvarmer",
+                    "value": "35",
+                    "total-results": 1
+                },
+                {
+                    "title": "Navigasjonssystem",
+                    "value": "40",
+                    "total-results": 1
+                },
+                {
+                    "title": "Skinninteriør",
+                    "value": "12",
+                    "total-results": 1
+                }
+            ]
+        },
+        "transmission": {
+            "title": "Girkasse",
+            "name": "transmission",
+            "queries": [
+                {
+                    "title": "Automat",
+                    "value": "2",
+                    "total-results": 1
+                }
+            ]
+        },
+        "dealer_segment": {
+            "title": "Annonsør",
+            "name": "dealer_segment",
+            "queries": [
+                {
+                    "title": "Annet bilutsalg",
+                    "value": "2",
+                    "total-results": 1
+                }
+            ]
+        },
+        "wheel_drive": {
+            "title": "Hjuldrift",
+            "name": "wheel_drive",
+            "queries": [
+                {
+                    "title": "Firehjulsdrift",
+                    "value": "2",
+                    "total-results": 1
+                }
+            ]
+        },
+        "condition": {
+            "title": "Bilens tilstand",
+            "name": "condition",
+            "queries": [
+                {
+                    "title": "Service",
+                    "value": "1",
+                    "total-results": 1
+                }
+            ]
+        },
+        "motor_ad_location": {
+            "title": "Kjøretøyet står i",
+            "name": "motor_ad_location"
+        },
+        "location": {
+            "title": "Område",
+            "name": "location",
+            "queries": [
+                {
+                    "title": "Akershus",
+                    "value": "20003",
+                    "total-results": 1
+                }
+            ]
+        },
+        "price": {
+            "title": "Pris",
+            "range": true,
+            "name": "price",
+            "queries": [
+                {
+                    "title": "500001-",
+                    "value": "500001-null",
+                    "total-results": 1
+                }
+            ]
+        },
+        "body_type": {
+            "title": "Karosseri",
+            "name": "body_type",
+            "queries": [
+                {
+                    "title": "SUV/Offroad",
+                    "value": "9",
+                    "total-results": 1
+                }
+            ]
+        },
+        "price_changed": {
+            "title": "Redusert pris",
+            "name": "price_changed"
+        }
+    },
+    "map": {
+        "parameter": "bbox",
+        "areaParameters": [
+            "location"
+        ]
+    }
+}

--- a/Demo/Resources/b2b/van-norway.json
+++ b/Demo/Resources/b2b/van-norway.json
@@ -1,0 +1,1736 @@
+{
+    "market": "van-norway",
+    "hits": 7004,
+    "label": "Varebiler i Norge",
+    "type": "search",
+    "filters": [
+        "markets",
+        "q",
+        "published",
+        "make",
+        "year",
+        "mileage",
+        "price",
+        "body_type",
+        "location",
+        "engine_fuel",
+        "exterior_colour",
+        "engine_effect",
+        "number_of_seats",
+        "wheel_drive",
+        "dealer_segment",
+        "transmission",
+        "wheel_sets",
+        "warranty_insurance",
+        "condition",
+        "sales_form"
+    ],
+    "filter-data": {
+        "year": {
+            "title": "Årsmodell",
+            "range": true,
+            "name": "year"
+        },
+        "engine_effect": {
+            "title": "Hestekrefter",
+            "range": true,
+            "name": "engine_effect"
+        },
+        "mileage": {
+            "title": "Kilometerstand",
+            "range": true,
+            "name": "mileage"
+        },
+        "number_of_seats": {
+            "title": "Antall seter",
+            "range": true,
+            "name": "number_of_seats"
+        },
+        "make": {
+            "title": "Merke",
+            "name": "make",
+            "queries": [
+                {
+                    "title": "Alfa Romeo",
+                    "value": "0.3233",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Giulietta",
+                                "value": "1.3233.3785",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 1
+                },
+                {
+                    "title": "Audi",
+                    "value": "0.744",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "RS4",
+                                "value": "1.744.6721",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 1
+                },
+                {
+                    "title": "BMW",
+                    "value": "0.749",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "3-serie",
+                                "value": "1.749.2132",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 1
+                },
+                {
+                    "title": "Cadillac",
+                    "value": "0.752",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Escalade",
+                                "value": "1.752.7670",
+                                "total-results": 2
+                            }
+                        ]
+                    },
+                    "total-results": 2
+                },
+                {
+                    "title": "Chevrolet",
+                    "value": "0.753",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Avalanche",
+                                "value": "1.753.7539",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "Cargovan",
+                                "value": "1.753.2000053",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Colorado",
+                                "value": "1.753.3828",
+                                "total-results": 6
+                            },
+                            {
+                                "title": "C-10",
+                                "value": "1.753.2000263",
+                                "total-results": 5
+                            },
+                            {
+                                "title": "El Camino",
+                                "value": "1.753.3862",
+                                "total-results": 3
+                            },
+                            {
+                                "title": "Express",
+                                "value": "1.753.2000287",
+                                "total-results": 3
+                            },
+                            {
+                                "title": "Extended Cab",
+                                "value": "1.753.7329",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Silverado",
+                                "value": "1.753.7540",
+                                "total-results": 46
+                            },
+                            {
+                                "title": "Suburban",
+                                "value": "1.753.917",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Tahoe",
+                                "value": "1.753.4338",
+                                "total-results": 11
+                            },
+                            {
+                                "title": "Van",
+                                "value": "1.753.7330",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 81
+                },
+                {
+                    "title": "Chrysler",
+                    "value": "0.754",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Grand Voyager",
+                                "value": "1.754.918",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Voyager",
+                                "value": "1.754.928",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 2
+                },
+                {
+                    "title": "Citroen",
+                    "value": "0.757",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Berlingo",
+                                "value": "1.757.3255",
+                                "total-results": 230
+                            },
+                            {
+                                "title": "Berlingo Electrique",
+                                "value": "1.757.7768",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "C4 Picasso",
+                                "value": "1.757.1492",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "C8",
+                                "value": "1.757.7660",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "C-Crosser",
+                                "value": "1.757.8339",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Grand C4 Picasso",
+                                "value": "1.757.2000080",
+                                "total-results": 4
+                            },
+                            {
+                                "title": "Jumper",
+                                "value": "1.757.950",
+                                "total-results": 28
+                            },
+                            {
+                                "title": "Jumpy",
+                                "value": "1.757.7517",
+                                "total-results": 91
+                            },
+                            {
+                                "title": "SpaceTourer",
+                                "value": "1.757.2000434",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 359
+                },
+                {
+                    "title": "Dacia",
+                    "value": "0.8079",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Andre",
+                                "value": "1.8079.2000245",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 1
+                },
+                {
+                    "title": "Dodge",
+                    "value": "0.764",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Durango",
+                                "value": "1.764.3796",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "Journey",
+                                "value": "1.764.2000089",
+                                "total-results": 3
+                            },
+                            {
+                                "title": "RAM",
+                                "value": "1.764.3797",
+                                "total-results": 55
+                            },
+                            {
+                                "title": "RAM SRT-10",
+                                "value": "1.764.8283",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 61
+                },
+                {
+                    "title": "Fiat",
+                    "value": "0.766",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Doblo",
+                                "value": "1.766.200036",
+                                "total-results": 119
+                            },
+                            {
+                                "title": "Ducato",
+                                "value": "1.766.1031",
+                                "total-results": 35
+                            },
+                            {
+                                "title": "Freemont",
+                                "value": "1.766.2000201",
+                                "total-results": 9
+                            },
+                            {
+                                "title": "Fullback",
+                                "value": "1.766.2000374",
+                                "total-results": 11
+                            },
+                            {
+                                "title": "Scudo",
+                                "value": "1.766.8323",
+                                "total-results": 34
+                            },
+                            {
+                                "title": "Strada",
+                                "value": "1.766.2000063",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "Talento",
+                                "value": "1.766.2000403",
+                                "total-results": 25
+                            }
+                        ]
+                    },
+                    "total-results": 235
+                },
+                {
+                    "title": "Ford",
+                    "value": "0.767",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Courier",
+                                "value": "1.767.1050",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "Expedition",
+                                "value": "1.767.7512",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "F-serie",
+                                "value": "1.767.7160",
+                                "total-results": 58
+                            },
+                            {
+                                "title": "Galaxy",
+                                "value": "1.767.1053",
+                                "total-results": 19
+                            },
+                            {
+                                "title": "Ranger",
+                                "value": "1.767.2854",
+                                "total-results": 147
+                            },
+                            {
+                                "title": "SVT Lightning",
+                                "value": "1.767.8268",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "S-MAX",
+                                "value": "1.767.1065",
+                                "total-results": 4
+                            },
+                            {
+                                "title": "Tourneo Connect",
+                                "value": "1.767.2000290",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "Transit",
+                                "value": "1.767.1063",
+                                "total-results": 117
+                            },
+                            {
+                                "title": "Transit Connect",
+                                "value": "1.767.8191",
+                                "total-results": 294
+                            },
+                            {
+                                "title": "Transit Courier",
+                                "value": "1.767.2000310",
+                                "total-results": 74
+                            },
+                            {
+                                "title": "Transit Custom",
+                                "value": "1.767.2000266",
+                                "total-results": 159
+                            }
+                        ]
+                    },
+                    "total-results": 882
+                },
+                {
+                    "title": "GMC",
+                    "value": "0.7547",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Andre",
+                                "value": "1.7547.7556",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Sierra",
+                                "value": "1.7547.2000251",
+                                "total-results": 3
+                            },
+                            {
+                                "title": "Syclone",
+                                "value": "1.7547.2000286",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 6
+                },
+                {
+                    "title": "Honda",
+                    "value": "0.771",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Ridgeline",
+                                "value": "1.771.8097",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 1
+                },
+                {
+                    "title": "Hyundai",
+                    "value": "0.772",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Galloper",
+                                "value": "1.772.7184",
+                                "total-results": 3
+                            },
+                            {
+                                "title": "Grand Santa Fe",
+                                "value": "1.772.2000349",
+                                "total-results": 17
+                            },
+                            {
+                                "title": "H-1",
+                                "value": "1.772.2899",
+                                "total-results": 37
+                            },
+                            {
+                                "title": "ix55",
+                                "value": "1.772.2000132",
+                                "total-results": 3
+                            },
+                            {
+                                "title": "Santa Fe",
+                                "value": "1.772.6739",
+                                "total-results": 10
+                            },
+                            {
+                                "title": "Terracan",
+                                "value": "1.772.7246",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 71
+                },
+                {
+                    "title": "Isuzu",
+                    "value": "0.7179",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Andre",
+                                "value": "1.7179.7181",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "D-max",
+                                "value": "1.7179.2000077",
+                                "total-results": 268
+                            }
+                        ]
+                    },
+                    "total-results": 270
+                },
+                {
+                    "title": "Iveco",
+                    "value": "0.7280",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Daily",
+                                "value": "1.7280.7294",
+                                "total-results": 42
+                            },
+                            {
+                                "title": "3510",
+                                "value": "1.7280.7580",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 43
+                },
+                {
+                    "title": "Jeep",
+                    "value": "0.776",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Cherokee",
+                                "value": "1.776.1113",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Comanche",
+                                "value": "1.776.1114",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Commander",
+                                "value": "1.776.1496",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "Wrangler",
+                                "value": "1.776.1116",
+                                "total-results": 27
+                            }
+                        ]
+                    },
+                    "total-results": 31
+                },
+                {
+                    "title": "Kia",
+                    "value": "0.777",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Carnival",
+                                "value": "1.777.6741",
+                                "total-results": 6
+                            },
+                            {
+                                "title": "Sorento",
+                                "value": "1.777.7711",
+                                "total-results": 9
+                            }
+                        ]
+                    },
+                    "total-results": 15
+                },
+                {
+                    "title": "Land Rover",
+                    "value": "0.781",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Defender",
+                                "value": "1.781.6742",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "Discovery",
+                                "value": "1.781.1135",
+                                "total-results": 94
+                            }
+                        ]
+                    },
+                    "total-results": 97
+                },
+                {
+                    "title": "Lincoln",
+                    "value": "0.7153",
+                    "total-results": 1
+                },
+                {
+                    "title": "Mazda",
+                    "value": "0.784",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "BT-50",
+                                "value": "1.784.2000068",
+                                "total-results": 4
+                            }
+                        ]
+                    },
+                    "total-results": 4
+                },
+                {
+                    "title": "Mercedes-Benz",
+                    "value": "0.785",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Andre",
+                                "value": "1.785.2094",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Citan",
+                                "value": "1.785.2000230",
+                                "total-results": 66
+                            },
+                            {
+                                "title": "Geländewagen",
+                                "value": "1.785.2259",
+                                "total-results": 44
+                            },
+                            {
+                                "title": "GL",
+                                "value": "1.785.8289",
+                                "total-results": 36
+                            },
+                            {
+                                "title": "GLS",
+                                "value": "1.785.2000384",
+                                "total-results": 15
+                            },
+                            {
+                                "title": "R-Klasse",
+                                "value": "1.785.8121",
+                                "total-results": 6
+                            },
+                            {
+                                "title": "Sprinter",
+                                "value": "1.785.1187",
+                                "total-results": 243
+                            },
+                            {
+                                "title": "Vito",
+                                "value": "1.785.2897",
+                                "total-results": 252
+                            },
+                            {
+                                "title": "V-Klasse",
+                                "value": "1.785.3772",
+                                "total-results": 8
+                            },
+                            {
+                                "title": "X-Klasse",
+                                "value": "1.785.2000422",
+                                "total-results": 34
+                            }
+                        ]
+                    },
+                    "total-results": 706
+                },
+                {
+                    "title": "Mitsubishi",
+                    "value": "0.787",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Andre",
+                                "value": "1.787.2096",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Grandis",
+                                "value": "1.787.7994",
+                                "total-results": 7
+                            },
+                            {
+                                "title": "L200",
+                                "value": "1.787.1195",
+                                "total-results": 50
+                            },
+                            {
+                                "title": "L300",
+                                "value": "1.787.1196",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "L400",
+                                "value": "1.787.3046",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "Outlander",
+                                "value": "1.787.7713",
+                                "total-results": 29
+                            },
+                            {
+                                "title": "Pajero",
+                                "value": "1.787.1198",
+                                "total-results": 126
+                            }
+                        ]
+                    },
+                    "total-results": 217
+                },
+                {
+                    "title": "Nissan",
+                    "value": "0.792",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Andre",
+                                "value": "1.792.2101",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "e-NV200",
+                                "value": "1.792.2000311",
+                                "total-results": 20
+                            },
+                            {
+                                "title": "Interstar",
+                                "value": "1.792.7984",
+                                "total-results": 4
+                            },
+                            {
+                                "title": "King Cab",
+                                "value": "1.792.1220",
+                                "total-results": 22
+                            },
+                            {
+                                "title": "Kubistar",
+                                "value": "1.792.7983",
+                                "total-results": 6
+                            },
+                            {
+                                "title": "Navara",
+                                "value": "1.792.8234",
+                                "total-results": 111
+                            },
+                            {
+                                "title": "NP300",
+                                "value": "1.792.2000260",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "NV200",
+                                "value": "1.792.2000162",
+                                "total-results": 53
+                            },
+                            {
+                                "title": "NV300",
+                                "value": "1.792.2000405",
+                                "total-results": 26
+                            },
+                            {
+                                "title": "NV400",
+                                "value": "1.792.2000234",
+                                "total-results": 11
+                            },
+                            {
+                                "title": "Pathfinder",
+                                "value": "1.792.7985",
+                                "total-results": 25
+                            },
+                            {
+                                "title": "Patrol",
+                                "value": "1.792.1224",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "Primastar",
+                                "value": "1.792.7685",
+                                "total-results": 19
+                            }
+                        ]
+                    },
+                    "total-results": 304
+                },
+                {
+                    "title": "Opel",
+                    "value": "0.795",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Combo",
+                                "value": "1.795.1252",
+                                "total-results": 83
+                            },
+                            {
+                                "title": "Movano",
+                                "value": "1.795.7186",
+                                "total-results": 17
+                            },
+                            {
+                                "title": "Vivaro",
+                                "value": "1.795.7623",
+                                "total-results": 90
+                            },
+                            {
+                                "title": "Zafira",
+                                "value": "1.795.3753",
+                                "total-results": 2
+                            }
+                        ]
+                    },
+                    "total-results": 193
+                },
+                {
+                    "title": "Peugeot",
+                    "value": "0.796",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Bipper",
+                                "value": "1.796.2000329",
+                                "total-results": 5
+                            },
+                            {
+                                "title": "Boxer",
+                                "value": "1.796.1285",
+                                "total-results": 46
+                            },
+                            {
+                                "title": "Expert",
+                                "value": "1.796.7621",
+                                "total-results": 122
+                            },
+                            {
+                                "title": "Partner",
+                                "value": "1.796.3754",
+                                "total-results": 376
+                            },
+                            {
+                                "title": "Partner Electric",
+                                "value": "1.796.7767",
+                                "total-results": 11
+                            },
+                            {
+                                "title": "807",
+                                "value": "1.796.7634",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "1007",
+                                "value": "1.796.8120",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "4007",
+                                "value": "1.796.2000074",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "5008",
+                                "value": "1.796.2000139",
+                                "total-results": 13
+                            }
+                        ]
+                    },
+                    "total-results": 579
+                },
+                {
+                    "title": "Renault",
+                    "value": "0.804",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Andre",
+                                "value": "1.804.2113",
+                                "total-results": 3
+                            },
+                            {
+                                "title": "Espace",
+                                "value": "1.804.1324",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Kangoo",
+                                "value": "1.804.3820",
+                                "total-results": 52
+                            },
+                            {
+                                "title": "Kangoo Electric",
+                                "value": "1.804.7769",
+                                "total-results": 8
+                            },
+                            {
+                                "title": "Kangoo Express",
+                                "value": "1.804.7241",
+                                "total-results": 5
+                            },
+                            {
+                                "title": "Master",
+                                "value": "1.804.7455",
+                                "total-results": 33
+                            },
+                            {
+                                "title": "Trafic",
+                                "value": "1.804.1332",
+                                "total-results": 46
+                            }
+                        ]
+                    },
+                    "total-results": 148
+                },
+                {
+                    "title": "Seat",
+                    "value": "0.807",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Alhambra",
+                                "value": "1.807.3825",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 1
+                },
+                {
+                    "title": "Skoda",
+                    "value": "0.808",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Pickup",
+                                "value": "1.808.2000337",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 1
+                },
+                {
+                    "title": "Ssangyong",
+                    "value": "0.7190",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Actyon Sport",
+                                "value": "1.7190.8302",
+                                "total-results": 6
+                            },
+                            {
+                                "title": "Musso",
+                                "value": "1.7190.7192",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Rexton",
+                                "value": "1.7190.7511",
+                                "total-results": 69
+                            },
+                            {
+                                "title": "Rexton W",
+                                "value": "1.7190.2000316",
+                                "total-results": 18
+                            },
+                            {
+                                "title": "Rodius",
+                                "value": "1.7190.8173",
+                                "total-results": 13
+                            }
+                        ]
+                    },
+                    "total-results": 110
+                },
+                {
+                    "title": "Suzuki",
+                    "value": "0.811",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "SJ",
+                                "value": "1.811.1376",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "XL7",
+                                "value": "1.811.8081",
+                                "total-results": 6
+                            }
+                        ]
+                    },
+                    "total-results": 8
+                },
+                {
+                    "title": "Toyota",
+                    "value": "0.813",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Corolla",
+                                "value": "1.813.1389",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Crown",
+                                "value": "1.813.1392",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Dyna",
+                                "value": "1.813.1393",
+                                "total-results": 9
+                            },
+                            {
+                                "title": "HiAce",
+                                "value": "1.813.1394",
+                                "total-results": 190
+                            },
+                            {
+                                "title": "HiLux",
+                                "value": "1.813.1396",
+                                "total-results": 232
+                            },
+                            {
+                                "title": "Land Cruiser",
+                                "value": "1.813.1397",
+                                "total-results": 173
+                            },
+                            {
+                                "title": "Land Cruiser V8",
+                                "value": "1.813.2000240",
+                                "total-results": 8
+                            },
+                            {
+                                "title": "Proace",
+                                "value": "1.813.2000267",
+                                "total-results": 118
+                            },
+                            {
+                                "title": "RAV4",
+                                "value": "1.813.3074",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Tundra",
+                                "value": "1.813.8256",
+                                "total-results": 9
+                            },
+                            {
+                                "title": "Verso",
+                                "value": "1.813.2000134",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Yaris Verso",
+                                "value": "1.813.8109",
+                                "total-results": 18
+                            }
+                        ]
+                    },
+                    "total-results": 765
+                },
+                {
+                    "title": "Volkswagen",
+                    "value": "0.817",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Amarok",
+                                "value": "1.817.2000170",
+                                "total-results": 147
+                            },
+                            {
+                                "title": "Caddy",
+                                "value": "1.817.6709",
+                                "total-results": 481
+                            },
+                            {
+                                "title": "Caddy Alltrack",
+                                "value": "1.817.2000430",
+                                "total-results": 5
+                            },
+                            {
+                                "title": "Caddy Maxi",
+                                "value": "1.817.2000231",
+                                "total-results": 224
+                            },
+                            {
+                                "title": "Caravelle",
+                                "value": "1.817.1430",
+                                "total-results": 12
+                            },
+                            {
+                                "title": "Crafter",
+                                "value": "1.817.2000048",
+                                "total-results": 73
+                            },
+                            {
+                                "title": "LT",
+                                "value": "1.817.7650",
+                                "total-results": 6
+                            },
+                            {
+                                "title": "Multivan",
+                                "value": "1.817.7952",
+                                "total-results": 12
+                            },
+                            {
+                                "title": "Sharan",
+                                "value": "1.817.1442",
+                                "total-results": 3
+                            },
+                            {
+                                "title": "Taro",
+                                "value": "1.817.2000269",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "Touran",
+                                "value": "1.817.7593",
+                                "total-results": 135
+                            },
+                            {
+                                "title": "Transporter",
+                                "value": "1.817.1444",
+                                "total-results": 687
+                            }
+                        ]
+                    },
+                    "total-results": 1789
+                },
+                {
+                    "title": "Volvo",
+                    "value": "0.818",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "XC 90",
+                                "value": "1.818.7651",
+                                "total-results": 16
+                            },
+                            {
+                                "title": "240",
+                                "value": "1.818.1456",
+                                "total-results": 2
+                            }
+                        ]
+                    },
+                    "total-results": 18
+                }
+            ]
+        },
+        "leaseprice_init": {
+            "title": "Innskudd",
+            "range": true,
+            "name": "leaseprice_init"
+        },
+        "registration_class": {
+            "title": "Avgiftsklasse",
+            "name": "registration_class",
+            "queries": [
+                {
+                    "title": "Varebil",
+                    "value": "2",
+                    "total-results": 7004
+                }
+            ]
+        },
+        "engine_fuel": {
+            "title": "Drivstoff",
+            "name": "engine_fuel",
+            "queries": [
+                {
+                    "title": "Bensin",
+                    "value": "0/1",
+                    "total-results": 364
+                },
+                {
+                    "title": "Diesel",
+                    "value": "0/2",
+                    "total-results": 6545
+                },
+                {
+                    "title": "Elektrisitet",
+                    "value": "0/4",
+                    "total-results": 78
+                },
+                {
+                    "title": "Gass",
+                    "value": "0/3",
+                    "total-results": 7
+                },
+                {
+                    "title": "Gass+bensin",
+                    "value": "0/5",
+                    "total-results": 9
+                }
+            ]
+        },
+        "warranty_insurance": {
+            "title": "Garanti og forsikringer",
+            "name": "warranty_insurance",
+            "queries": [
+                {
+                    "title": "Bytterett",
+                    "value": "42",
+                    "total-results": 613
+                },
+                {
+                    "title": "Garanti",
+                    "value": "1",
+                    "total-results": 3677
+                },
+                {
+                    "title": "Programbil",
+                    "value": "41",
+                    "total-results": 33
+                }
+            ]
+        },
+        "wheel_sets": {
+            "title": "Hjulsett",
+            "name": "wheel_sets",
+            "queries": [
+                {
+                    "title": "Ett hjulsett",
+                    "value": "1",
+                    "total-results": 598
+                },
+                {
+                    "title": "To hjulsett",
+                    "value": "2",
+                    "total-results": 4913
+                }
+            ]
+        },
+        "sales_form": {
+            "title": "Salgsform",
+            "name": "sales_form",
+            "queries": [
+                {
+                    "title": "Auksjon",
+                    "value": "7",
+                    "total-results": 110
+                },
+                {
+                    "title": "Bruktbil til salgs",
+                    "value": "1",
+                    "total-results": 6605
+                },
+                {
+                    "title": "Leasing",
+                    "value": "5",
+                    "total-results": 258
+                },
+                {
+                    "title": "Nybil til salgs",
+                    "value": "2",
+                    "total-results": 31
+                }
+            ]
+        },
+        "exterior_colour": {
+            "title": "Farge",
+            "name": "exterior_colour",
+            "queries": [
+                {
+                    "title": "Beige",
+                    "value": "1",
+                    "total-results": 34
+                },
+                {
+                    "title": "Blå",
+                    "value": "2",
+                    "total-results": 353
+                },
+                {
+                    "title": "Bronse",
+                    "value": "3",
+                    "total-results": 8
+                },
+                {
+                    "title": "Brun",
+                    "value": "4",
+                    "total-results": 89
+                },
+                {
+                    "title": "Grønn",
+                    "value": "5",
+                    "total-results": 50
+                },
+                {
+                    "title": "Grå",
+                    "value": "6",
+                    "total-results": 901
+                },
+                {
+                    "title": "Gul",
+                    "value": "7",
+                    "total-results": 24
+                },
+                {
+                    "title": "Gull",
+                    "value": "8",
+                    "total-results": 5
+                },
+                {
+                    "title": "Hvit",
+                    "value": "9",
+                    "total-results": 2516
+                },
+                {
+                    "title": "Lilla",
+                    "value": "10",
+                    "total-results": 3
+                },
+                {
+                    "title": "Oransje",
+                    "value": "11",
+                    "total-results": 56
+                },
+                {
+                    "title": "Rosa",
+                    "value": "12",
+                    "total-results": 1
+                },
+                {
+                    "title": "Rød",
+                    "value": "13",
+                    "total-results": 409
+                },
+                {
+                    "title": "Svart",
+                    "value": "14",
+                    "total-results": 1303
+                },
+                {
+                    "title": "Sølv",
+                    "value": "15",
+                    "total-results": 1232
+                }
+            ]
+        },
+        "published": {
+            "title": "Publisert",
+            "name": "published",
+            "queries": [
+                {
+                    "title": "Nye i dag",
+                    "value": "1",
+                    "total-results": 143
+                }
+            ]
+        },
+        "leaseprice_month": {
+            "title": "Månedspris",
+            "range": true,
+            "name": "leaseprice_month"
+        },
+        "car_equipment": {
+            "title": "Utstyr",
+            "name": "car_equipment",
+            "queries": [
+                {
+                    "title": "Hengerfeste",
+                    "value": "23",
+                    "total-results": 4363
+                },
+                {
+                    "title": "Motorvarmer",
+                    "value": "35",
+                    "total-results": 1805
+                },
+                {
+                    "title": "Navigasjonssystem",
+                    "value": "40",
+                    "total-results": 1905
+                },
+                {
+                    "title": "Radio DAB+",
+                    "value": "77",
+                    "total-results": 2779
+                },
+                {
+                    "title": "Skinninteriør",
+                    "value": "12",
+                    "total-results": 1646
+                }
+            ]
+        },
+        "transmission": {
+            "title": "Girkasse",
+            "name": "transmission",
+            "queries": [
+                {
+                    "title": "Automat",
+                    "value": "2",
+                    "total-results": 2847
+                },
+                {
+                    "title": "Manuell",
+                    "value": "1",
+                    "total-results": 4149
+                }
+            ]
+        },
+        "dealer_segment": {
+            "title": "Annonsør",
+            "name": "dealer_segment",
+            "queries": [
+                {
+                    "title": "Annet bilutsalg",
+                    "value": "2",
+                    "total-results": 2781
+                },
+                {
+                    "title": "Merkeforhandler",
+                    "value": "1",
+                    "total-results": 2566
+                },
+                {
+                    "title": "Privat",
+                    "value": "3",
+                    "total-results": 1657
+                }
+            ]
+        },
+        "wheel_drive": {
+            "title": "Hjuldrift",
+            "name": "wheel_drive",
+            "queries": [
+                {
+                    "title": "Bakhjulsdrift",
+                    "value": "1",
+                    "total-results": 552
+                },
+                {
+                    "title": "Firehjulsdrift",
+                    "value": "2",
+                    "total-results": 3174
+                },
+                {
+                    "title": "Forhjulsdrift",
+                    "value": "3",
+                    "total-results": 3243
+                }
+            ]
+        },
+        "condition": {
+            "title": "Bilens tilstand",
+            "name": "condition",
+            "queries": [
+                {
+                    "title": "Service",
+                    "value": "1",
+                    "total-results": 2775
+                },
+                {
+                    "title": "Testrapport",
+                    "value": "3",
+                    "total-results": 8
+                },
+                {
+                    "title": "Tilstandsrapport",
+                    "value": "2",
+                    "total-results": 246
+                }
+            ]
+        },
+        "motor_ad_location": {
+            "title": "Kjøretøyet står i",
+            "name": "motor_ad_location"
+        },
+        "location": {
+            "title": "Område",
+            "name": "location",
+            "queries": [
+                {
+                    "title": "Akershus",
+                    "value": "20003",
+                    "total-results": 931
+                },
+                {
+                    "title": "Aust-Agder",
+                    "value": "20010",
+                    "total-results": 181
+                },
+                {
+                    "title": "Buskerud",
+                    "value": "20007",
+                    "total-results": 822
+                },
+                {
+                    "title": "Finnmark",
+                    "value": "20020",
+                    "total-results": 91
+                },
+                {
+                    "title": "Hedmark",
+                    "value": "20005",
+                    "total-results": 325
+                },
+                {
+                    "title": "Hordaland",
+                    "value": "20013",
+                    "total-results": 427
+                },
+                {
+                    "title": "Møre og Romsdal",
+                    "value": "20015",
+                    "total-results": 316
+                },
+                {
+                    "title": "Nordland",
+                    "value": "20018",
+                    "total-results": 182
+                },
+                {
+                    "title": "Oppland",
+                    "value": "20006",
+                    "total-results": 275
+                },
+                {
+                    "title": "Oslo",
+                    "value": "20061",
+                    "total-results": 409
+                },
+                {
+                    "title": "Rogaland",
+                    "value": "20012",
+                    "total-results": 596
+                },
+                {
+                    "title": "Sogn og Fjordane",
+                    "value": "20014",
+                    "total-results": 94
+                },
+                {
+                    "title": "Telemark",
+                    "value": "20009",
+                    "total-results": 378
+                },
+                {
+                    "title": "Troms",
+                    "value": "20019",
+                    "total-results": 170
+                },
+                {
+                    "title": "Trøndelag",
+                    "value": "20016",
+                    "total-results": 612
+                },
+                {
+                    "title": "Vestfold",
+                    "value": "20008",
+                    "total-results": 333
+                },
+                {
+                    "title": "Vest-Agder",
+                    "value": "20011",
+                    "total-results": 252
+                },
+                {
+                    "title": "Østfold",
+                    "value": "20002",
+                    "total-results": 608
+                }
+            ]
+        },
+        "price": {
+            "title": "Pris",
+            "range": true,
+            "name": "price",
+            "queries": [
+                {
+                    "title": "0-50000",
+                    "value": "0-50000",
+                    "total-results": 928
+                },
+                {
+                    "title": "50001-100000",
+                    "value": "50001-100000",
+                    "total-results": 1169
+                },
+                {
+                    "title": "100001-150000",
+                    "value": "100001-150000",
+                    "total-results": 1077
+                },
+                {
+                    "title": "150001-250000",
+                    "value": "150001-250000",
+                    "total-results": 1547
+                },
+                {
+                    "title": "250001-500000",
+                    "value": "250001-500000",
+                    "total-results": 1778
+                },
+                {
+                    "title": "500001-",
+                    "value": "500001-null",
+                    "total-results": 504
+                }
+            ]
+        },
+        "body_type": {
+            "title": "Karosseri",
+            "name": "body_type",
+            "queries": [
+                {
+                    "title": "Annet",
+                    "value": "11",
+                    "total-results": 85
+                },
+                {
+                    "title": "Coupe",
+                    "value": "6",
+                    "total-results": 1
+                },
+                {
+                    "title": "Flerbruksbil",
+                    "value": "5",
+                    "total-results": 145
+                },
+                {
+                    "title": "Kasse",
+                    "value": "10",
+                    "total-results": 4484
+                },
+                {
+                    "title": "Kombi 3-dørs",
+                    "value": "1",
+                    "total-results": 3
+                },
+                {
+                    "title": "Kombi 5-dørs",
+                    "value": "2",
+                    "total-results": 16
+                },
+                {
+                    "title": "Pickup",
+                    "value": "8",
+                    "total-results": 1350
+                },
+                {
+                    "title": "Stasjonsvogn",
+                    "value": "4",
+                    "total-results": 299
+                },
+                {
+                    "title": "SUV/Offroad",
+                    "value": "9",
+                    "total-results": 549
+                }
+            ]
+        },
+        "price_changed": {
+            "title": "Redusert pris",
+            "name": "price_changed",
+            "queries": [
+                {
+                    "title": "Ny pris siste 5 dager",
+                    "value": "1",
+                    "total-results": 4
+                }
+            ]
+        }
+    },
+    "map": {
+        "parameter": "bbox",
+        "areaParameters": [
+            "location"
+        ]
+    }
+}

--- a/Demo/Root/DemoFilterRootViewControllerHelper.swift
+++ b/Demo/Root/DemoFilterRootViewControllerHelper.swift
@@ -23,6 +23,7 @@ class DemoFilter {
             boatVerticalDemos(),
             mcVerticalDemos(),
             realestateVerticalDemos(),
+            b2bVerticalDemos(),
         ].flatMap { $0 }
 
         let verticalDemos: [String: [VerticalDemo]] = marketDemos.reduce(into: [:]) {
@@ -144,6 +145,22 @@ class DemoFilter {
             let isExternal = market == .travelFhh
             return isExternal
         })
+    }
+
+    private func b2bVerticalDemos() -> [MarketDemos] {
+        let markets: [(market: FilterMarketB2B, title: String)] = [
+            (market: .truck, title: "Lastebil og henger"),
+            (market: .truckAbroad, title: "Lastebil og henger i utlandet"),
+            (market: .bus, title: "Buss og minibuss"),
+            (market: .construction, title: "Bygg og anlegg"),
+            (market: .agricultureTractor, title: "Traktor"),
+            (market: .agricultureThresher, title: "Tresker"),
+            (market: .agricultureTools, title: "Landbruksredskap"),
+            (market: .vanNorway, title: "Varebiler i Norge"),
+            (market: .vanAbroad, title: "Varebiler i utlandet"),
+        ]
+
+        return createVerticalDemos(from: markets)
     }
 }
 

--- a/Sources/FINNFilterImplementation/FilterKey.swift
+++ b/Sources/FINNFilterImplementation/FilterKey.swift
@@ -9,9 +9,11 @@ public enum FilterKey: String, CodingKey {
     case area
     case boatClass = "class"
     case bodyType = "body_type"
+    case busSegment = "bus_segment"
     case carEquipment = "car_equipment"
     case category
     case condition
+    case constructionSegment = "construction_segment"
     case constructionYear = "construction_year"
     case dealerSegment = "dealer_segment"
     case energyLabel = "energy_label"
@@ -63,9 +65,11 @@ public enum FilterKey: String, CodingKey {
     case searchType = "search_type"
     case segment
     case transmission
+    case truckSegment = "truck_segment"
     case type
     case viewing
     case warrantyInsurance = "warranty_insurance"
+    case weight
     case width
     case wheelDrive = "wheel_drive"
     case wheelSets = "wheel_sets"

--- a/Sources/FINNFilterImplementation/FilterMarket.swift
+++ b/Sources/FINNFilterImplementation/FilterMarket.swift
@@ -11,6 +11,7 @@ enum FilterMarket {
     case mc(FilterMarketMC)
     case job(FilterMarketJob)
     case boat(FilterMarketBoat)
+    case b2b(FilterMarketB2B)
 
     init?(market: String) {
         guard let market = FilterMarket.allCases.first(where: { $0.handlesVerticalId(market) }) else {
@@ -34,6 +35,8 @@ enum FilterMarket {
             return job
         case let .boat(boat):
             return boat
+        case let .b2b(b2b):
+            return b2b
         }
     }
 }
@@ -65,12 +68,35 @@ extension FilterMarket: FilterConfiguration {
 // MARK: - CaseIterable
 
 extension FilterMarket: CaseIterable {
-    static var allCases: [FilterMarket] {
+    private static var allB2BMarkets: [FilterMarket] {
+        return FilterMarketB2B.allCases.map(FilterMarket.b2b)
+    }
+
+    private static var allBapMarkets: [FilterMarket] {
         return FilterMarketBap.allCases.map(FilterMarket.bap)
-            + FilterMarketRealestate.allCases.map(FilterMarket.realestate)
-            + FilterMarketCar.allCases.map(FilterMarket.car)
-            + FilterMarketMC.allCases.map(FilterMarket.mc)
-            + FilterMarketJob.allCases.map(FilterMarket.job)
-            + FilterMarketBoat.allCases.map(FilterMarket.boat)
+    }
+
+    private static var allBoatMarkets: [FilterMarket] {
+        return FilterMarketBoat.allCases.map(FilterMarket.boat)
+    }
+
+    private static var allCarMarkets: [FilterMarket] {
+        return FilterMarketCar.allCases.map(FilterMarket.car)
+    }
+
+    private static var allJobMarkets: [FilterMarket] {
+        return FilterMarketJob.allCases.map(FilterMarket.job)
+    }
+
+    private static var allMCMarkets: [FilterMarket] {
+        return FilterMarketMC.allCases.map(FilterMarket.mc)
+    }
+
+    private static var allRealestateMarkets: [FilterMarket] {
+        return FilterMarketRealestate.allCases.map(FilterMarket.realestate)
+    }
+
+    static var allCases: [FilterMarket] {
+        return allB2BMarkets + allBapMarkets + allBoatMarkets + allCarMarkets + allJobMarkets + allMCMarkets + allRealestateMarkets
     }
 }

--- a/Sources/FINNFilterImplementation/FilterMarkets/FilterMarketB2B.swift
+++ b/Sources/FINNFilterImplementation/FilterMarkets/FilterMarketB2B.swift
@@ -24,7 +24,7 @@ extension FilterMarketB2B: FilterConfiguration {
     }
 
     var preferenceFilterKeys: [FilterKey] {
-        return [.published]
+        return [.published, .dealerSegment]
     }
 
     var supportedFiltersKeys: [FilterKey] {
@@ -37,8 +37,7 @@ extension FilterMarketB2B: FilterConfiguration {
                 .price,
                 .year,
                 .engineEffect,
-                .weight,
-                .dealerSegment,
+                .weight
             ]
         case .bus:
             return [
@@ -47,8 +46,7 @@ extension FilterMarketB2B: FilterConfiguration {
                 .make,
                 .price,
                 .year,
-                .engineEffect,
-                .dealerSegment,
+                .engineEffect
             ]
         case .construction:
             return [
@@ -57,8 +55,7 @@ extension FilterMarketB2B: FilterConfiguration {
                 .make,
                 .price,
                 .year,
-                .engineEffect,
-                .dealerSegment,
+                .engineEffect
             ]
         case .agricultureTractor, .agricultureThresher:
             return [
@@ -66,16 +63,14 @@ extension FilterMarketB2B: FilterConfiguration {
                 .make,
                 .price,
                 .year,
-                .engineEffect,
-                .dealerSegment,
+                .engineEffect
             ]
         case .agricultureTools:
             return [
                 .location,
                 .category,
                 .price,
-                .year,
-                .dealerSegment,
+                .year
             ]
         case .vanNorway, .vanAbroad:
             return [
@@ -90,12 +85,11 @@ extension FilterMarketB2B: FilterConfiguration {
                 .engineEffect,
                 .numberOfSeats,
                 .wheelDrive,
-                .dealerSegment,
                 .transmission,
                 .wheelSets,
                 .warrantyInsurance,
                 .condition,
-                .salesForm,
+                .salesForm
             ]
         }
     }

--- a/Sources/FINNFilterImplementation/FilterMarkets/FilterMarketB2B.swift
+++ b/Sources/FINNFilterImplementation/FilterMarkets/FilterMarketB2B.swift
@@ -120,6 +120,93 @@ extension FilterMarketB2B: FilterConfiguration {
         }
 
         switch filterKey {
+        case .price:
+            switch self {
+            case .bus:
+                lowValue = 0
+                highValue = 500_000
+                increment = 10_000
+                rangeBoundsOffsets = (hasLowerBoundOffset: false, hasUpperBoundOffset: true)
+            case .agricultureTractor:
+                lowValue = 0
+                highValue = 1_000_000
+                increment = 10_000
+                rangeBoundsOffsets = (hasLowerBoundOffset: false, hasUpperBoundOffset: true)
+            case .vanNorway, .vanAbroad:
+                lowValue = 10_000
+                highValue = 700_000
+                increment = 10_000
+                rangeBoundsOffsets = (hasLowerBoundOffset: true, hasUpperBoundOffset: true)
+            default:
+                lowValue = 30_000
+                highValue = 1_000_000
+                increment = 10_000
+                rangeBoundsOffsets = (hasLowerBoundOffset: true, hasUpperBoundOffset: true)
+            }
+            unit = "kr"
+            accessibilityValues = (stepIncrement: nil, valueSuffix: nil)
+            appearanceProperties = (usesSmallNumberInputFont: false, displaysUnitInNumberInput: true, isCurrencyValueRange: true)
+        case .year:
+            switch self {
+            case .bus, .vanNorway, .vanAbroad:
+                lowValue = 1990
+            default:
+                lowValue = 1985
+            }
+
+            highValue = Calendar.current.component(.year, from: Date())
+            unit = "år"
+            rangeBoundsOffsets = (hasLowerBoundOffset: true, hasUpperBoundOffset: true)
+            increment = 1
+            accessibilityValues = (stepIncrement: nil, valueSuffix: nil)
+            appearanceProperties = (usesSmallNumberInputFont: false, displaysUnitInNumberInput: false, isCurrencyValueRange: false)
+        case .engineEffect:
+            switch self {
+            case .bus:
+                lowValue = 100
+                highValue = 500
+                rangeBoundsOffsets = (hasLowerBoundOffset: true, hasUpperBoundOffset: true)
+            case .agricultureTractor, .agricultureThresher:
+                lowValue = 0
+                highValue = 500
+                rangeBoundsOffsets = (hasLowerBoundOffset: false, hasUpperBoundOffset: true)
+            case .vanNorway, .vanAbroad:
+                lowValue = 50
+                highValue = 500
+                rangeBoundsOffsets = (hasLowerBoundOffset: true, hasUpperBoundOffset: true)
+            default:
+                lowValue = 100
+                highValue = 600
+                rangeBoundsOffsets = (hasLowerBoundOffset: true, hasUpperBoundOffset: true)
+            }
+            unit = "hk"
+            increment = 10
+            accessibilityValues = (stepIncrement: nil, valueSuffix: nil)
+            appearanceProperties = (usesSmallNumberInputFont: false, displaysUnitInNumberInput: true, isCurrencyValueRange: false)
+        case .weight:
+            lowValue = 1_000
+            highValue = 40_000
+            unit = "kg"
+            rangeBoundsOffsets = (hasLowerBoundOffset: true, hasUpperBoundOffset: true)
+            increment = 50
+            accessibilityValues = (stepIncrement: nil, valueSuffix: nil)
+            appearanceProperties = (usesSmallNumberInputFont: false, displaysUnitInNumberInput: true, isCurrencyValueRange: false)
+        case .mileage:
+            lowValue = 0
+            highValue = 200_000
+            unit = "km"
+            rangeBoundsOffsets = (hasLowerBoundOffset: false, hasUpperBoundOffset: true)
+            increment = 1000
+            accessibilityValues = (stepIncrement: nil, valueSuffix: nil)
+            appearanceProperties = (usesSmallNumberInputFont: false, displaysUnitInNumberInput: true, isCurrencyValueRange: false)
+        case .numberOfSeats:
+            lowValue = 0
+            highValue = 10
+            unit = "seter"
+            rangeBoundsOffsets = (hasLowerBoundOffset: false, hasUpperBoundOffset: true)
+            increment = 1
+            accessibilityValues = (stepIncrement: nil, valueSuffix: nil)
+            appearanceProperties = (usesSmallNumberInputFont: false, displaysUnitInNumberInput: true, isCurrencyValueRange: false)
         default:
             return nil
         }

--- a/Sources/FINNFilterImplementation/FilterMarkets/FilterMarketB2B.swift
+++ b/Sources/FINNFilterImplementation/FilterMarkets/FilterMarketB2B.swift
@@ -1,0 +1,89 @@
+//
+//  Copyright © FINN.no AS, Inc. All rights reserved.
+//
+
+import Foundation
+
+enum FilterMarketB2B: String, CaseIterable {
+    case truck
+    case truckAbroad = "truck-abroad"
+    case bus
+    case construction
+    case agricultureTractor = "agriculture-tractor"
+    case agricultureThresher = "agriculture-thresher"
+    case agricultureTools = "agriculture-tools"
+    case vanNorway = "van-norway"
+    case vanAbroad = "van-abroad"
+}
+
+// MARK: - FilterConfiguration
+
+extension FilterMarketB2B: FilterConfiguration {
+    func handlesVerticalId(_ vertical: String) -> Bool {
+        return rawValue == vertical
+    }
+
+    var preferenceFilterKeys: [FilterKey] {
+        return [.published]
+    }
+
+    var supportedFiltersKeys: [FilterKey] {
+        switch self {
+        case .truck, .truckAbroad:
+            return [
+            ]
+        case .bus:
+            return [
+            ]
+        case .construction:
+            return [
+            ]
+        case .agricultureTractor, .agricultureThresher:
+            return [
+            ]
+        case .agricultureTools:
+            return [
+            ]
+        case .vanNorway, .vanAbroad:
+            return [
+            ]
+        }
+    }
+
+    var mapFilterKey: FilterKey? {
+        return .location
+    }
+
+    func createFilterInfoFrom(rangeFilterData: FilterData) -> FilterInfoType? {
+        let parameterName = rangeFilterData.parameterName
+        let name = rangeFilterData.title
+        let lowValue: Int
+        let highValue: Int
+        let increment: Int
+        let unit: String
+        let rangeBoundsOffsets: RangeFilterInfo.RangeBoundsOffsets
+        let accessibilityValues: RangeFilterInfo.AccessibilityValues
+        let appearanceProperties: RangeFilterInfo.AppearenceProperties
+
+        guard let filterKey = FilterKey(stringValue: rangeFilterData.parameterName) else {
+            return nil
+        }
+
+        switch filterKey {
+        default:
+            return nil
+        }
+
+        return RangeFilterInfo(
+            parameterName: parameterName,
+            title: name,
+            lowValue: lowValue,
+            highValue: highValue,
+            increment: increment,
+            rangeBoundsOffsets: rangeBoundsOffsets,
+            unit: unit,
+            accesibilityValues: accessibilityValues,
+            appearanceProperties: appearanceProperties
+        )
+    }
+}

--- a/Sources/FINNFilterImplementation/FilterMarkets/FilterMarketB2B.swift
+++ b/Sources/FINNFilterImplementation/FilterMarkets/FilterMarketB2B.swift
@@ -31,21 +31,71 @@ extension FilterMarketB2B: FilterConfiguration {
         switch self {
         case .truck, .truckAbroad:
             return [
+                .location,
+                .truckSegment,
+                .make,
+                .price,
+                .year,
+                .engineEffect,
+                .weight,
+                .dealerSegment,
             ]
         case .bus:
             return [
+                .location,
+                .busSegment,
+                .make,
+                .price,
+                .year,
+                .engineEffect,
+                .dealerSegment,
             ]
         case .construction:
             return [
+                .location,
+                .constructionSegment,
+                .make,
+                .price,
+                .year,
+                .engineEffect,
+                .dealerSegment,
             ]
         case .agricultureTractor, .agricultureThresher:
             return [
+                .location,
+                .make,
+                .price,
+                .year,
+                .engineEffect,
+                .dealerSegment,
             ]
         case .agricultureTools:
             return [
+                .location,
+                .category,
+                .price,
+                .year,
+                .dealerSegment,
             ]
         case .vanNorway, .vanAbroad:
             return [
+                .make,
+                .year,
+                .mileage,
+                .price,
+                .bodyType,
+                .location,
+                .engineFuel,
+                .exteriorColour,
+                .engineEffect,
+                .numberOfSeats,
+                .wheelDrive,
+                .dealerSegment,
+                .transmission,
+                .wheelSets,
+                .warrantyInsurance,
+                .condition,
+                .salesForm,
             ]
         }
     }

--- a/UnitTests/FilterBuilder/FilterMarketTests.swift
+++ b/UnitTests/FilterBuilder/FilterMarketTests.swift
@@ -20,7 +20,8 @@ extension FilterMarketTests {
              .mc(.mc), .mc(.mopedScooter), .mc(.snowmobile), .mc(.atv),
              .job(.fullTime), .job(.partTime), .job(.management),
              .boat(.boatSale), .boat(.boatUsedWanted), .boat(.boatRent), .boat(.boatMotor), .boat(.boatParts), .boat(.boatPartsMotorWanted), .boat(.boatDock), .boat(.boatDockWanted),
-             .realestate(.homes), .realestate(.development), .realestate(.plot), .realestate(.leisureSale), .realestate(.leisureSaleAbroad), .realestate(.leisurePlot), .realestate(.letting), .realestate(.lettingWanted), .realestate(.businessSale), .realestate(.businessLetting), .realestate(.businessPlot), .realestate(.companyForSale), .realestate(.travelFhh):
+             .realestate(.homes), .realestate(.development), .realestate(.plot), .realestate(.leisureSale), .realestate(.leisureSaleAbroad), .realestate(.leisurePlot), .realestate(.letting), .realestate(.lettingWanted), .realestate(.businessSale), .realestate(.businessLetting), .realestate(.businessPlot), .realestate(.companyForSale), .realestate(.travelFhh),
+             .b2b(.truck), .b2b(.truckAbroad), .b2b(.bus), .b2b(.construction), .b2b(.agricultureTractor), .b2b(.agricultureThresher), .b2b(.agricultureTools), .b2b(.vanNorway), .b2b(.vanAbroad):
             break
         }
         return true


### PR DESCRIPTION
# Why?
The user should be able to filter B2B market.

⚠️ The compiler started to complain about long time to resolve the method `FilterMarket.allCases` once I added `FilterMarketB2B` into the mix. The cases for each of the markets are now stored into static vars instead.

# What?
- Added filters/support for B2B market.
- Refactored `FilterMarket.allCases`.