### PR TITLE
Configure market Car

### DIFF
--- a/Charcoal.xcodeproj/project.pbxproj
+++ b/Charcoal.xcodeproj/project.pbxproj
@@ -35,6 +35,8 @@
 		08716B6721FB108D003180D8 /* realestate-leisure-sale-abroad.json in Resources */ = {isa = PBXBuildFile; fileRef = 08716B5A21FB108D003180D8 /* realestate-leisure-sale-abroad.json */; };
 		08716B6821FB108D003180D8 /* realestate-plot.json in Resources */ = {isa = PBXBuildFile; fileRef = 08716B5B21FB108D003180D8 /* realestate-plot.json */; };
 		08716B6921FB108D003180D8 /* realestate-leisure-plot.json in Resources */ = {isa = PBXBuildFile; fileRef = 08716B5C21FB108D003180D8 /* realestate-leisure-plot.json */; };
+		08716B9721FF40F6003180D8 /* mobile-home.json in Resources */ = {isa = PBXBuildFile; fileRef = 08716B9621FF40F6003180D8 /* mobile-home.json */; };
+		08716B9921FF4112003180D8 /* caravan.json in Resources */ = {isa = PBXBuildFile; fileRef = 08716B9821FF4112003180D8 /* caravan.json */; };
 		088C090F21F5C3AA00983132 /* job-full-time.json in Resources */ = {isa = PBXBuildFile; fileRef = 088C090E21F5C3AA00983132 /* job-full-time.json */; };
 		088C091121F5CE4200983132 /* job-part-time.json in Resources */ = {isa = PBXBuildFile; fileRef = 088C091021F5CE4200983132 /* job-part-time.json */; };
 		088C091321F5CE4C00983132 /* job-management.json in Resources */ = {isa = PBXBuildFile; fileRef = 088C091221F5CE4C00983132 /* job-management.json */; };
@@ -257,6 +259,8 @@
 		08716B5A21FB108D003180D8 /* realestate-leisure-sale-abroad.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "realestate-leisure-sale-abroad.json"; sourceTree = "<group>"; };
 		08716B5B21FB108D003180D8 /* realestate-plot.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "realestate-plot.json"; sourceTree = "<group>"; };
 		08716B5C21FB108D003180D8 /* realestate-leisure-plot.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "realestate-leisure-plot.json"; sourceTree = "<group>"; };
+		08716B9621FF40F6003180D8 /* mobile-home.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "mobile-home.json"; sourceTree = "<group>"; };
+		08716B9821FF4112003180D8 /* caravan.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = caravan.json; sourceTree = "<group>"; };
 		088C090E21F5C3AA00983132 /* job-full-time.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "job-full-time.json"; sourceTree = "<group>"; };
 		088C091021F5CE4200983132 /* job-part-time.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "job-part-time.json"; sourceTree = "<group>"; };
 		088C091221F5CE4C00983132 /* job-management.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "job-management.json"; sourceTree = "<group>"; };
@@ -518,6 +522,8 @@
 			children = (
 				9BE0D54021A4509F00F0B63B /* car-abroad.json */,
 				554D154F20C0782200FA3930 /* car-norway.json */,
+				08716B9621FF40F6003180D8 /* mobile-home.json */,
+				08716B9821FF4112003180D8 /* caravan.json */,
 			);
 			path = car;
 			sourceTree = "<group>";
@@ -1208,12 +1214,14 @@
 				08716B5D21FB108D003180D8 /* realestate-business-plot.json in Resources */,
 				08716B6321FB108D003180D8 /* realestate-development.json in Resources */,
 				08716B5F21FB108D003180D8 /* realestate-homes.json in Resources */,
+				08716B9721FF40F6003180D8 /* mobile-home.json in Resources */,
 				088C091B21F5E67900983132 /* atv.json in Resources */,
 				08716B6621FB108D003180D8 /* company-for-sale.json in Resources */,
 				08716B6221FB108D003180D8 /* realestate-leisure-sale.json in Resources */,
 				088C091121F5CE4200983132 /* job-part-time.json in Resources */,
 				08716B5E21FB108D003180D8 /* realestate-letting-wanted.json in Resources */,
 				08716B6421FB108D003180D8 /* realestate-business-sale.json in Resources */,
+				08716B9921FF4112003180D8 /* caravan.json in Resources */,
 				44ECE675208F7FD20017AC82 /* Assets.xcassets in Resources */,
 				08716B4721F89D4A003180D8 /* boat-parts.json in Resources */,
 				088C091521F5E09900983132 /* mc.json in Resources */,

--- a/Demo/Resources/car/car-abroad.json
+++ b/Demo/Resources/car/car-abroad.json
@@ -1,7 +1,7 @@
 {
     "market": "car-abroad",
-    "hits": 222,
-    "label": "Parallelimporterte biler",
+    "hits": 207,
+    "label": "Biler i utlandet",
     "type": "search",
     "filters": [
         "markets",
@@ -84,23 +84,13 @@
                                 "total-results": 1
                             },
                             {
-                                "title": "Giulietta",
-                                "value": "1.3233.3785",
-                                "total-results": 1
-                            },
-                            {
                                 "title": "Sprint",
                                 "value": "1.3233.3237",
                                 "total-results": 1
                             }
                         ]
                     },
-                    "total-results": 3
-                },
-                {
-                    "title": "Andre",
-                    "value": "0.2252",
-                    "total-results": 1
+                    "total-results": 2
                 },
                 {
                     "title": "Audi",
@@ -117,7 +107,7 @@
                             {
                                 "title": "A4 allroad",
                                 "value": "1.744.2000140",
-                                "total-results": 3
+                                "total-results": 2
                             },
                             {
                                 "title": "A5",
@@ -135,9 +125,9 @@
                                 "total-results": 1
                             },
                             {
-                                "title": "Q3",
-                                "value": "1.744.2000190",
-                                "total-results": 1
+                                "title": "Andre",
+                                "value": "1.744.2053",
+                                "total-results": 3
                             },
                             {
                                 "title": "Q5",
@@ -151,7 +141,7 @@
                             }
                         ]
                     },
-                    "total-results": 14
+                    "total-results": 15
                 },
                 {
                     "title": "Bentley",
@@ -177,6 +167,11 @@
                         "name": "model",
                         "queries": [
                             {
+                                "title": "M3",
+                                "value": "1.749.893",
+                                "total-results": 1
+                            },
+                            {
                                 "title": "X5",
                                 "value": "1.749.6737",
                                 "total-results": 5
@@ -194,7 +189,7 @@
                             {
                                 "title": "3-serie",
                                 "value": "1.749.2132",
-                                "total-results": 9
+                                "total-results": 8
                             },
                             {
                                 "title": "4-serie",
@@ -204,7 +199,7 @@
                             {
                                 "title": "5-serie",
                                 "value": "1.749.2131",
-                                "total-results": 23
+                                "total-results": 22
                             },
                             {
                                 "title": "6-serie",
@@ -218,23 +213,7 @@
                             }
                         ]
                     },
-                    "total-results": 53
-                },
-                {
-                    "title": "Cadillac",
-                    "value": "0.752",
-                    "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                            {
-                                "title": "SRX",
-                                "value": "1.752.7988",
-                                "total-results": 1
-                            }
-                        ]
-                    },
-                    "total-results": 1
+                    "total-results": 52
                 },
                 {
                     "title": "Chevrolet",
@@ -244,45 +223,13 @@
                         "name": "model",
                         "queries": [
                             {
-                                "title": "Camaro",
-                                "value": "1.753.905",
-                                "total-results": 1
-                            }
-                        ]
-                    },
-                    "total-results": 1
-                },
-                {
-                    "title": "Chrysler",
-                    "value": "0.754",
-                    "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                            {
-                                "title": "Voyager",
-                                "value": "1.754.928",
-                                "total-results": 1
-                            }
-                        ]
-                    },
-                    "total-results": 1
-                },
-                {
-                    "title": "Dodge",
-                    "value": "0.764",
-                    "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                            {
-                                "title": "Andre",
-                                "value": "1.764.2073",
+                                "title": "Bel Air",
+                                "value": "1.753.2000406",
                                 "total-results": 1
                             },
                             {
-                                "title": "Challenger",
-                                "value": "1.764.2074",
+                                "title": "Camaro",
+                                "value": "1.753.905",
                                 "total-results": 1
                             }
                         ]
@@ -304,7 +251,7 @@
                             {
                                 "title": "500",
                                 "value": "1.766.2000071",
-                                "total-results": 2
+                                "total-results": 1
                             },
                             {
                                 "title": "500L",
@@ -313,7 +260,7 @@
                             }
                         ]
                     },
-                    "total-results": 5
+                    "total-results": 4
                 },
                 {
                     "title": "Ford",
@@ -325,37 +272,6 @@
                             {
                                 "title": "Focus",
                                 "value": "1.767.3739",
-                                "total-results": 1
-                            },
-                            {
-                                "title": "Grand C-MAX",
-                                "value": "1.767.2000218",
-                                "total-results": 1
-                            },
-                            {
-                                "title": "Mustang",
-                                "value": "1.767.1056",
-                                "total-results": 1
-                            },
-                            {
-                                "title": "Transit Connect",
-                                "value": "1.767.8191",
-                                "total-results": 1
-                            }
-                        ]
-                    },
-                    "total-results": 4
-                },
-                {
-                    "title": "Honda",
-                    "value": "0.771",
-                    "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                            {
-                                "title": "Civic",
-                                "value": "1.771.1088",
                                 "total-results": 1
                             }
                         ]
@@ -384,22 +300,6 @@
                     "total-results": 3
                 },
                 {
-                    "title": "Iveco",
-                    "value": "0.7280",
-                    "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                            {
-                                "title": "Daily",
-                                "value": "1.7280.7294",
-                                "total-results": 1
-                            }
-                        ]
-                    },
-                    "total-results": 1
-                },
-                {
                     "title": "Jaguar",
                     "value": "0.775",
                     "filter": {
@@ -407,13 +307,8 @@
                         "name": "model",
                         "queries": [
                             {
-                                "title": "Andre",
-                                "value": "1.775.2084",
-                                "total-results": 1
-                            },
-                            {
-                                "title": "E-TYPE",
-                                "value": "1.775.2000124",
+                                "title": "I-PACE",
+                                "value": "1.775.2000447",
                                 "total-results": 1
                             },
                             {
@@ -423,7 +318,7 @@
                             }
                         ]
                     },
-                    "total-results": 3
+                    "total-results": 2
                 },
                 {
                     "title": "Kia",
@@ -433,8 +328,29 @@
                         "name": "model",
                         "queries": [
                             {
+                                "title": "Niro",
+                                "value": "1.777.2000392",
+                                "total-results": 4
+                            },
+                            {
                                 "title": "Picanto",
                                 "value": "1.777.8178",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 5
+                },
+                {
+                    "title": "Land Rover",
+                    "value": "0.781",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Defender",
+                                "value": "1.781.6742",
                                 "total-results": 1
                             }
                         ]
@@ -454,6 +370,11 @@
                                 "total-results": 2
                             },
                             {
+                                "title": "Andre",
+                                "value": "1.785.2094",
+                                "total-results": 1
+                            },
+                            {
                                 "title": "A-Klasse",
                                 "value": "1.785.3777",
                                 "total-results": 2
@@ -464,11 +385,6 @@
                                 "total-results": 3
                             },
                             {
-                                "title": "CLK",
-                                "value": "1.785.6713",
-                                "total-results": 1
-                            },
-                            {
                                 "title": "C-Klasse",
                                 "value": "1.785.3776",
                                 "total-results": 12
@@ -476,7 +392,7 @@
                             {
                                 "title": "E-Klasse",
                                 "value": "1.785.3775",
-                                "total-results": 28
+                                "total-results": 26
                             },
                             {
                                 "title": "E-klasse All-Terrain",
@@ -486,7 +402,7 @@
                             {
                                 "title": "Geländewagen",
                                 "value": "1.785.2259",
-                                "total-results": 2
+                                "total-results": 4
                             },
                             {
                                 "title": "GLA",
@@ -506,7 +422,7 @@
                             {
                                 "title": "M-Klasse",
                                 "value": "1.785.3774",
-                                "total-results": 3
+                                "total-results": 2
                             },
                             {
                                 "title": "SLK",
@@ -516,11 +432,11 @@
                             {
                                 "title": "S-Klasse",
                                 "value": "1.785.3773",
-                                "total-results": 2
+                                "total-results": 1
                             }
                         ]
                     },
-                    "total-results": 78
+                    "total-results": 76
                 },
                 {
                     "title": "MG",
@@ -548,16 +464,11 @@
                             {
                                 "title": "Outlander",
                                 "value": "1.787.7713",
-                                "total-results": 6
-                            },
-                            {
-                                "title": "Space Star",
-                                "value": "1.787.3752",
-                                "total-results": 1
+                                "total-results": 5
                             }
                         ]
                     },
-                    "total-results": 7
+                    "total-results": 5
                 },
                 {
                     "title": "Nissan",
@@ -574,43 +485,6 @@
                         ]
                     },
                     "total-results": 3
-                },
-                {
-                    "title": "Opel",
-                    "value": "0.795",
-                    "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                            {
-                                "title": "Astra",
-                                "value": "1.795.1247",
-                                "total-results": 1
-                            },
-                            {
-                                "title": "Combo",
-                                "value": "1.795.1252",
-                                "total-results": 1
-                            }
-                        ]
-                    },
-                    "total-results": 2
-                },
-                {
-                    "title": "Pontiac",
-                    "value": "0.800",
-                    "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                            {
-                                "title": "Andre",
-                                "value": "1.800.2109",
-                                "total-results": 1
-                            }
-                        ]
-                    },
-                    "total-results": 1
                 },
                 {
                     "title": "Porsche",
@@ -669,11 +543,11 @@
                             {
                                 "title": "Superb",
                                 "value": "1.808.7532",
-                                "total-results": 5
+                                "total-results": 4
                             }
                         ]
                     },
-                    "total-results": 9
+                    "total-results": 8
                 },
                 {
                     "title": "Tesla",
@@ -704,8 +578,8 @@
                                 "total-results": 1
                             },
                             {
-                                "title": "MR2",
-                                "value": "1.813.1398",
+                                "title": "HiAce",
+                                "value": "1.813.1394",
                                 "total-results": 1
                             },
                             {
@@ -725,11 +599,6 @@
                         "name": "model",
                         "queries": [
                             {
-                                "title": "Caddy",
-                                "value": "1.817.6709",
-                                "total-results": 1
-                            },
-                            {
                                 "title": "Golf",
                                 "value": "1.817.1433",
                                 "total-results": 4
@@ -737,6 +606,11 @@
                             {
                                 "title": "Passat",
                                 "value": "1.817.1437",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "Passat Alltrack",
+                                "value": "1.817.2000209",
                                 "total-results": 1
                             },
                             {
@@ -751,7 +625,7 @@
                             }
                         ]
                     },
-                    "total-results": 8
+                    "total-results": 9
                 },
                 {
                     "title": "Volvo",
@@ -760,11 +634,6 @@
                         "title": "Modell",
                         "name": "model",
                         "queries": [
-                            {
-                                "title": "V70",
-                                "value": "1.818.3077",
-                                "total-results": 1
-                            },
                             {
                                 "title": "V90",
                                 "value": "1.818.2000386",
@@ -787,7 +656,7 @@
                             }
                         ]
                     },
-                    "total-results": 7
+                    "total-results": 6
                 }
             ]
         },
@@ -803,22 +672,22 @@
                 {
                     "title": "Annet",
                     "value": "6",
-                    "total-results": 12
+                    "total-results": 11
                 },
                 {
                     "title": "Lett lastebil",
                     "value": "5",
-                    "total-results": 1
+                    "total-results": 3
                 },
                 {
                     "title": "Personbil",
                     "value": "1",
-                    "total-results": 204
+                    "total-results": 192
                 },
                 {
                     "title": "Varebil",
                     "value": "2",
-                    "total-results": 5
+                    "total-results": 1
                 }
             ]
         },
@@ -829,27 +698,22 @@
                 {
                     "title": "Bensin",
                     "value": "0/1",
-                    "total-results": 66
+                    "total-results": 47
                 },
                 {
                     "title": "Diesel",
                     "value": "0/2",
-                    "total-results": 103
+                    "total-results": 102
                 },
                 {
                     "title": "Elektrisitet",
                     "value": "0/4",
-                    "total-results": 12
-                },
-                {
-                    "title": "Gass",
-                    "value": "0/3",
-                    "total-results": 1
+                    "total-results": 17
                 },
                 {
                     "title": "Hybrid",
                     "value": "0/11111",
-                    "total-results": 40
+                    "total-results": 41
                 }
             ]
         },
@@ -860,7 +724,7 @@
                 {
                     "title": "Garanti",
                     "value": "1",
-                    "total-results": 113
+                    "total-results": 112
                 }
             ]
         },
@@ -871,12 +735,12 @@
                 {
                     "title": "Ett hjulsett",
                     "value": "1",
-                    "total-results": 128
+                    "total-results": 121
                 },
                 {
                     "title": "To hjulsett",
                     "value": "2",
-                    "total-results": 13
+                    "total-results": 14
                 }
             ]
         },
@@ -887,7 +751,7 @@
                 {
                     "title": "Bruktbil til salgs",
                     "value": "1",
-                    "total-results": 219
+                    "total-results": 204
                 },
                 {
                     "title": "Leasing",
@@ -908,7 +772,12 @@
                 {
                     "title": "Blå",
                     "value": "2",
-                    "total-results": 16
+                    "total-results": 15
+                },
+                {
+                    "title": "Bronse",
+                    "value": "3",
+                    "total-results": 1
                 },
                 {
                     "title": "Brun",
@@ -918,42 +787,42 @@
                 {
                     "title": "Grønn",
                     "value": "5",
-                    "total-results": 2
+                    "total-results": 3
                 },
                 {
                     "title": "Grå",
                     "value": "6",
-                    "total-results": 40
-                },
-                {
-                    "title": "Gul",
-                    "value": "7",
-                    "total-results": 1
+                    "total-results": 36
                 },
                 {
                     "title": "Hvit",
                     "value": "9",
-                    "total-results": 53
+                    "total-results": 48
+                },
+                {
+                    "title": "Oransje",
+                    "value": "11",
+                    "total-results": 1
                 },
                 {
                     "title": "Rød",
                     "value": "13",
-                    "total-results": 15
+                    "total-results": 11
                 },
                 {
                     "title": "Svart",
                     "value": "14",
-                    "total-results": 75
+                    "total-results": 74
                 },
                 {
                     "title": "Sølv",
                     "value": "15",
-                    "total-results": 17
+                    "total-results": 13
                 },
                 {
                     "title": "Turkis",
                     "value": "16",
-                    "total-results": 1
+                    "total-results": 2
                 }
             ]
         },
@@ -964,7 +833,7 @@
                 {
                     "title": "Nye i dag",
                     "value": "1",
-                    "total-results": 4
+                    "total-results": 1
                 }
             ]
         },
@@ -980,27 +849,27 @@
                 {
                     "title": "Hengerfeste",
                     "value": "23",
-                    "total-results": 41
+                    "total-results": 38
                 },
                 {
                     "title": "Motorvarmer",
                     "value": "35",
-                    "total-results": 37
+                    "total-results": 39
                 },
                 {
                     "title": "Navigasjonssystem",
                     "value": "40",
-                    "total-results": 121
+                    "total-results": 123
                 },
                 {
                     "title": "Radio DAB+",
                     "value": "77",
-                    "total-results": 22
+                    "total-results": 26
                 },
                 {
                     "title": "Skinninteriør",
                     "value": "12",
-                    "total-results": 109
+                    "total-results": 108
                 }
             ]
         },
@@ -1011,12 +880,12 @@
                 {
                     "title": "Automat",
                     "value": "2",
-                    "total-results": 184
+                    "total-results": 179
                 },
                 {
                     "title": "Manuell",
                     "value": "1",
-                    "total-results": 38
+                    "total-results": 28
                 }
             ]
         },
@@ -1027,17 +896,12 @@
                 {
                     "title": "Annet bilutsalg",
                     "value": "2",
-                    "total-results": 191
-                },
-                {
-                    "title": "Merkeforhandler",
-                    "value": "1",
-                    "total-results": 2
+                    "total-results": 188
                 },
                 {
                     "title": "Privat",
                     "value": "3",
-                    "total-results": 29
+                    "total-results": 19
                 }
             ]
         },
@@ -1048,17 +912,17 @@
                 {
                     "title": "Bakhjulsdrift",
                     "value": "1",
-                    "total-results": 77
+                    "total-results": 66
                 },
                 {
                     "title": "Firehjulsdrift",
                     "value": "2",
-                    "total-results": 106
+                    "total-results": 110
                 },
                 {
                     "title": "Forhjulsdrift",
                     "value": "3",
-                    "total-results": 39
+                    "total-results": 31
                 }
             ]
         },
@@ -1069,7 +933,7 @@
                 {
                     "title": "Service",
                     "value": "1",
-                    "total-results": 59
+                    "total-results": 53
                 }
             ]
         },
@@ -1084,17 +948,17 @@
                 {
                     "title": "Akershus",
                     "value": "20003",
-                    "total-results": 141
+                    "total-results": 139
                 },
                 {
                     "title": "Aust-Agder",
                     "value": "20010",
-                    "total-results": 1
+                    "total-results": 3
                 },
                 {
                     "title": "Buskerud",
                     "value": "20007",
-                    "total-results": 6
+                    "total-results": 2
                 },
                 {
                     "title": "Hedmark",
@@ -1104,17 +968,22 @@
                 {
                     "title": "Hordaland",
                     "value": "20013",
-                    "total-results": 3
+                    "total-results": 2
+                },
+                {
+                    "title": "Nordland",
+                    "value": "20018",
+                    "total-results": 1
                 },
                 {
                     "title": "Oppland",
                     "value": "20006",
-                    "total-results": 3
+                    "total-results": 1
                 },
                 {
                     "title": "Oslo",
                     "value": "20061",
-                    "total-results": 6
+                    "total-results": 8
                 },
                 {
                     "title": "Rogaland",
@@ -1124,7 +993,7 @@
                 {
                     "title": "Trøndelag",
                     "value": "20016",
-                    "total-results": 2
+                    "total-results": 1
                 },
                 {
                     "title": "Vestfold",
@@ -1139,7 +1008,7 @@
                 {
                     "title": "Østfold",
                     "value": "20002",
-                    "total-results": 4
+                    "total-results": 1
                 }
             ]
         },
@@ -1151,32 +1020,32 @@
                 {
                     "title": "0-50000",
                     "value": "0-50000",
-                    "total-results": 8
+                    "total-results": 3
                 },
                 {
                     "title": "50001-100000",
                     "value": "50001-100000",
-                    "total-results": 9
+                    "total-results": 2
                 },
                 {
                     "title": "100001-150000",
                     "value": "100001-150000",
-                    "total-results": 6
+                    "total-results": 3
                 },
                 {
                     "title": "150001-250000",
                     "value": "150001-250000",
-                    "total-results": 12
+                    "total-results": 8
                 },
                 {
                     "title": "250001-500000",
                     "value": "250001-500000",
-                    "total-results": 91
+                    "total-results": 90
                 },
                 {
                     "title": "500001-",
                     "value": "500001-null",
-                    "total-results": 96
+                    "total-results": 101
                 }
             ]
         },
@@ -1187,22 +1056,22 @@
                 {
                     "title": "Annet",
                     "value": "11",
-                    "total-results": 5
+                    "total-results": 4
                 },
                 {
                     "title": "Cabriolet",
                     "value": "7",
-                    "total-results": 8
+                    "total-results": 6
                 },
                 {
                     "title": "Coupe",
                     "value": "6",
-                    "total-results": 16
+                    "total-results": 12
                 },
                 {
                     "title": "Flerbruksbil",
                     "value": "5",
-                    "total-results": 4
+                    "total-results": 3
                 },
                 {
                     "title": "Kasse",
@@ -1217,27 +1086,22 @@
                 {
                     "title": "Kombi 5-dørs",
                     "value": "2",
-                    "total-results": 32
-                },
-                {
-                    "title": "Pickup",
-                    "value": "8",
-                    "total-results": 1
+                    "total-results": 30
                 },
                 {
                     "title": "Sedan",
                     "value": "3",
-                    "total-results": 50
+                    "total-results": 45
                 },
                 {
                     "title": "Stasjonsvogn",
                     "value": "4",
-                    "total-results": 66
+                    "total-results": 60
                 },
                 {
                     "title": "SUV/Offroad",
                     "value": "9",
-                    "total-results": 37
+                    "total-results": 44
                 }
             ]
         },
@@ -1246,72 +1110,6 @@
             "name": "price_changed"
         }
     },
-    "menubar": [
-        {
-            "type": "sort",
-            "label": "Sortér",
-            "data": {
-                "parameter": "sort",
-                "values": [
-                    {
-                        "label": "Publisert",
-                        "value": "0",
-                        "selected": true
-                    },
-                    {
-                        "label": "Modell",
-                        "value": "1",
-                        "selected": false
-                    },
-                    {
-                        "label": "Pris lav-høy",
-                        "value": "2",
-                        "selected": false
-                    },
-                    {
-                        "label": "Pris høy-lav",
-                        "value": "3",
-                        "selected": false
-                    },
-                    {
-                        "label": "Km lav-høy",
-                        "value": "4",
-                        "selected": false
-                    },
-                    {
-                        "label": "Km høy-lav",
-                        "value": "5",
-                        "selected": false
-                    },
-                    {
-                        "label": "År nyest-eldst",
-                        "value": "6",
-                        "selected": false
-                    },
-                    {
-                        "label": "År eldst-nyest",
-                        "value": "7",
-                        "selected": false
-                    },
-                    {
-                        "label": "Mest relevant",
-                        "value": "9",
-                        "selected": false
-                    },
-                    {
-                        "label": "Nærmest",
-                        "value": "99",
-                        "selected": false
-                    }
-                ]
-            }
-        }
-    ],
-    "sections": [
-        {
-            "cells": []
-        }
-    ],
     "map": {
         "parameter": "bbox",
         "areaParameters": [

--- a/Demo/Resources/car/car-norway.json
+++ b/Demo/Resources/car/car-norway.json
@@ -1,33 +1,33 @@
 {
     "market": "car-norway",
-    "hits": 63455,
+    "hits": 62882,
     "label": "Biler i Norge",
     "type": "search",
     "filters": [
-                "markets",
-                "q",
-                "published",
-                "make",
-                "dealer_segment",
-                "sales_form",
-                "year",
-                "mileage",
-                "price",
-                "price_changed",
-                "location",
-                "body_type",
-                "engine_fuel",
-                "exterior_colour",
-                "engine_effect",
-                "number_of_seats",
-                "wheel_drive",
-                "transmission",
-                "car_equipment",
-                "wheel_sets",
-                "warranty_insurance",
-                "condition",
-                "registration_class"
-                ],
+        "markets",
+        "q",
+        "published",
+        "make",
+        "dealer_segment",
+        "sales_form",
+        "year",
+        "mileage",
+        "price",
+        "price_changed",
+        "location",
+        "body_type",
+        "engine_fuel",
+        "exterior_colour",
+        "engine_effect",
+        "number_of_seats",
+        "wheel_drive",
+        "transmission",
+        "car_equipment",
+        "wheel_sets",
+        "warranty_insurance",
+        "condition",
+        "registration_class"
+    ],
     "filter-data": {
         "year": {
             "title": "Årsmodell",
@@ -53,5871 +53,5588 @@
             "title": "Merke",
             "name": "make",
             "queries": [
-                        {
-                        "title": "Abarth",
-                        "value": "0.8093",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "124 Spider",
-                                    "value": "1.8093.2000412",
-                                    "total-results": 2
-                                    },
-                                    {
-                                    "title": "595",
-                                    "value": "1.8093.2000413",
-                                    "total-results": 5
-                                    },
-                                    {
-                                    "title": "695",
-                                    "value": "1.8093.2000414",
-                                    "total-results": 2
-                                    }
-                                    ]
-                        },
-                        "total-results": 9
-                        },
-                        {
-                        "title": "Alfa Romeo",
-                        "value": "0.3233",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Brera",
-                                    "value": "1.3233.8251",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "Giulia",
-                                    "value": "1.3233.2000373",
-                                    "total-results": 41
-                                    },
-                                    {
-                                    "title": "Giulietta",
-                                    "value": "1.3233.3785",
-                                    "total-results": 71
-                                    },
-                                    {
-                                    "title": "GT",
-                                    "value": "1.3233.8082",
-                                    "total-results": 5
-                                    },
-                                    {
-                                    "title": "GTV",
-                                    "value": "1.3233.3239",
-                                    "total-results": 7
-                                    },
-                                    {
-                                    "title": "MiTo",
-                                    "value": "1.3233.2000094",
-                                    "total-results": 21
-                                    },
-                                    {
-                                    "title": "Spider",
-                                    "value": "1.3233.3238",
-                                    "total-results": 2
-                                    },
-                                    {
-                                    "title": "Stelvio",
-                                    "value": "1.3233.2000407",
-                                    "total-results": 60
-                                    },
-                                    {
-                                    "title": "147",
-                                    "value": "1.3233.7176",
-                                    "total-results": 15
-                                    },
-                                    {
-                                    "title": "156",
-                                    "value": "1.3233.3730",
-                                    "total-results": 11
-                                    },
-                                    {
-                                    "title": "159",
-                                    "value": "1.3233.8169",
-                                    "total-results": 32
-                                    },
-                                    {
-                                    "title": "159 SportWagon",
-                                    "value": "1.3233.6735",
-                                    "total-results": 15
-                                    },
-                                    {
-                                    "title": "166",
-                                    "value": "1.3233.3729",
-                                    "total-results": 2
-                                    }
-                                    ]
-                        },
-                        "total-results": 286
-                        },
-                        {
-                        "title": "Alpina",
-                        "value": "0.8092",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "B10",
-                                    "value": "1.8092.2000355",
-                                    "total-results": 4
-                                    },
-                                    {
-                                    "title": "D5",
-                                    "value": "1.8092.2000366",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "D10",
-                                    "value": "1.8092.2000363",
-                                    "total-results": 1
-                                    }
-                                    ]
-                        },
-                        "total-results": 6
-                        },
-                        {
-                        "title": "Andre",
-                        "value": "0.2252",
-                        "total-results": 145
-                        },
-                        {
-                        "title": "Aston Martin",
-                        "value": "0.6733",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Cygnet",
-                                    "value": "1.6733.2000262",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "DB7",
-                                    "value": "1.6733.8318",
-                                    "total-results": 3
-                                    },
-                                    {
-                                    "title": "DB9",
-                                    "value": "1.6733.8319",
-                                    "total-results": 6
-                                    },
-                                    {
-                                    "title": "Rapide",
-                                    "value": "1.6733.2000257",
-                                    "total-results": 4
-                                    },
-                                    {
-                                    "title": "V8 Vantage",
-                                    "value": "1.6733.8320",
-                                    "total-results": 4
-                                    },
-                                    {
-                                    "title": "V12 Vantage",
-                                    "value": "1.6733.2000345",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "Vanquish",
-                                    "value": "1.6733.8321",
-                                    "total-results": 1
-                                    }
-                                    ]
-                        },
-                        "total-results": 25
-                        },
-                        {
-                        "title": "Audi",
-                        "value": "0.744",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "A1",
-                                    "value": "1.744.2000166",
-                                    "total-results": 188
-                                    },
-                                    {
-                                    "title": "A2",
-                                    "value": "1.744.6720",
-                                    "total-results": 11
-                                    },
-                                    {
-                                    "title": "A3",
-                                    "value": "1.744.2046",
-                                    "total-results": 927
-                                    },
-                                    {
-                                    "title": "A4",
-                                    "value": "1.744.839",
-                                    "total-results": 956
-                                    },
-                                    {
-                                    "title": "A4 allroad",
-                                    "value": "1.744.2000140",
-                                    "total-results": 208
-                                    },
-                                    {
-                                    "title": "A5",
-                                    "value": "1.744.8314",
-                                    "total-results": 249
-                                    },
-                                    {
-                                    "title": "A6",
-                                    "value": "1.744.840",
-                                    "total-results": 700
-                                    },
-                                    {
-                                    "title": "A6 allroad",
-                                    "value": "1.744.6736",
-                                    "total-results": 231
-                                    },
-                                    {
-                                    "title": "A7",
-                                    "value": "1.744.2000174",
-                                    "total-results": 83
-                                    },
-                                    {
-                                    "title": "A8",
-                                    "value": "1.744.841",
-                                    "total-results": 150
-                                    },
-                                    {
-                                    "title": "Andre",
-                                    "value": "1.744.2053",
-                                    "total-results": 2
-                                    },
-                                    {
-                                    "title": "Q2",
-                                    "value": "1.744.2000400",
-                                    "total-results": 17
-                                    },
-                                    {
-                                    "title": "Q3",
-                                    "value": "1.744.2000190",
-                                    "total-results": 82
-                                    },
-                                    {
-                                    "title": "Q5",
-                                    "value": "1.744.2000097",
-                                    "total-results": 344
-                                    },
-                                    {
-                                    "title": "Q7",
-                                    "value": "1.744.8149",
-                                    "total-results": 145
-                                    },
-                                    {
-                                    "title": "R8",
-                                    "value": "1.744.8340",
-                                    "total-results": 25
-                                    },
-                                    {
-                                    "title": "RS3",
-                                    "value": "1.744.2000184",
-                                    "total-results": 10
-                                    },
-                                    {
-                                    "title": "RS4",
-                                    "value": "1.744.6721",
-                                    "total-results": 27
-                                    },
-                                    {
-                                    "title": "RS5",
-                                    "value": "1.744.2000185",
-                                    "total-results": 7
-                                    },
-                                    {
-                                    "title": "RS6",
-                                    "value": "1.744.7709",
-                                    "total-results": 57
-                                    },
-                                    {
-                                    "title": "RS7",
-                                    "value": "1.744.2000291",
-                                    "total-results": 6
-                                    },
-                                    {
-                                    "title": "S1",
-                                    "value": "1.744.2000304",
-                                    "total-results": 2
-                                    },
-                                    {
-                                    "title": "S2",
-                                    "value": "1.744.7557",
-                                    "total-results": 3
-                                    },
-                                    {
-                                    "title": "S3",
-                                    "value": "1.744.3731",
-                                    "total-results": 25
-                                    },
-                                    {
-                                    "title": "S4",
-                                    "value": "1.744.2891",
-                                    "total-results": 32
-                                    },
-                                    {
-                                    "title": "S5",
-                                    "value": "1.744.2000082",
-                                    "total-results": 12
-                                    },
-                                    {
-                                    "title": "S6",
-                                    "value": "1.744.843",
-                                    "total-results": 16
-                                    },
-                                    {
-                                    "title": "S7",
-                                    "value": "1.744.2000246",
-                                    "total-results": 3
-                                    },
-                                    {
-                                    "title": "S8",
-                                    "value": "1.744.3786",
-                                    "total-results": 26
-                                    },
-                                    {
-                                    "title": "SQ5",
-                                    "value": "1.744.2000296",
-                                    "total-results": 7
-                                    },
-                                    {
-                                    "title": "SQ7",
-                                    "value": "1.744.2000402",
-                                    "total-results": 3
-                                    },
-                                    {
-                                    "title": "TT",
-                                    "value": "1.744.3732",
-                                    "total-results": 107
-                                    },
-                                    {
-                                    "title": "V8",
-                                    "value": "1.744.8313",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "80",
-                                    "value": "1.744.837",
-                                    "total-results": 25
-                                    },
-                                    {
-                                    "title": "90",
-                                    "value": "1.744.838",
-                                    "total-results": 2
-                                    },
-                                    {
-                                    "title": "100",
-                                    "value": "1.744.833",
-                                    "total-results": 14
-                                    }
-                                    ]
-                        },
-                        "total-results": 4713
-                        },
-                        {
-                        "title": "Austin",
-                        "value": "0.8076",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Andre",
-                                    "value": "1.8076.2000180",
-                                    "total-results": 7
-                                    },
-                                    {
-                                    "title": "Healey 100 6",
-                                    "value": "1.8076.2000323",
-                                    "total-results": 4
-                                    },
-                                    {
-                                    "title": "Healey 3000",
-                                    "value": "1.8076.2000127",
-                                    "total-results": 1
-                                    }
-                                    ]
-                        },
-                        "total-results": 12
-                        },
-                        {
-                        "title": "Bentley",
-                        "value": "0.7166",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Andre",
-                                    "value": "1.7166.7169",
-                                    "total-results": 4
-                                    },
-                                    {
-                                    "title": "Continental",
-                                    "value": "1.7166.7168",
-                                    "total-results": 13
-                                    },
-                                    {
-                                    "title": "Flying Spur",
-                                    "value": "1.7166.2000325",
-                                    "total-results": 3
-                                    },
-                                    {
-                                    "title": "Mulsanne",
-                                    "value": "1.7166.7167",
-                                    "total-results": 1
-                                    }
-                                    ]
-                        },
-                        "total-results": 22
-                        },
-                        {
-                        "title": "BMW",
-                        "value": "0.749",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Andre",
-                                    "value": "1.749.2058",
-                                    "total-results": 6
-                                    },
-                                    {
-                                    "title": "i3",
-                                    "value": "1.749.2000264",
-                                    "total-results": 218
-                                    },
-                                    {
-                                    "title": "i8",
-                                    "value": "1.749.2000309",
-                                    "total-results": 26
-                                    },
-                                    {
-                                    "title": "M2",
-                                    "value": "1.749.2000370",
-                                    "total-results": 28
-                                    },
-                                    {
-                                    "title": "M3",
-                                    "value": "1.749.893",
-                                    "total-results": 73
-                                    },
-                                    {
-                                    "title": "M4",
-                                    "value": "1.749.2000295",
-                                    "total-results": 33
-                                    },
-                                    {
-                                    "title": "M5",
-                                    "value": "1.749.2133",
-                                    "total-results": 50
-                                    },
-                                    {
-                                    "title": "M6",
-                                    "value": "1.749.8288",
-                                    "total-results": 12
-                                    },
-                                    {
-                                    "title": "X1",
-                                    "value": "1.749.2000133",
-                                    "total-results": 211
-                                    },
-                                    {
-                                    "title": "X2",
-                                    "value": "1.749.2000440",
-                                    "total-results": 35
-                                    },
-                                    {
-                                    "title": "X3",
-                                    "value": "1.749.7798",
-                                    "total-results": 463
-                                    },
-                                    {
-                                    "title": "X4",
-                                    "value": "1.749.2000294",
-                                    "total-results": 59
-                                    },
-                                    {
-                                    "title": "X5",
-                                    "value": "1.749.6737",
-                                    "total-results": 534
-                                    },
-                                    {
-                                    "title": "X6",
-                                    "value": "1.749.2000085",
-                                    "total-results": 86
-                                    },
-                                    {
-                                    "title": "Z3",
-                                    "value": "1.749.3003",
-                                    "total-results": 14
-                                    },
-                                    {
-                                    "title": "Z4",
-                                    "value": "1.749.7683",
-                                    "total-results": 14
-                                    },
-                                    {
-                                    "title": "1-serie",
-                                    "value": "1.749.7967",
-                                    "total-results": 623
-                                    },
-                                    {
-                                    "title": "2-serie",
-                                    "value": "1.749.2000283",
-                                    "total-results": 231
-                                    },
-                                    {
-                                    "title": "3-serie",
-                                    "value": "1.749.2132",
-                                    "total-results": 1522
-                                    },
-                                    {
-                                    "title": "4-serie",
-                                    "value": "1.749.2000265",
-                                    "total-results": 101
-                                    },
-                                    {
-                                    "title": "5-serie",
-                                    "value": "1.749.2131",
-                                    "total-results": 1469
-                                    },
-                                    {
-                                    "title": "6-serie",
-                                    "value": "1.749.3004",
-                                    "total-results": 73
-                                    },
-                                    {
-                                    "title": "7-serie",
-                                    "value": "1.749.2130",
-                                    "total-results": 159
-                                    },
-                                    {
-                                    "title": "8-serie",
-                                    "value": "1.749.2129",
-                                    "total-results": 3
-                                    },
-                                    {
-                                    "title": "1800",
-                                    "value": "1.749.866",
-                                    "total-results": 2
-                                    },
-                                    {
-                                    "title": "2000",
-                                    "value": "1.749.867",
-                                    "total-results": 2
-                                    },
-                                    {
-                                    "title": "2002",
-                                    "value": "1.749.868",
-                                    "total-results": 4
-                                    }
-                                    ]
-                        },
-                        "total-results": 6057
-                        },
-                        {
-                        "title": "Buddy",
-                        "value": "0.8066",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Citi-Jet 6",
-                                    "value": "1.8066.2000120",
-                                    "total-results": 2
-                                    },
-                                    {
-                                    "title": "Premium",
-                                    "value": "1.8066.2000144",
-                                    "total-results": 2
-                                    }
-                                    ]
-                        },
-                        "total-results": 4
-                        },
-                        {
-                        "title": "Buick",
-                        "value": "0.750",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Andre",
-                                    "value": "1.750.2059",
-                                    "total-results": 14
-                                    },
-                                    {
-                                    "title": "Century",
-                                    "value": "1.750.894",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "Le Sabre",
-                                    "value": "1.750.895",
-                                    "total-results": 2
-                                    },
-                                    {
-                                    "title": "Park Avenue",
-                                    "value": "1.750.896",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "Regal",
-                                    "value": "1.750.897",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "Skylark",
-                                    "value": "1.750.898",
-                                    "total-results": 1
-                                    }
-                                    ]
-                        },
-                        "total-results": 21
-                        },
-                        {
-                        "title": "Cadillac",
-                        "value": "0.752",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Andre",
-                                    "value": "1.752.2061",
-                                    "total-results": 20
-                                    },
-                                    {
-                                    "title": "BLS",
-                                    "value": "1.752.979",
-                                    "total-results": 5
-                                    },
-                                    {
-                                    "title": "CTS",
-                                    "value": "1.752.7987",
-                                    "total-results": 3
-                                    },
-                                    {
-                                    "title": "Deville",
-                                    "value": "1.752.900",
-                                    "total-results": 17
-                                    },
-                                    {
-                                    "title": "Eldorado",
-                                    "value": "1.752.2000168",
-                                    "total-results": 14
-                                    },
-                                    {
-                                    "title": "Escalade",
-                                    "value": "1.752.7670",
-                                    "total-results": 6
-                                    },
-                                    {
-                                    "title": "Seville",
-                                    "value": "1.752.3787",
-                                    "total-results": 7
-                                    },
-                                    {
-                                    "title": "SRX",
-                                    "value": "1.752.7988",
-                                    "total-results": 3
-                                    },
-                                    {
-                                    "title": "XLR",
-                                    "value": "1.752.2000103",
-                                    "total-results": 2
-                                    }
-                                    ]
-                        },
-                        "total-results": 79
-                        },
-                        {
-                        "title": "Chevrolet",
-                        "value": "0.753",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Alero",
-                                    "value": "1.753.3736",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "Andre",
-                                    "value": "1.753.2062",
-                                    "total-results": 16
-                                    },
-                                    {
-                                    "title": "Astro",
-                                    "value": "1.753.901",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "Avalanche",
-                                    "value": "1.753.7539",
-                                    "total-results": 9
-                                    },
-                                    {
-                                    "title": "Aveo",
-                                    "value": "1.753.2000098",
-                                    "total-results": 3
-                                    },
-                                    {
-                                    "title": "Beauville",
-                                    "value": "1.753.902",
-                                    "total-results": 6
-                                    },
-                                    {
-                                    "title": "Bel Air",
-                                    "value": "1.753.2000406",
-                                    "total-results": 4
-                                    },
-                                    {
-                                    "title": "Blazer",
-                                    "value": "1.753.904",
-                                    "total-results": 10
-                                    },
-                                    {
-                                    "title": "Bolt",
-                                    "value": "1.753.2000410",
-                                    "total-results": 47
-                                    },
-                                    {
-                                    "title": "Camaro",
-                                    "value": "1.753.905",
-                                    "total-results": 45
-                                    },
-                                    {
-                                    "title": "Caprice",
-                                    "value": "1.753.907",
-                                    "total-results": 7
-                                    },
-                                    {
-                                    "title": "Captiva",
-                                    "value": "1.753.1486",
-                                    "total-results": 16
-                                    },
-                                    {
-                                    "title": "Cargovan",
-                                    "value": "1.753.2000053",
-                                    "total-results": 3
-                                    },
-                                    {
-                                    "title": "Chevelle",
-                                    "value": "1.753.3864",
-                                    "total-results": 6
-                                    },
-                                    {
-                                    "title": "Colorado",
-                                    "value": "1.753.3828",
-                                    "total-results": 5
-                                    },
-                                    {
-                                    "title": "Corvette",
-                                    "value": "1.753.912",
-                                    "total-results": 161
-                                    },
-                                    {
-                                    "title": "Crew Cab",
-                                    "value": "1.753.7541",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "Cruze",
-                                    "value": "1.753.2000233",
-                                    "total-results": 9
-                                    },
-                                    {
-                                    "title": "C-10",
-                                    "value": "1.753.2000263",
-                                    "total-results": 18
-                                    },
-                                    {
-                                    "title": "El Camino",
-                                    "value": "1.753.3862",
-                                    "total-results": 5
-                                    },
-                                    {
-                                    "title": "Epica",
-                                    "value": "1.753.2000044",
-                                    "total-results": 2
-                                    },
-                                    {
-                                    "title": "Express",
-                                    "value": "1.753.2000287",
-                                    "total-results": 10
-                                    },
-                                    {
-                                    "title": "Impala",
-                                    "value": "1.753.3860",
-                                    "total-results": 11
-                                    },
-                                    {
-                                    "title": "Kalos",
-                                    "value": "1.753.8094",
-                                    "total-results": 3
-                                    },
-                                    {
-                                    "title": "Lacetti",
-                                    "value": "1.753.8095",
-                                    "total-results": 3
-                                    },
-                                    {
-                                    "title": "Lumina",
-                                    "value": "1.753.3005",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "Malibu",
-                                    "value": "1.753.913",
-                                    "total-results": 2
-                                    },
-                                    {
-                                    "title": "Master",
-                                    "value": "1.753.2000417",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "Matiz",
-                                    "value": "1.753.8093",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "Monte Carlo",
-                                    "value": "1.753.914",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "Nubira",
-                                    "value": "1.753.8096",
-                                    "total-results": 10
-                                    },
-                                    {
-                                    "title": "Regular Cab",
-                                    "value": "1.753.7542",
-                                    "total-results": 5
-                                    },
-                                    {
-                                    "title": "Silverado",
-                                    "value": "1.753.7540",
-                                    "total-results": 68
-                                    },
-                                    {
-                                    "title": "Spark",
-                                    "value": "1.753.2000179",
-                                    "total-results": 13
-                                    },
-                                    {
-                                    "title": "Starcraft",
-                                    "value": "1.753.916",
-                                    "total-results": 19
-                                    },
-                                    {
-                                    "title": "Suburban",
-                                    "value": "1.753.917",
-                                    "total-results": 49
-                                    },
-                                    {
-                                    "title": "S-10",
-                                    "value": "1.753.3733",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "Tahoe",
-                                    "value": "1.753.4338",
-                                    "total-results": 68
-                                    },
-                                    {
-                                    "title": "Trax",
-                                    "value": "1.753.2000254",
-                                    "total-results": 13
-                                    },
-                                    {
-                                    "title": "Van",
-                                    "value": "1.753.7330",
-                                    "total-results": 37
-                                    },
-                                    {
-                                    "title": "Volt",
-                                    "value": "1.753.2000182",
-                                    "total-results": 3
-                                    }
-                                    ]
-                        },
-                        "total-results": 695
-                        },
-                        {
-                        "title": "Chrysler",
-                        "value": "0.754",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Andre",
-                                    "value": "1.754.2063",
-                                    "total-results": 8
-                                    },
-                                    {
-                                    "title": "Crossfire",
-                                    "value": "1.754.7900",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "Grand Voyager",
-                                    "value": "1.754.918",
-                                    "total-results": 19
-                                    },
-                                    {
-                                    "title": "Neon",
-                                    "value": "1.754.921",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "New Yorker",
-                                    "value": "1.754.922",
-                                    "total-results": 3
-                                    },
-                                    {
-                                    "title": "Pacifica",
-                                    "value": "1.754.7946",
-                                    "total-results": 5
-                                    },
-                                    {
-                                    "title": "Prowler",
-                                    "value": "1.754.7622",
-                                    "total-results": 2
-                                    },
-                                    {
-                                    "title": "PT Cruiser",
-                                    "value": "1.754.6738",
-                                    "total-results": 5
-                                    },
-                                    {
-                                    "title": "Sebring",
-                                    "value": "1.754.7173",
-                                    "total-results": 10
-                                    },
-                                    {
-                                    "title": "Stratus",
-                                    "value": "1.754.926",
-                                    "total-results": 8
-                                    },
-                                    {
-                                    "title": "Vision",
-                                    "value": "1.754.927",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "Voyager",
-                                    "value": "1.754.928",
-                                    "total-results": 21
-                                    },
-                                    {
-                                    "title": "300C",
-                                    "value": "1.754.7945",
-                                    "total-results": 5
-                                    },
-                                    {
-                                    "title": "300 M",
-                                    "value": "1.754.7174",
-                                    "total-results": 1
-                                    }
-                                    ]
-                        },
-                        "total-results": 90
-                        },
-                        {
-                        "title": "Citroen",
-                        "value": "0.757",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Andre",
-                                    "value": "1.757.2066",
-                                    "total-results": 7
-                                    },
-                                    {
-                                    "title": "Berlingo",
-                                    "value": "1.757.3255",
-                                    "total-results": 256
-                                    },
-                                    {
-                                    "title": "Berlingo Electrique",
-                                    "value": "1.757.7768",
-                                    "total-results": 7
-                                    },
-                                    {
-                                    "title": "BX",
-                                    "value": "1.757.940",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "C1",
-                                    "value": "1.757.8237",
-                                    "total-results": 63
-                                    },
-                                    {
-                                    "title": "C2",
-                                    "value": "1.757.7793",
-                                    "total-results": 6
-                                    },
-                                    {
-                                    "title": "C3",
-                                    "value": "1.757.7521",
-                                    "total-results": 152
-                                    },
-                                    {
-                                    "title": "C3 Aircross",
-                                    "value": "1.757.2000446",
-                                    "total-results": 10
-                                    },
-                                    {
-                                    "title": "C3 Picasso",
-                                    "value": "1.757.2000116",
-                                    "total-results": 28
-                                    },
-                                    {
-                                    "title": "C4",
-                                    "value": "1.757.7986",
-                                    "total-results": 110
-                                    },
-                                    {
-                                    "title": "C4 Aircross",
-                                    "value": "1.757.2000211",
-                                    "total-results": 29
-                                    },
-                                    {
-                                    "title": "C4 Cactus",
-                                    "value": "1.757.2000292",
-                                    "total-results": 60
-                                    },
-                                    {
-                                    "title": "C4 Picasso",
-                                    "value": "1.757.1492",
-                                    "total-results": 62
-                                    },
-                                    {
-                                    "title": "C5",
-                                    "value": "1.757.7115",
-                                    "total-results": 110
-                                    },
-                                    {
-                                    "title": "C8",
-                                    "value": "1.757.7660",
-                                    "total-results": 5
-                                    },
-                                    {
-                                    "title": "C-Crosser",
-                                    "value": "1.757.8339",
-                                    "total-results": 8
-                                    },
-                                    {
-                                    "title": "C-Zero",
-                                    "value": "1.757.2000187",
-                                    "total-results": 30
-                                    },
-                                    {
-                                    "title": "DS3",
-                                    "value": "1.757.2000154",
-                                    "total-results": 72
-                                    },
-                                    {
-                                    "title": "DS4",
-                                    "value": "1.757.2000195",
-                                    "total-results": 10
-                                    },
-                                    {
-                                    "title": "DS5",
-                                    "value": "1.757.2000207",
-                                    "total-results": 27
-                                    },
-                                    {
-                                    "title": "Grand C4 Picasso",
-                                    "value": "1.757.2000080",
-                                    "total-results": 76
-                                    },
-                                    {
-                                    "title": "Jumper",
-                                    "value": "1.757.950",
-                                    "total-results": 26
-                                    },
-                                    {
-                                    "title": "Jumpy",
-                                    "value": "1.757.7517",
-                                    "total-results": 63
-                                    },
-                                    {
-                                    "title": "Saxo",
-                                    "value": "1.757.3012",
-                                    "total-results": 9
-                                    },
-                                    {
-                                    "title": "SpaceTourer",
-                                    "value": "1.757.2000434",
-                                    "total-results": 2
-                                    },
-                                    {
-                                    "title": "Xantia",
-                                    "value": "1.757.953",
-                                    "total-results": 4
-                                    },
-                                    {
-                                    "title": "XM",
-                                    "value": "1.757.954",
-                                    "total-results": 5
-                                    },
-                                    {
-                                    "title": "Xsara",
-                                    "value": "1.757.3011",
-                                    "total-results": 7
-                                    },
-                                    {
-                                    "title": "Xsara Picasso",
-                                    "value": "1.757.7861",
-                                    "total-results": 15
-                                    },
-                                    {
-                                    "title": "2CV",
-                                    "value": "1.757.937",
-                                    "total-results": 8
-                                    }
-                                    ]
-                        },
-                        "total-results": 1276
-                        },
-                        {
-                        "title": "Dacia",
-                        "value": "0.8079",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Duster",
-                                    "value": "1.8079.2000191",
-                                    "total-results": 27
-                                    }
-                                    ]
-                        },
-                        "total-results": 27
-                        },
-                        {
-                        "title": "Daewoo",
-                        "value": "0.760",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Koranda",
-                                    "value": "1.760.7760",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "Matiz",
-                                    "value": "1.760.3790",
-                                    "total-results": 2
-                                    },
-                                    {
-                                    "title": "Musso",
-                                    "value": "1.760.3789",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "Nubira",
-                                    "value": "1.760.3206",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "Tacuma",
-                                    "value": "1.760.6751",
-                                    "total-results": 2
-                                    }
-                                    ]
-                        },
-                        "total-results": 7
-                        },
-                        {
-                        "title": "DAF",
-                        "value": "0.8090",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Andre",
-                                    "value": "1.8090.2000441",
-                                    "total-results": 1
-                                    }
-                                    ]
-                        },
-                        "total-results": 1
-                        },
-                        {
-                        "title": "Daihatsu",
-                        "value": "0.762",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Copen",
-                                    "value": "1.762.2000158",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "Gran Move",
-                                    "value": "1.762.3792",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "Rocky",
-                                    "value": "1.762.975",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "Sirion",
-                                    "value": "1.762.3794",
-                                    "total-results": 4
-                                    },
-                                    {
-                                    "title": "Terios",
-                                    "value": "1.762.3795",
-                                    "total-results": 12
-                                    }
-                                    ]
-                        },
-                        "total-results": 19
-                        },
-                        {
-                        "title": "Datsun",
-                        "value": "0.8089",
-                        "total-results": 5
-                        },
-                        {
-                        "title": "De Tomaso",
-                        "value": "0.8069",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Andre",
-                                    "value": "1.8069.2000107",
-                                    "total-results": 1
-                                    }
-                                    ]
-                        },
-                        "total-results": 1
-                        },
-                        {
-                        "title": "Dodge",
-                        "value": "0.764",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Andre",
-                                    "value": "1.764.2073",
-                                    "total-results": 16
-                                    },
-                                    {
-                                    "title": "Avenger",
-                                    "value": "1.764.2000095",
-                                    "total-results": 6
-                                    },
-                                    {
-                                    "title": "Caliber",
-                                    "value": "1.764.1494",
-                                    "total-results": 13
-                                    },
-                                    {
-                                    "title": "Challenger",
-                                    "value": "1.764.2074",
-                                    "total-results": 9
-                                    },
-                                    {
-                                    "title": "Charger",
-                                    "value": "1.764.2077",
-                                    "total-results": 9
-                                    },
-                                    {
-                                    "title": "Dakota",
-                                    "value": "1.764.1001",
-                                    "total-results": 4
-                                    },
-                                    {
-                                    "title": "Durango",
-                                    "value": "1.764.3796",
-                                    "total-results": 18
-                                    },
-                                    {
-                                    "title": "Grand Caravan",
-                                    "value": "1.764.1004",
-                                    "total-results": 2
-                                    },
-                                    {
-                                    "title": "Journey",
-                                    "value": "1.764.2000089",
-                                    "total-results": 18
-                                    },
-                                    {
-                                    "title": "Magnum",
-                                    "value": "1.764.7982",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "RAM",
-                                    "value": "1.764.3797",
-                                    "total-results": 78
-                                    },
-                                    {
-                                    "title": "RAM SRT-10",
-                                    "value": "1.764.8283",
-                                    "total-results": 10
-                                    },
-                                    {
-                                    "title": "Viper",
-                                    "value": "1.764.7860",
-                                    "total-results": 7
-                                    }
-                                    ]
-                        },
-                        "total-results": 193
-                        },
-                        {
-                        "title": "DS",
-                        "value": "0.8091",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "DS 3",
-                                    "value": "1.8091.2000340",
-                                    "total-results": 5
-                                    },
-                                    {
-                                    "title": "DS 4",
-                                    "value": "1.8091.2000341",
-                                    "total-results": 3
-                                    },
-                                    {
-                                    "title": "DS 5",
-                                    "value": "1.8091.2000342",
-                                    "total-results": 5
-                                    }
-                                    ]
-                        },
-                        "total-results": 17
-                        },
-                        {
-                        "title": "Ferrari",
-                        "value": "0.2999",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Andre",
-                                    "value": "1.2999.3017",
-                                    "total-results": 2
-                                    },
-                                    {
-                                    "title": "California",
-                                    "value": "1.2999.2000151",
-                                    "total-results": 10
-                                    },
-                                    {
-                                    "title": "FF",
-                                    "value": "1.2999.2000199",
-                                    "total-results": 4
-                                    },
-                                    {
-                                    "title": "Testarossa",
-                                    "value": "1.2999.7163",
-                                    "total-results": 2
-                                    },
-                                    {
-                                    "title": "308",
-                                    "value": "1.2999.2000122",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "348",
-                                    "value": "1.2999.7162",
-                                    "total-results": 5
-                                    },
-                                    {
-                                    "title": "355",
-                                    "value": "1.2999.3801",
-                                    "total-results": 3
-                                    },
-                                    {
-                                    "title": "360",
-                                    "value": "1.2999.3800",
-                                    "total-results": 8
-                                    },
-                                    {
-                                    "title": "430",
-                                    "value": "1.2999.8330",
-                                    "total-results": 8
-                                    },
-                                    {
-                                    "title": "456",
-                                    "value": "1.2999.3799",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "458 Italia",
-                                    "value": "1.2999.2000148",
-                                    "total-results": 5
-                                    },
-                                    {
-                                    "title": "488 GTB",
-                                    "value": "1.2999.2000321",
-                                    "total-results": 3
-                                    },
-                                    {
-                                    "title": "488 Spider",
-                                    "value": "1.2999.2000351",
-                                    "total-results": 2
-                                    },
-                                    {
-                                    "title": "550 Maranello",
-                                    "value": "1.2999.3798",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "599",
-                                    "value": "1.2999.2000153",
-                                    "total-results": 2
-                                    },
-                                    {
-                                    "title": "612",
-                                    "value": "1.2999.8307",
-                                    "total-results": 1
-                                    }
-                                    ]
-                        },
-                        "total-results": 58
-                        },
-                        {
-                        "title": "Fiat",
-                        "value": "0.766",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Andre",
-                                    "value": "1.766.2075",
-                                    "total-results": 13
-                                    },
-                                    {
-                                    "title": "Barchetta",
-                                    "value": "1.766.2881",
-                                    "total-results": 5
-                                    },
-                                    {
-                                    "title": "Bravo",
-                                    "value": "1.766.3225",
-                                    "total-results": 15
-                                    },
-                                    {
-                                    "title": "Coupe",
-                                    "value": "1.766.3802",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "Croma",
-                                    "value": "1.766.1030",
-                                    "total-results": 10
-                                    },
-                                    {
-                                    "title": "Doblo",
-                                    "value": "1.766.200036",
-                                    "total-results": 101
-                                    },
-                                    {
-                                    "title": "Ducato",
-                                    "value": "1.766.1031",
-                                    "total-results": 39
-                                    },
-                                    {
-                                    "title": "Freemont",
-                                    "value": "1.766.2000201",
-                                    "total-results": 13
-                                    },
-                                    {
-                                    "title": "Fullback",
-                                    "value": "1.766.2000374",
-                                    "total-results": 9
-                                    },
-                                    {
-                                    "title": "Panda",
-                                    "value": "1.766.1033",
-                                    "total-results": 22
-                                    },
-                                    {
-                                    "title": "Punto",
-                                    "value": "1.766.1034",
-                                    "total-results": 7
-                                    },
-                                    {
-                                    "title": "Punto Evo",
-                                    "value": "1.766.2000221",
-                                    "total-results": 4
-                                    },
-                                    {
-                                    "title": "Scudo",
-                                    "value": "1.766.8323",
-                                    "total-results": 22
-                                    },
-                                    {
-                                    "title": "Sedici",
-                                    "value": "1.766.8324",
-                                    "total-results": 3
-                                    },
-                                    {
-                                    "title": "Stilo",
-                                    "value": "1.766.7465",
-                                    "total-results": 6
-                                    },
-                                    {
-                                    "title": "Strada",
-                                    "value": "1.766.2000063",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "Talento",
-                                    "value": "1.766.2000403",
-                                    "total-results": 23
-                                    },
-                                    {
-                                    "title": "Tipo",
-                                    "value": "1.766.1039",
-                                    "total-results": 14
-                                    },
-                                    {
-                                    "title": "Uno",
-                                    "value": "1.766.1040",
-                                    "total-results": 2
-                                    },
-                                    {
-                                    "title": "124 Spider",
-                                    "value": "1.766.2000411",
-                                    "total-results": 7
-                                    },
-                                    {
-                                    "title": "500",
-                                    "value": "1.766.2000071",
-                                    "total-results": 315
-                                    },
-                                    {
-                                    "title": "500L",
-                                    "value": "1.766.2000241",
-                                    "total-results": 33
-                                    },
-                                    {
-                                    "title": "500X",
-                                    "value": "1.766.2000322",
-                                    "total-results": 13
-                                    }
-                                    ]
-                        },
-                        "total-results": 692
-                        },
-                        {
-                        "title": "Fisker",
-                        "value": "0.8073",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Karma",
-                                    "value": "1.8073.2000115",
-                                    "total-results": 3
-                                    }
-                                    ]
-                        },
-                        "total-results": 3
-                        },
-                        {
-                        "title": "Ford",
-                        "value": "0.767",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Andre",
-                                    "value": "1.767.2076",
-                                    "total-results": 52
-                                    },
-                                    {
-                                    "title": "Bronco",
-                                    "value": "1.767.2850",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "B-MAX",
-                                    "value": "1.767.2000232",
-                                    "total-results": 42
-                                    },
-                                    {
-                                    "title": "Cougar",
-                                    "value": "1.767.3738",
-                                    "total-results": 3
-                                    },
-                                    {
-                                    "title": "Courier",
-                                    "value": "1.767.1050",
-                                    "total-results": 2
-                                    },
-                                    {
-                                    "title": "Custom Line",
-                                    "value": "1.767.7326",
-                                    "total-results": 4
-                                    },
-                                    {
-                                    "title": "C-Max",
-                                    "value": "1.767.7995",
-                                    "total-results": 138
-                                    },
-                                    {
-                                    "title": "Econoline",
-                                    "value": "1.767.2849",
-                                    "total-results": 17
-                                    },
-                                    {
-                                    "title": "Ecosport",
-                                    "value": "1.767.2000348",
-                                    "total-results": 41
-                                    },
-                                    {
-                                    "title": "Edge",
-                                    "value": "1.767.2000385",
-                                    "total-results": 45
-                                    },
-                                    {
-                                    "title": "Escort",
-                                    "value": "1.767.1051",
-                                    "total-results": 15
-                                    },
-                                    {
-                                    "title": "Excursion",
-                                    "value": "1.767.7109",
-                                    "total-results": 21
-                                    },
-                                    {
-                                    "title": "Expedition",
-                                    "value": "1.767.7512",
-                                    "total-results": 8
-                                    },
-                                    {
-                                    "title": "Explorer",
-                                    "value": "1.767.2848",
-                                    "total-results": 5
-                                    },
-                                    {
-                                    "title": "Fiesta",
-                                    "value": "1.767.1052",
-                                    "total-results": 433
-                                    },
-                                    {
-                                    "title": "Focus",
-                                    "value": "1.767.3739",
-                                    "total-results": 907
-                                    },
-                                    {
-                                    "title": "Fusion",
-                                    "value": "1.767.7600",
-                                    "total-results": 22
-                                    },
-                                    {
-                                    "title": "F-serie",
-                                    "value": "1.767.7160",
-                                    "total-results": 70
-                                    },
-                                    {
-                                    "title": "Galaxy",
-                                    "value": "1.767.1053",
-                                    "total-results": 135
-                                    },
-                                    {
-                                    "title": "Granada",
-                                    "value": "1.767.1054",
-                                    "total-results": 14
-                                    },
-                                    {
-                                    "title": "Grand C-MAX",
-                                    "value": "1.767.2000218",
-                                    "total-results": 27
-                                    },
-                                    {
-                                    "title": "Grand Tourneo Connect",
-                                    "value": "1.767.2000350",
-                                    "total-results": 2
-                                    },
-                                    {
-                                    "title": "Ka",
-                                    "value": "1.767.3020",
-                                    "total-results": 24
-                                    },
-                                    {
-                                    "title": "Ka+",
-                                    "value": "1.767.2000408",
-                                    "total-results": 37
-                                    },
-                                    {
-                                    "title": "Kuga",
-                                    "value": "1.767.2000084",
-                                    "total-results": 331
-                                    },
-                                    {
-                                    "title": "Maverick",
-                                    "value": "1.767.8101",
-                                    "total-results": 10
-                                    },
-                                    {
-                                    "title": "Mondeo",
-                                    "value": "1.767.1055",
-                                    "total-results": 765
-                                    },
-                                    {
-                                    "title": "Mustang",
-                                    "value": "1.767.1056",
-                                    "total-results": 101
-                                    },
-                                    {
-                                    "title": "Probe",
-                                    "value": "1.767.2855",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "Puma",
-                                    "value": "1.767.3257",
-                                    "total-results": 3
-                                    },
-                                    {
-                                    "title": "Ranger",
-                                    "value": "1.767.2854",
-                                    "total-results": 122
-                                    },
-                                    {
-                                    "title": "Scorpio",
-                                    "value": "1.767.1059",
-                                    "total-results": 3
-                                    },
-                                    {
-                                    "title": "Sierra",
-                                    "value": "1.767.1060",
-                                    "total-results": 13
-                                    },
-                                    {
-                                    "title": "SVT Lightning",
-                                    "value": "1.767.8268",
-                                    "total-results": 4
-                                    },
-                                    {
-                                    "title": "S-MAX",
-                                    "value": "1.767.1065",
-                                    "total-results": 320
-                                    },
-                                    {
-                                    "title": "Taunus",
-                                    "value": "1.767.1061",
-                                    "total-results": 16
-                                    },
-                                    {
-                                    "title": "Taurus",
-                                    "value": "1.767.2853",
-                                    "total-results": 2
-                                    },
-                                    {
-                                    "title": "Thunderbird",
-                                    "value": "1.767.2852",
-                                    "total-results": 12
-                                    },
-                                    {
-                                    "title": "Tourneo Connect",
-                                    "value": "1.767.2000290",
-                                    "total-results": 12
-                                    },
-                                    {
-                                    "title": "Tourneo Courier",
-                                    "value": "1.767.2000339",
-                                    "total-results": 5
-                                    },
-                                    {
-                                    "title": "Tourneo Custom",
-                                    "value": "1.767.2000272",
-                                    "total-results": 18
-                                    },
-                                    {
-                                    "title": "Transit",
-                                    "value": "1.767.1063",
-                                    "total-results": 186
-                                    },
-                                    {
-                                    "title": "Transit Connect",
-                                    "value": "1.767.8191",
-                                    "total-results": 262
-                                    },
-                                    {
-                                    "title": "Transit Courier",
-                                    "value": "1.767.2000310",
-                                    "total-results": 54
-                                    },
-                                    {
-                                    "title": "Transit Custom",
-                                    "value": "1.767.2000266",
-                                    "total-results": 160
-                                    }
-                                    ]
-                        },
-                        "total-results": 4476
-                        },
-                        {
-                        "title": "GMC",
-                        "value": "0.7547",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Andre",
-                                    "value": "1.7547.7556",
-                                    "total-results": 9
-                                    },
-                                    {
-                                    "title": "Sierra",
-                                    "value": "1.7547.2000251",
-                                    "total-results": 2
-                                    },
-                                    {
-                                    "title": "Syclone",
-                                    "value": "1.7547.2000286",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "Yukon",
-                                    "value": "1.7547.7551",
-                                    "total-results": 11
-                                    }
-                                    ]
-                        },
-                        "total-results": 23
-                        },
-                        {
-                        "title": "Honda",
-                        "value": "0.771",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Accord",
-                                    "value": "1.771.1087",
-                                    "total-results": 69
-                                    },
-                                    {
-                                    "title": "Andre",
-                                    "value": "1.771.2080",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "Civic",
-                                    "value": "1.771.1088",
-                                    "total-results": 219
-                                    },
-                                    {
-                                    "title": "CR-V",
-                                    "value": "1.771.3027",
-                                    "total-results": 394
-                                    },
-                                    {
-                                    "title": "CR-Z",
-                                    "value": "1.771.2000167",
-                                    "total-results": 4
-                                    },
-                                    {
-                                    "title": "Element",
-                                    "value": "1.771.8089",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "FR-V",
-                                    "value": "1.771.8088",
-                                    "total-results": 4
-                                    },
-                                    {
-                                    "title": "HR-V",
-                                    "value": "1.771.3744",
-                                    "total-results": 70
-                                    },
-                                    {
-                                    "title": "Insight",
-                                    "value": "1.771.2000117",
-                                    "total-results": 6
-                                    },
-                                    {
-                                    "title": "Integra",
-                                    "value": "1.771.2000014",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "Jazz",
-                                    "value": "1.771.7514",
-                                    "total-results": 94
-                                    },
-                                    {
-                                    "title": "Legend",
-                                    "value": "1.771.1090",
-                                    "total-results": 3
-                                    },
-                                    {
-                                    "title": "Nsx",
-                                    "value": "1.771.1091",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "Prelude",
-                                    "value": "1.771.1092",
-                                    "total-results": 10
-                                    },
-                                    {
-                                    "title": "Ridgeline",
-                                    "value": "1.771.8097",
-                                    "total-results": 6
-                                    },
-                                    {
-                                    "title": "S2000",
-                                    "value": "1.771.3803",
-                                    "total-results": 4
-                                    },
-                                    {
-                                    "title": "Shuttle",
-                                    "value": "1.771.1094",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "Stream",
-                                    "value": "1.771.2000040",
-                                    "total-results": 2
-                                    }
-                                    ]
-                        },
-                        "total-results": 892
-                        },
-                        {
-                        "title": "Hummer",
-                        "value": "0.7672",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Andre",
-                                    "value": "1.7672.7673",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "H1",
-                                    "value": "1.7672.7674",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "H2",
-                                    "value": "1.7672.7675",
-                                    "total-results": 14
-                                    },
-                                    {
-                                    "title": "H3",
-                                    "value": "1.7672.8180",
-                                    "total-results": 6
-                                    }
-                                    ]
-                        },
-                        "total-results": 22
-                        },
-                        {
-                        "title": "Hyundai",
-                        "value": "0.772",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Accent",
-                                    "value": "1.772.1095",
-                                    "total-results": 14
-                                    },
-                                    {
-                                    "title": "Andre",
-                                    "value": "1.772.2081",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "Atos",
-                                    "value": "1.772.3746",
-                                    "total-results": 6
-                                    },
-                                    {
-                                    "title": "Coupe",
-                                    "value": "1.772.3804",
-                                    "total-results": 12
-                                    },
-                                    {
-                                    "title": "Elantra",
-                                    "value": "1.772.1096",
-                                    "total-results": 6
-                                    },
-                                    {
-                                    "title": "Galloper",
-                                    "value": "1.772.7184",
-                                    "total-results": 8
-                                    },
-                                    {
-                                    "title": "Getz",
-                                    "value": "1.772.7588",
-                                    "total-results": 31
-                                    },
-                                    {
-                                    "title": "Grand Santa Fe",
-                                    "value": "1.772.2000349",
-                                    "total-results": 15
-                                    },
-                                    {
-                                    "title": "H-1",
-                                    "value": "1.772.2899",
-                                    "total-results": 45
-                                    },
-                                    {
-                                    "title": "H-100",
-                                    "value": "1.772.7108",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "i10",
-                                    "value": "1.772.2000091",
-                                    "total-results": 55
-                                    },
-                                    {
-                                    "title": "i20",
-                                    "value": "1.772.2000102",
-                                    "total-results": 160
-                                    },
-                                    {
-                                    "title": "i30",
-                                    "value": "1.772.2000069",
-                                    "total-results": 241
-                                    },
-                                    {
-                                    "title": "i40",
-                                    "value": "1.772.2000194",
-                                    "total-results": 76
-                                    },
-                                    {
-                                    "title": "Ioniq",
-                                    "value": "1.772.2000393",
-                                    "total-results": 122
-                                    },
-                                    {
-                                    "title": "ix20",
-                                    "value": "1.772.2000171",
-                                    "total-results": 33
-                                    },
-                                    {
-                                    "title": "ix35",
-                                    "value": "1.772.2000157",
-                                    "total-results": 118
-                                    },
-                                    {
-                                    "title": "ix55",
-                                    "value": "1.772.2000132",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "Kona",
-                                    "value": "1.772.2000438",
-                                    "total-results": 25
-                                    },
-                                    {
-                                    "title": "Matrix",
-                                    "value": "1.772.7178",
-                                    "total-results": 19
-                                    },
-                                    {
-                                    "title": "Santa Fe",
-                                    "value": "1.772.6739",
-                                    "total-results": 130
-                                    },
-                                    {
-                                    "title": "Sonata",
-                                    "value": "1.772.1097",
-                                    "total-results": 6
-                                    },
-                                    {
-                                    "title": "Terracan",
-                                    "value": "1.772.7246",
-                                    "total-results": 12
-                                    },
-                                    {
-                                    "title": "Trajet",
-                                    "value": "1.772.6740",
-                                    "total-results": 3
-                                    },
-                                    {
-                                    "title": "Tucson",
-                                    "value": "1.772.7951",
-                                    "total-results": 75
-                                    },
-                                    {
-                                    "title": "Veloster",
-                                    "value": "1.772.2000193",
-                                    "total-results": 7
-                                    },
-                                    {
-                                    "title": "X35",
-                                    "value": "1.772.2000155",
-                                    "total-results": 1
-                                    }
-                                    ]
-                        },
-                        "total-results": 1224
-                        },
-                        {
-                        "title": "Infiniti",
-                        "value": "0.8065",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "QX56",
-                                    "value": "1.8065.2000059",
-                                    "total-results": 1
-                                    }
-                                    ]
-                        },
-                        "total-results": 1
-                        },
-                        {
-                        "title": "Isuzu",
-                        "value": "0.7179",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "D-max",
-                                    "value": "1.7179.2000077",
-                                    "total-results": 211
-                                    }
-                                    ]
-                        },
-                        "total-results": 211
-                        },
-                        {
-                        "title": "Iveco",
-                        "value": "0.7280",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Andre",
-                                    "value": "1.7280.7296",
-                                    "total-results": 6
-                                    },
-                                    {
-                                    "title": "Daily",
-                                    "value": "1.7280.7294",
-                                    "total-results": 52
-                                    }
-                                    ]
-                        },
-                        "total-results": 62
-                        },
-                        {
-                        "title": "Jaguar",
-                        "value": "0.775",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Andre",
-                                    "value": "1.775.2084",
-                                    "total-results": 5
-                                    },
-                                    {
-                                    "title": "E-PACE",
-                                    "value": "1.775.2000432",
-                                    "total-results": 14
-                                    },
-                                    {
-                                    "title": "E-TYPE",
-                                    "value": "1.775.2000124",
-                                    "total-results": 5
-                                    },
-                                    {
-                                    "title": "F-PACE",
-                                    "value": "1.775.2000371",
-                                    "total-results": 55
-                                    },
-                                    {
-                                    "title": "F-TYPE",
-                                    "value": "1.775.2000252",
-                                    "total-results": 17
-                                    },
-                                    {
-                                    "title": "S-TYPE",
-                                    "value": "1.775.3747",
-                                    "total-results": 8
-                                    },
-                                    {
-                                    "title": "XE",
-                                    "value": "1.775.2000324",
-                                    "total-results": 21
-                                    },
-                                    {
-                                    "title": "XF",
-                                    "value": "1.775.8317",
-                                    "total-results": 57
-                                    },
-                                    {
-                                    "title": "XJ",
-                                    "value": "1.775.3806",
-                                    "total-results": 53
-                                    },
-                                    {
-                                    "title": "XJR",
-                                    "value": "1.775.2000389",
-                                    "total-results": 8
-                                    },
-                                    {
-                                    "title": "XJS",
-                                    "value": "1.775.1112",
-                                    "total-results": 6
-                                    },
-                                    {
-                                    "title": "XK",
-                                    "value": "1.775.3035",
-                                    "total-results": 33
-                                    },
-                                    {
-                                    "title": "X-TYPE",
-                                    "value": "1.775.2000042",
-                                    "total-results": 23
-                                    }
-                                    ]
-                        },
-                        "total-results": 305
-                        },
-                        {
-                        "title": "Jeep",
-                        "value": "0.776",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Andre",
-                                    "value": "1.776.2085",
-                                    "total-results": 9
-                                    },
-                                    {
-                                    "title": "Cherokee",
-                                    "value": "1.776.1113",
-                                    "total-results": 44
-                                    },
-                                    {
-                                    "title": "Commander",
-                                    "value": "1.776.1496",
-                                    "total-results": 27
-                                    },
-                                    {
-                                    "title": "Compass",
-                                    "value": "1.776.8315",
-                                    "total-results": 44
-                                    },
-                                    {
-                                    "title": "Grand Cherokee",
-                                    "value": "1.776.2143",
-                                    "total-results": 49
-                                    },
-                                    {
-                                    "title": "Patriot",
-                                    "value": "1.776.8316",
-                                    "total-results": 7
-                                    },
-                                    {
-                                    "title": "Renegade",
-                                    "value": "1.776.2000317",
-                                    "total-results": 23
-                                    },
-                                    {
-                                    "title": "Wrangler",
-                                    "value": "1.776.1116",
-                                    "total-results": 32
-                                    }
-                                    ]
-                        },
-                        "total-results": 235
-                        },
-                        {
-                        "title": "Kewet",
-                        "value": "0.7764",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "City-Jet 5",
-                                    "value": "1.7764.7766",
-                                    "total-results": 1
-                                    }
-                                    ]
-                        },
-                        "total-results": 1
-                        },
-                        {
-                        "title": "Kia",
-                        "value": "0.777",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Andre",
-                                    "value": "1.777.2086",
-                                    "total-results": 2
-                                    },
-                                    {
-                                    "title": "Carens",
-                                    "value": "1.777.7566",
-                                    "total-results": 21
-                                    },
-                                    {
-                                    "title": "Carnival",
-                                    "value": "1.777.6741",
-                                    "total-results": 9
-                                    },
-                                    {
-                                    "title": "Cee'd",
-                                    "value": "1.777.2000064",
-                                    "total-results": 199
-                                    },
-                                    {
-                                    "title": "Cerato",
-                                    "value": "1.777.8179",
-                                    "total-results": 4
-                                    },
-                                    {
-                                    "title": "Magentis",
-                                    "value": "1.777.7324",
-                                    "total-results": 4
-                                    },
-                                    {
-                                    "title": "Niro",
-                                    "value": "1.777.2000392",
-                                    "total-results": 48
-                                    },
-                                    {
-                                    "title": "Optima",
-                                    "value": "1.777.2000223",
-                                    "total-results": 54
-                                    },
-                                    {
-                                    "title": "Picanto",
-                                    "value": "1.777.8178",
-                                    "total-results": 104
-                                    },
-                                    {
-                                    "title": "Rio",
-                                    "value": "1.777.7117",
-                                    "total-results": 78
-                                    },
-                                    {
-                                    "title": "Shuma",
-                                    "value": "1.777.3808",
-                                    "total-results": 4
-                                    },
-                                    {
-                                    "title": "Sorento",
-                                    "value": "1.777.7711",
-                                    "total-results": 43
-                                    },
-                                    {
-                                    "title": "Soul",
-                                    "value": "1.777.2000300",
-                                    "total-results": 183
-                                    },
-                                    {
-                                    "title": "Sportage",
-                                    "value": "1.777.1119",
-                                    "total-results": 232
-                                    },
-                                    {
-                                    "title": "Stinger",
-                                    "value": "1.777.2000435",
-                                    "total-results": 13
-                                    },
-                                    {
-                                    "title": "Stonic",
-                                    "value": "1.777.2000433",
-                                    "total-results": 6
-                                    },
-                                    {
-                                    "title": "Venga",
-                                    "value": "1.777.2000164",
-                                    "total-results": 29
-                                    }
-                                    ]
-                        },
-                        "total-results": 1035
-                        },
-                        {
-                        "title": "Lada",
-                        "value": "0.779",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Niva",
-                                    "value": "1.779.1125",
-                                    "total-results": 4
-                                    },
-                                    {
-                                    "title": "1300",
-                                    "value": "1.779.1122",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "1500",
-                                    "value": "1.779.1123",
-                                    "total-results": 2
-                                    }
-                                    ]
-                        },
-                        "total-results": 7
-                        },
-                        {
-                        "title": "Lamborghini",
-                        "value": "0.6731",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Andre",
-                                    "value": "1.6731.7218",
-                                    "total-results": 2
-                                    },
-                                    {
-                                    "title": "Aventador",
-                                    "value": "1.6731.2000222",
-                                    "total-results": 2
-                                    },
-                                    {
-                                    "title": "Diablo",
-                                    "value": "1.6731.7879",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "Gallardo",
-                                    "value": "1.6731.2000112",
-                                    "total-results": 3
-                                    },
-                                    {
-                                    "title": "Huracan",
-                                    "value": "1.6731.2000298",
-                                    "total-results": 3
-                                    }
-                                    ]
-                        },
-                        "total-results": 12
-                        },
-                        {
-                        "title": "Lancia",
-                        "value": "0.780",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Andre",
-                                    "value": "1.780.2089",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "Delta",
-                                    "value": "1.780.1130",
-                                    "total-results": 3
-                                    },
-                                    {
-                                    "title": "Kappa",
-                                    "value": "1.780.3811",
-                                    "total-results": 2
-                                    },
-                                    {
-                                    "title": "Thema",
-                                    "value": "1.780.1132",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "Ypsilon",
-                                    "value": "1.780.2000049",
-                                    "total-results": 1
-                                    }
-                                    ]
-                        },
-                        "total-results": 8
-                        },
-                        {
-                        "title": "Land Rover",
-                        "value": "0.781",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Andre",
-                                    "value": "1.781.2090",
-                                    "total-results": 5
-                                    },
-                                    {
-                                    "title": "Defender",
-                                    "value": "1.781.6742",
-                                    "total-results": 10
-                                    },
-                                    {
-                                    "title": "Discovery",
-                                    "value": "1.781.1135",
-                                    "total-results": 150
-                                    },
-                                    {
-                                    "title": "Discovery Sport",
-                                    "value": "1.781.2000319",
-                                    "total-results": 42
-                                    },
-                                    {
-                                    "title": "Freelander",
-                                    "value": "1.781.3750",
-                                    "total-results": 44
-                                    },
-                                    {
-                                    "title": "Range Rover",
-                                    "value": "1.781.1136",
-                                    "total-results": 72
-                                    },
-                                    {
-                                    "title": "Range Rover Evoque",
-                                    "value": "1.781.2000197",
-                                    "total-results": 108
-                                    },
-                                    {
-                                    "title": "Range Rover Sport",
-                                    "value": "1.781.8265",
-                                    "total-results": 105
-                                    },
-                                    {
-                                    "title": "Range Rover Velar",
-                                    "value": "1.781.2000416",
-                                    "total-results": 44
-                                    }
-                                    ]
-                        },
-                        "total-results": 580
-                        },
-                        {
-                        "title": "Lexus",
-                        "value": "0.782",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Andre",
-                                    "value": "1.782.2091",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "CT200h",
-                                    "value": "1.782.2000186",
-                                    "total-results": 70
-                                    },
-                                    {
-                                    "title": "GS",
-                                    "value": "1.782.3040",
-                                    "total-results": 3
-                                    },
-                                    {
-                                    "title": "IS",
-                                    "value": "1.782.3812",
-                                    "total-results": 50
-                                    },
-                                    {
-                                    "title": "LC",
-                                    "value": "1.782.2000419",
-                                    "total-results": 2
-                                    },
-                                    {
-                                    "title": "LS",
-                                    "value": "1.782.1137",
-                                    "total-results": 8
-                                    },
-                                    {
-                                    "title": "NX 300h",
-                                    "value": "1.782.2000305",
-                                    "total-results": 38
-                                    },
-                                    {
-                                    "title": "RC",
-                                    "value": "1.782.2000387",
-                                    "total-results": 8
-                                    },
-                                    {
-                                    "title": "RX300",
-                                    "value": "1.782.7949",
-                                    "total-results": 4
-                                    },
-                                    {
-                                    "title": "RX400h",
-                                    "value": "1.782.2000070",
-                                    "total-results": 16
-                                    },
-                                    {
-                                    "title": "RX450h",
-                                    "value": "1.782.2000149",
-                                    "total-results": 48
-                                    }
-                                    ]
-                        },
-                        "total-results": 248
-                        },
-                        {
-                        "title": "Lincoln",
-                        "value": "0.7153",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Andre",
-                                    "value": "1.7153.7154",
-                                    "total-results": 21
-                                    },
-                                    {
-                                    "title": "Town Car",
-                                    "value": "1.7153.7152",
-                                    "total-results": 4
-                                    }
-                                    ]
-                        },
-                        "total-results": 28
-                        },
-                        {
-                        "title": "Lotus",
-                        "value": "0.7191",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Andre",
-                                    "value": "1.7191.7196",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "Elise",
-                                    "value": "1.7191.7195",
-                                    "total-results": 2
-                                    },
-                                    {
-                                    "title": "Europa S",
-                                    "value": "1.7191.2000114",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "Seven",
-                                    "value": "1.7191.7194",
-                                    "total-results": 1
-                                    }
-                                    ]
-                        },
-                        "total-results": 5
-                        },
-                        {
-                        "title": "Maserati",
-                        "value": "0.3001",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Andre",
-                                    "value": "1.3001.3041",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "Biturbo",
-                                    "value": "1.3001.7123",
-                                    "total-results": 2
-                                    },
-                                    {
-                                    "title": "Coupe",
-                                    "value": "1.3001.7712",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "Ghibli",
-                                    "value": "1.3001.7120",
-                                    "total-results": 11
-                                    },
-                                    {
-                                    "title": "GranTurismo",
-                                    "value": "1.3001.2000256",
-                                    "total-results": 8
-                                    },
-                                    {
-                                    "title": "Levante",
-                                    "value": "1.3001.2000353",
-                                    "total-results": 11
-                                    },
-                                    {
-                                    "title": "Quattroporte",
-                                    "value": "1.3001.7581",
-                                    "total-results": 9
-                                    }
-                                    ]
-                        },
-                        "total-results": 43
-                        },
-                        {
-                        "title": "Maybach",
-                        "value": "0.8082",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "57",
-                                    "value": "1.8082.2000203",
-                                    "total-results": 1
-                                    }
-                                    ]
-                        },
-                        "total-results": 1
-                        },
-                        {
-                        "title": "Mazda",
-                        "value": "0.784",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Andre",
-                                    "value": "1.784.2093",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "B2600",
-                                    "value": "1.784.1151",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "BT-50",
-                                    "value": "1.784.2000068",
-                                    "total-results": 3
-                                    },
-                                    {
-                                    "title": "B 2500 Freestyle Cab",
-                                    "value": "1.784.8238",
-                                    "total-results": 4
-                                    },
-                                    {
-                                    "title": "CX-3",
-                                    "value": "1.784.2000328",
-                                    "total-results": 68
-                                    },
-                                    {
-                                    "title": "CX-5",
-                                    "value": "1.784.2000214",
-                                    "total-results": 260
-                                    },
-                                    {
-                                    "title": "CX-7",
-                                    "value": "1.784.2000152",
-                                    "total-results": 4
-                                    },
-                                    {
-                                    "title": "Demio",
-                                    "value": "1.784.3751",
-                                    "total-results": 4
-                                    },
-                                    {
-                                    "title": "MPV",
-                                    "value": "1.784.3815",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "MX-3",
-                                    "value": "1.784.1154",
-                                    "total-results": 3
-                                    },
-                                    {
-                                    "title": "MX-5",
-                                    "value": "1.784.1155",
-                                    "total-results": 30
-                                    },
-                                    {
-                                    "title": "Premacy",
-                                    "value": "1.784.3816",
-                                    "total-results": 5
-                                    },
-                                    {
-                                    "title": "RX-2",
-                                    "value": "1.784.1157",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "RX-7",
-                                    "value": "1.784.1158",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "RX-8",
-                                    "value": "1.784.7797",
-                                    "total-results": 9
-                                    },
-                                    {
-                                    "title": "Tribute",
-                                    "value": "1.784.7114",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "Xedos",
-                                    "value": "1.784.1159",
-                                    "total-results": 4
-                                    },
-                                    {
-                                    "title": "2",
-                                    "value": "1.784.8063",
-                                    "total-results": 67
-                                    },
-                                    {
-                                    "title": "3",
-                                    "value": "1.784.7795",
-                                    "total-results": 161
-                                    },
-                                    {
-                                    "title": "5",
-                                    "value": "1.784.8147",
-                                    "total-results": 74
-                                    },
-                                    {
-                                    "title": "6",
-                                    "value": "1.784.7513",
-                                    "total-results": 305
-                                    },
-                                    {
-                                    "title": "323",
-                                    "value": "1.784.1145",
-                                    "total-results": 22
-                                    },
-                                    {
-                                    "title": "626",
-                                    "value": "1.784.1147",
-                                    "total-results": 9
-                                    },
-                                    {
-                                    "title": "929",
-                                    "value": "1.784.1149",
-                                    "total-results": 4
-                                    }
-                                    ]
-                        },
-                        "total-results": 1042
-                        },
-                        {
-                        "title": "McLaren",
-                        "value": "0.8087",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Andre",
-                                    "value": "1.8087.2000303",
-                                    "total-results": 2
-                                    },
-                                    {
-                                    "title": "12C",
-                                    "value": "1.8087.2000302",
-                                    "total-results": 2
-                                    },
-                                    {
-                                    "title": "570S",
-                                    "value": "1.8087.2000395",
-                                    "total-results": 3
-                                    }
-                                    ]
-                        },
-                        "total-results": 7
-                        },
-                        {
-                        "title": "Mercedes-Benz",
-                        "value": "0.785",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "AMG GT",
-                                    "value": "1.785.2000369",
-                                    "total-results": 17
-                                    },
-                                    {
-                                    "title": "Andre",
-                                    "value": "1.785.2094",
-                                    "total-results": 36
-                                    },
-                                    {
-                                    "title": "A-Klasse",
-                                    "value": "1.785.3777",
-                                    "total-results": 323
-                                    },
-                                    {
-                                    "title": "B-Klasse",
-                                    "value": "1.785.8111",
-                                    "total-results": 275
-                                    },
-                                    {
-                                    "title": "Citan",
-                                    "value": "1.785.2000230",
-                                    "total-results": 40
-                                    },
-                                    {
-                                    "title": "CL",
-                                    "value": "1.785.7112",
-                                    "total-results": 25
-                                    },
-                                    {
-                                    "title": "CLA",
-                                    "value": "1.785.2000250",
-                                    "total-results": 170
-                                    },
-                                    {
-                                    "title": "CLC",
-                                    "value": "1.785.2000100",
-                                    "total-results": 7
-                                    },
-                                    {
-                                    "title": "CLK",
-                                    "value": "1.785.6713",
-                                    "total-results": 71
-                                    },
-                                    {
-                                    "title": "CLS",
-                                    "value": "1.785.7960",
-                                    "total-results": 99
-                                    },
-                                    {
-                                    "title": "C-Klasse",
-                                    "value": "1.785.3776",
-                                    "total-results": 806
-                                    },
-                                    {
-                                    "title": "E-Klasse",
-                                    "value": "1.785.3775",
-                                    "total-results": 1347
-                                    },
-                                    {
-                                    "title": "E-klasse All-Terrain",
-                                    "value": "1.785.2000421",
-                                    "total-results": 10
-                                    },
-                                    {
-                                    "title": "Geländewagen",
-                                    "value": "1.785.2259",
-                                    "total-results": 126
-                                    },
-                                    {
-                                    "title": "GL",
-                                    "value": "1.785.8289",
-                                    "total-results": 107
-                                    },
-                                    {
-                                    "title": "GLA",
-                                    "value": "1.785.2000285",
-                                    "total-results": 55
-                                    },
-                                    {
-                                    "title": "GLC",
-                                    "value": "1.785.2000332",
-                                    "total-results": 157
-                                    },
-                                    {
-                                    "title": "GLE",
-                                    "value": "1.785.2000327",
-                                    "total-results": 43
-                                    },
-                                    {
-                                    "title": "GLK",
-                                    "value": "1.785.2000096",
-                                    "total-results": 63
-                                    },
-                                    {
-                                    "title": "GLS",
-                                    "value": "1.785.2000384",
-                                    "total-results": 24
-                                    },
-                                    {
-                                    "title": "M-Klasse",
-                                    "value": "1.785.3774",
-                                    "total-results": 201
-                                    },
-                                    {
-                                    "title": "R-Klasse",
-                                    "value": "1.785.8121",
-                                    "total-results": 39
-                                    },
-                                    {
-                                    "title": "SL",
-                                    "value": "1.785.7113",
-                                    "total-results": 77
-                                    },
-                                    {
-                                    "title": "SLC",
-                                    "value": "1.785.2000333",
-                                    "total-results": 11
-                                    },
-                                    {
-                                    "title": "SLK",
-                                    "value": "1.785.6712",
-                                    "total-results": 54
-                                    },
-                                    {
-                                    "title": "SLS",
-                                    "value": "1.785.2000177",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "Sprinter",
-                                    "value": "1.785.1187",
-                                    "total-results": 266
-                                    },
-                                    {
-                                    "title": "S-Klasse",
-                                    "value": "1.785.3773",
-                                    "total-results": 231
-                                    },
-                                    {
-                                    "title": "Vaneo",
-                                    "value": "1.785.7601",
-                                    "total-results": 4
-                                    },
-                                    {
-                                    "title": "Viano",
-                                    "value": "1.785.7871",
-                                    "total-results": 24
-                                    },
-                                    {
-                                    "title": "Vito",
-                                    "value": "1.785.2897",
-                                    "total-results": 258
-                                    },
-                                    {
-                                    "title": "V-Klasse",
-                                    "value": "1.785.3772",
-                                    "total-results": 25
-                                    },
-                                    {
-                                    "title": "X-Klasse",
-                                    "value": "1.785.2000422",
-                                    "total-results": 23
-                                    },
-                                    {
-                                    "title": "190",
-                                    "value": "1.785.8112",
-                                    "total-results": 22
-                                    }
-                                    ]
-                        },
-                        "total-results": 5062
-                        },
-                        {
-                        "title": "Mercury",
-                        "value": "0.7554",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Andre",
-                                    "value": "1.7554.7555",
-                                    "total-results": 10
-                                    }
-                                    ]
-                        },
-                        "total-results": 11
-                        },
-                        {
-                        "title": "MG",
-                        "value": "0.786",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Andre",
-                                    "value": "1.786.2095",
-                                    "total-results": 15
-                                    },
-                                    {
-                                    "title": "MG-F",
-                                    "value": "1.786.3817",
-                                    "total-results": 2
-                                    }
-                                    ]
-                        },
-                        "total-results": 18
-                        },
-                        {
-                        "title": "MINI",
-                        "value": "0.7147",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Cabrio",
-                                    "value": "1.7147.2000271",
-                                    "total-results": 11
-                                    },
-                                    {
-                                    "title": "Clubman",
-                                    "value": "1.7147.2000105",
-                                    "total-results": 37
-                                    },
-                                    {
-                                    "title": "Cooper",
-                                    "value": "1.7147.7150",
-                                    "total-results": 162
-                                    },
-                                    {
-                                    "title": "Cooper S",
-                                    "value": "1.7147.2000043",
-                                    "total-results": 52
-                                    },
-                                    {
-                                    "title": "Countryman",
-                                    "value": "1.7147.2000173",
-                                    "total-results": 123
-                                    },
-                                    {
-                                    "title": "Coupe",
-                                    "value": "1.7147.2000236",
-                                    "total-results": 2
-                                    },
-                                    {
-                                    "title": "One",
-                                    "value": "1.7147.7149",
-                                    "total-results": 100
-                                    },
-                                    {
-                                    "title": "Paceman",
-                                    "value": "1.7147.2000247",
-                                    "total-results": 2
-                                    },
-                                    {
-                                    "title": "Roadster",
-                                    "value": "1.7147.2000237",
-                                    "total-results": 3
-                                    },
-                                    {
-                                    "title": "3-dørs",
-                                    "value": "1.7147.2000270",
-                                    "total-results": 10
-                                    }
-                                    ]
-                        },
-                        "total-results": 502
-                        },
-                        {
-                        "title": "Mitsubishi",
-                        "value": "0.787",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Andre",
-                                    "value": "1.787.2096",
-                                    "total-results": 3
-                                    },
-                                    {
-                                    "title": "ASX",
-                                    "value": "1.787.2000165",
-                                    "total-results": 158
-                                    },
-                                    {
-                                    "title": "Carisma",
-                                    "value": "1.787.1190",
-                                    "total-results": 29
-                                    },
-                                    {
-                                    "title": "Colt",
-                                    "value": "1.787.1191",
-                                    "total-results": 97
-                                    },
-                                    {
-                                    "title": "Eclipse",
-                                    "value": "1.787.1193",
-                                    "total-results": 12
-                                    },
-                                    {
-                                    "title": "Eclipse Cross",
-                                    "value": "1.787.2000439",
-                                    "total-results": 20
-                                    },
-                                    {
-                                    "title": "Galant",
-                                    "value": "1.787.1194",
-                                    "total-results": 13
-                                    },
-                                    {
-                                    "title": "Grandis",
-                                    "value": "1.787.7994",
-                                    "total-results": 38
-                                    },
-                                    {
-                                    "title": "i-Miev",
-                                    "value": "1.787.2000181",
-                                    "total-results": 28
-                                    },
-                                    {
-                                    "title": "L200",
-                                    "value": "1.787.1195",
-                                    "total-results": 64
-                                    },
-                                    {
-                                    "title": "L300",
-                                    "value": "1.787.1196",
-                                    "total-results": 2
-                                    },
-                                    {
-                                    "title": "L400",
-                                    "value": "1.787.3046",
-                                    "total-results": 4
-                                    },
-                                    {
-                                    "title": "Lancer",
-                                    "value": "1.787.1197",
-                                    "total-results": 98
-                                    },
-                                    {
-                                    "title": "Outlander",
-                                    "value": "1.787.7713",
-                                    "total-results": 817
-                                    },
-                                    {
-                                    "title": "Pajero",
-                                    "value": "1.787.1198",
-                                    "total-results": 201
-                                    },
-                                    {
-                                    "title": "Pajero Pinin",
-                                    "value": "1.787.7992",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "Pajero Sport",
-                                    "value": "1.787.7953",
-                                    "total-results": 7
-                                    },
-                                    {
-                                    "title": "Sapporo",
-                                    "value": "1.787.1199",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "Sigma",
-                                    "value": "1.787.1200",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "Space Star",
-                                    "value": "1.787.3752",
-                                    "total-results": 67
-                                    },
-                                    {
-                                    "title": "Space Star I",
-                                    "value": "1.787.2000239",
-                                    "total-results": 9
-                                    },
-                                    {
-                                    "title": "Space Wagon",
-                                    "value": "1.787.1201",
-                                    "total-results": 9
-                                    },
-                                    {
-                                    "title": "3000 gt",
-                                    "value": "1.787.7155",
-                                    "total-results": 4
-                                    }
-                                    ]
-                        },
-                        "total-results": 1685
-                        },
-                        {
-                        "title": "Morgan",
-                        "value": "0.788",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Plus 4",
-                                    "value": "1.788.3049",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "Plus 8",
-                                    "value": "1.788.1204",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "3-wheeler",
-                                    "value": "1.788.2000258",
-                                    "total-results": 2
-                                    },
-                                    {
-                                    "title": "4/4",
-                                    "value": "1.788.7762",
-                                    "total-results": 3
-                                    }
-                                    ]
-                        },
-                        "total-results": 7
-                        },
-                        {
-                        "title": "Morris",
-                        "value": "0.789",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Andre",
-                                    "value": "1.789.2098",
-                                    "total-results": 3
-                                    }
-                                    ]
-                        },
-                        "total-results": 3
-                        },
-                        {
-                        "title": "Nissan",
-                        "value": "0.792",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Almera",
-                                    "value": "1.792.1217",
-                                    "total-results": 20
-                                    },
-                                    {
-                                    "title": "Andre",
-                                    "value": "1.792.2101",
-                                    "total-results": 5
-                                    },
-                                    {
-                                    "title": "Cherry",
-                                    "value": "1.792.1219",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "e-NV200",
-                                    "value": "1.792.2000311",
-                                    "total-results": 31
-                                    },
-                                    {
-                                    "title": "GT-R",
-                                    "value": "1.792.2000200",
-                                    "total-results": 10
-                                    },
-                                    {
-                                    "title": "Interstar",
-                                    "value": "1.792.7984",
-                                    "total-results": 6
-                                    },
-                                    {
-                                    "title": "Juke",
-                                    "value": "1.792.2000175",
-                                    "total-results": 78
-                                    },
-                                    {
-                                    "title": "King Cab",
-                                    "value": "1.792.1220",
-                                    "total-results": 25
-                                    },
-                                    {
-                                    "title": "Kubistar",
-                                    "value": "1.792.7983",
-                                    "total-results": 7
-                                    },
-                                    {
-                                    "title": "Leaf",
-                                    "value": "1.792.2000183",
-                                    "total-results": 565
-                                    },
-                                    {
-                                    "title": "Maxima",
-                                    "value": "1.792.1222",
-                                    "total-results": 6
-                                    },
-                                    {
-                                    "title": "Micra",
-                                    "value": "1.792.1223",
-                                    "total-results": 81
-                                    },
-                                    {
-                                    "title": "Murano",
-                                    "value": "1.792.2000046",
-                                    "total-results": 4
-                                    },
-                                    {
-                                    "title": "Navara",
-                                    "value": "1.792.8234",
-                                    "total-results": 122
-                                    },
-                                    {
-                                    "title": "Note",
-                                    "value": "1.792.6753",
-                                    "total-results": 71
-                                    },
-                                    {
-                                    "title": "NP300",
-                                    "value": "1.792.2000260",
-                                    "total-results": 5
-                                    },
-                                    {
-                                    "title": "NV200",
-                                    "value": "1.792.2000162",
-                                    "total-results": 38
-                                    },
-                                    {
-                                    "title": "NV300",
-                                    "value": "1.792.2000405",
-                                    "total-results": 28
-                                    },
-                                    {
-                                    "title": "NV400",
-                                    "value": "1.792.2000234",
-                                    "total-results": 10
-                                    },
-                                    {
-                                    "title": "Pathfinder",
-                                    "value": "1.792.7985",
-                                    "total-results": 59
-                                    },
-                                    {
-                                    "title": "Patrol",
-                                    "value": "1.792.1224",
-                                    "total-results": 38
-                                    },
-                                    {
-                                    "title": "Pixo",
-                                    "value": "1.792.2000161",
-                                    "total-results": 4
-                                    },
-                                    {
-                                    "title": "Primastar",
-                                    "value": "1.792.7685",
-                                    "total-results": 22
-                                    },
-                                    {
-                                    "title": "Primera",
-                                    "value": "1.792.1226",
-                                    "total-results": 64
-                                    },
-                                    {
-                                    "title": "Pulsar",
-                                    "value": "1.792.2000308",
-                                    "total-results": 39
-                                    },
-                                    {
-                                    "title": "Qashqai",
-                                    "value": "1.792.2000061",
-                                    "total-results": 583
-                                    },
-                                    {
-                                    "title": "Qashqai +2",
-                                    "value": "1.792.2000160",
-                                    "total-results": 124
-                                    },
-                                    {
-                                    "title": "Serena",
-                                    "value": "1.792.1227",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "Skyline",
-                                    "value": "1.792.8142",
-                                    "total-results": 9
-                                    },
-                                    {
-                                    "title": "Sunny",
-                                    "value": "1.792.1230",
-                                    "total-results": 4
-                                    },
-                                    {
-                                    "title": "Terrano",
-                                    "value": "1.792.1231",
-                                    "total-results": 11
-                                    },
-                                    {
-                                    "title": "Tino",
-                                    "value": "1.792.7595",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "X-Trail",
-                                    "value": "1.792.7188",
-                                    "total-results": 267
-                                    },
-                                    {
-                                    "title": "100 NX",
-                                    "value": "1.792.1214",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "200 SX",
-                                    "value": "1.792.1215",
-                                    "total-results": 21
-                                    },
-                                    {
-                                    "title": "300 ZX",
-                                    "value": "1.792.1216",
-                                    "total-results": 6
-                                    },
-                                    {
-                                    "title": "350 Z",
-                                    "value": "1.792.7950",
-                                    "total-results": 5
-                                    }
-                                    ]
-                        },
-                        "total-results": 2374
-                        },
-                        {
-                        "title": "Oldsmobile",
-                        "value": "0.794",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Andre",
-                                    "value": "1.794.2103",
-                                    "total-results": 8
-                                    },
-                                    {
-                                    "title": "Custom",
-                                    "value": "1.794.1237",
-                                    "total-results": 3
-                                    },
-                                    {
-                                    "title": "Cutlass",
-                                    "value": "1.794.1238",
-                                    "total-results": 7
-                                    },
-                                    {
-                                    "title": "Delta",
-                                    "value": "1.794.1239",
-                                    "total-results": 6
-                                    }
-                                    ]
-                        },
-                        "total-results": 24
-                        },
-                        {
-                        "title": "Opel",
-                        "value": "0.795",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "ADAM",
-                                    "value": "1.795.2000248",
-                                    "total-results": 29
-                                    },
-                                    {
-                                    "title": "Agila",
-                                    "value": "1.795.6750",
-                                    "total-results": 13
-                                    },
-                                    {
-                                    "title": "Ampera",
-                                    "value": "1.795.2000205",
-                                    "total-results": 41
-                                    },
-                                    {
-                                    "title": "Andre",
-                                    "value": "1.795.2104",
-                                    "total-results": 5
-                                    },
-                                    {
-                                    "title": "Antara",
-                                    "value": "1.795.2000065",
-                                    "total-results": 29
-                                    },
-                                    {
-                                    "title": "Ascona",
-                                    "value": "1.795.1246",
-                                    "total-results": 6
-                                    },
-                                    {
-                                    "title": "Astra",
-                                    "value": "1.795.1247",
-                                    "total-results": 534
-                                    },
-                                    {
-                                    "title": "Calibra",
-                                    "value": "1.795.1248",
-                                    "total-results": 5
-                                    },
-                                    {
-                                    "title": "Combo",
-                                    "value": "1.795.1252",
-                                    "total-results": 71
-                                    },
-                                    {
-                                    "title": "Commodore",
-                                    "value": "1.795.1253",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "Corsa",
-                                    "value": "1.795.1254",
-                                    "total-results": 209
-                                    },
-                                    {
-                                    "title": "Crossland X",
-                                    "value": "1.795.2000429",
-                                    "total-results": 10
-                                    },
-                                    {
-                                    "title": "Frontera",
-                                    "value": "1.795.1255",
-                                    "total-results": 4
-                                    },
-                                    {
-                                    "title": "Grandland X",
-                                    "value": "1.795.2000428",
-                                    "total-results": 27
-                                    },
-                                    {
-                                    "title": "GT",
-                                    "value": "1.795.2000081",
-                                    "total-results": 2
-                                    },
-                                    {
-                                    "title": "Insignia",
-                                    "value": "1.795.2000099",
-                                    "total-results": 344
-                                    },
-                                    {
-                                    "title": "Insignia Country Tourer",
-                                    "value": "1.795.2000288",
-                                    "total-results": 35
-                                    },
-                                    {
-                                    "title": "Kadett",
-                                    "value": "1.795.1259",
-                                    "total-results": 13
-                                    },
-                                    {
-                                    "title": "Manta",
-                                    "value": "1.795.1261",
-                                    "total-results": 6
-                                    },
-                                    {
-                                    "title": "Meriva",
-                                    "value": "1.795.7715",
-                                    "total-results": 83
-                                    },
-                                    {
-                                    "title": "Mokka",
-                                    "value": "1.795.2000226",
-                                    "total-results": 163
-                                    },
-                                    {
-                                    "title": "Movano",
-                                    "value": "1.795.7186",
-                                    "total-results": 16
-                                    },
-                                    {
-                                    "title": "Omega",
-                                    "value": "1.795.1264",
-                                    "total-results": 16
-                                    },
-                                    {
-                                    "title": "Rekord",
-                                    "value": "1.795.1265",
-                                    "total-results": 13
-                                    },
-                                    {
-                                    "title": "Senator",
-                                    "value": "1.795.1266",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "Signum",
-                                    "value": "1.795.7796",
-                                    "total-results": 11
-                                    },
-                                    {
-                                    "title": "Speedster",
-                                    "value": "1.795.7187",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "Tigra",
-                                    "value": "1.795.1267",
-                                    "total-results": 5
-                                    },
-                                    {
-                                    "title": "Vectra",
-                                    "value": "1.795.1268",
-                                    "total-results": 168
-                                    },
-                                    {
-                                    "title": "Vivaro",
-                                    "value": "1.795.7623",
-                                    "total-results": 125
-                                    },
-                                    {
-                                    "title": "Zafira",
-                                    "value": "1.795.3753",
-                                    "total-results": 143
-                                    },
-                                    {
-                                    "title": "Zafira Tourer",
-                                    "value": "1.795.2000274",
-                                    "total-results": 45
-                                    }
-                                    ]
-                        },
-                        "total-results": 2178
-                        },
-                        {
-                        "title": "Packard",
-                        "value": "0.8077",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Andre",
-                                    "value": "1.8077.2000249",
-                                    "total-results": 1
-                                    }
-                                    ]
-                        },
-                        "total-results": 2
-                        },
-                        {
-                        "title": "Peugeot",
-                        "value": "0.796",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Andre",
-                                    "value": "1.796.2105",
-                                    "total-results": 2
-                                    },
-                                    {
-                                    "title": "Bipper",
-                                    "value": "1.796.2000329",
-                                    "total-results": 7
-                                    },
-                                    {
-                                    "title": "Boxer",
-                                    "value": "1.796.1285",
-                                    "total-results": 40
-                                    },
-                                    {
-                                    "title": "Expert",
-                                    "value": "1.796.7621",
-                                    "total-results": 94
-                                    },
-                                    {
-                                    "title": "iOn",
-                                    "value": "1.796.2000189",
-                                    "total-results": 18
-                                    },
-                                    {
-                                    "title": "Partner",
-                                    "value": "1.796.3754",
-                                    "total-results": 235
-                                    },
-                                    {
-                                    "title": "Partner Electric",
-                                    "value": "1.796.7767",
-                                    "total-results": 3
-                                    },
-                                    {
-                                    "title": "RCZ",
-                                    "value": "1.796.2000169",
-                                    "total-results": 4
-                                    },
-                                    {
-                                    "title": "Traveller",
-                                    "value": "1.796.2000420",
-                                    "total-results": 6
-                                    },
-                                    {
-                                    "title": "106",
-                                    "value": "1.796.1270",
-                                    "total-results": 6
-                                    },
-                                    {
-                                    "title": "107",
-                                    "value": "1.796.8293",
-                                    "total-results": 31
-                                    },
-                                    {
-                                    "title": "108",
-                                    "value": "1.796.2000299",
-                                    "total-results": 20
-                                    },
-                                    {
-                                    "title": "205",
-                                    "value": "1.796.1272",
-                                    "total-results": 2
-                                    },
-                                    {
-                                    "title": "206",
-                                    "value": "1.796.3755",
-                                    "total-results": 96
-                                    },
-                                    {
-                                    "title": "206 CC",
-                                    "value": "1.796.7586",
-                                    "total-results": 5
-                                    },
-                                    {
-                                    "title": "206 SW",
-                                    "value": "1.796.7585",
-                                    "total-results": 6
-                                    },
-                                    {
-                                    "title": "207",
-                                    "value": "1.796.8294",
-                                    "total-results": 118
-                                    },
-                                    {
-                                    "title": "207 SW",
-                                    "value": "1.796.2000073",
-                                    "total-results": 9
-                                    },
-                                    {
-                                    "title": "208",
-                                    "value": "1.796.2000212",
-                                    "total-results": 147
-                                    },
-                                    {
-                                    "title": "306",
-                                    "value": "1.796.1275",
-                                    "total-results": 13
-                                    },
-                                    {
-                                    "title": "307",
-                                    "value": "1.796.7138",
-                                    "total-results": 146
-                                    },
-                                    {
-                                    "title": "307 CC",
-                                    "value": "1.796.7993",
-                                    "total-results": 3
-                                    },
-                                    {
-                                    "title": "307 SW",
-                                    "value": "1.796.7716",
-                                    "total-results": 75
-                                    },
-                                    {
-                                    "title": "308",
-                                    "value": "1.796.2000079",
-                                    "total-results": 321
-                                    },
-                                    {
-                                    "title": "308 SW",
-                                    "value": "1.796.2000101",
-                                    "total-results": 69
-                                    },
-                                    {
-                                    "title": "309",
-                                    "value": "1.796.1276",
-                                    "total-results": 2
-                                    },
-                                    {
-                                    "title": "405",
-                                    "value": "1.796.1279",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "406",
-                                    "value": "1.796.1280",
-                                    "total-results": 27
-                                    },
-                                    {
-                                    "title": "407",
-                                    "value": "1.796.7958",
-                                    "total-results": 99
-                                    },
-                                    {
-                                    "title": "508",
-                                    "value": "1.796.2000188",
-                                    "total-results": 176
-                                    },
-                                    {
-                                    "title": "605",
-                                    "value": "1.796.1284",
-                                    "total-results": 2
-                                    },
-                                    {
-                                    "title": "607",
-                                    "value": "1.796.6714",
-                                    "total-results": 10
-                                    },
-                                    {
-                                    "title": "806",
-                                    "value": "1.796.3051",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "807",
-                                    "value": "1.796.7634",
-                                    "total-results": 22
-                                    },
-                                    {
-                                    "title": "1007",
-                                    "value": "1.796.8120",
-                                    "total-results": 6
-                                    },
-                                    {
-                                    "title": "2008",
-                                    "value": "1.796.2000259",
-                                    "total-results": 92
-                                    },
-                                    {
-                                    "title": "3008",
-                                    "value": "1.796.2000131",
-                                    "total-results": 168
-                                    },
-                                    {
-                                    "title": "4007",
-                                    "value": "1.796.2000074",
-                                    "total-results": 15
-                                    },
-                                    {
-                                    "title": "4008",
-                                    "value": "1.796.2000213",
-                                    "total-results": 35
-                                    },
-                                    {
-                                    "title": "5008",
-                                    "value": "1.796.2000139",
-                                    "total-results": 121
-                                    }
-                                    ]
-                        },
-                        "total-results": 2260
-                        },
-                        {
-                        "title": "Piaggio",
-                        "value": "0.8084",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Porter",
-                                    "value": "1.8084.2000219",
-                                    "total-results": 1
-                                    }
-                                    ]
-                        },
-                        "total-results": 1
-                        },
-                        {
-                        "title": "Plymouth",
-                        "value": "0.797",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Andre",
-                                    "value": "1.797.2106",
-                                    "total-results": 9
-                                    }
-                                    ]
-                        },
-                        "total-results": 9
-                        },
-                        {
-                        "title": "Pontiac",
-                        "value": "0.800",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Andre",
-                                    "value": "1.800.2109",
-                                    "total-results": 11
-                                    },
-                                    {
-                                    "title": "Bonneville",
-                                    "value": "1.800.1294",
-                                    "total-results": 2
-                                    },
-                                    {
-                                    "title": "Firebird",
-                                    "value": "1.800.1296",
-                                    "total-results": 17
-                                    },
-                                    {
-                                    "title": "Trans Am",
-                                    "value": "1.800.1299",
-                                    "total-results": 9
-                                    }
-                                    ]
-                        },
-                        "total-results": 40
-                        },
-                        {
-                        "title": "Porsche",
-                        "value": "0.801",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Andre",
-                                    "value": "1.801.2110",
-                                    "total-results": 3
-                                    },
-                                    {
-                                    "title": "Boxster",
-                                    "value": "1.801.3756",
-                                    "total-results": 51
-                                    },
-                                    {
-                                    "title": "Cayenne",
-                                    "value": "1.801.7714",
-                                    "total-results": 198
-                                    },
-                                    {
-                                    "title": "Cayman",
-                                    "value": "1.801.2000067",
-                                    "total-results": 46
-                                    },
-                                    {
-                                    "title": "Macan",
-                                    "value": "1.801.2000276",
-                                    "total-results": 92
-                                    },
-                                    {
-                                    "title": "Panamera",
-                                    "value": "1.801.2000121",
-                                    "total-results": 181
-                                    },
-                                    {
-                                    "title": "911",
-                                    "value": "1.801.1301",
-                                    "total-results": 311
-                                    },
-                                    {
-                                    "title": "914",
-                                    "value": "1.801.7347",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "924",
-                                    "value": "1.801.1302",
-                                    "total-results": 3
-                                    },
-                                    {
-                                    "title": "928",
-                                    "value": "1.801.7342",
-                                    "total-results": 9
-                                    },
-                                    {
-                                    "title": "944",
-                                    "value": "1.801.1303",
-                                    "total-results": 13
-                                    }
-                                    ]
-                        },
-                        "total-results": 913
-                        },
-                        {
-                        "title": "Radical",
-                        "value": "0.8088",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "SR3",
-                                    "value": "1.8088.2000313",
-                                    "total-results": 1
-                                    }
-                                    ]
-                        },
-                        "total-results": 1
-                        },
-                        {
-                        "title": "Renault",
-                        "value": "0.804",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Andre",
-                                    "value": "1.804.2113",
-                                    "total-results": 11
-                                    },
-                                    {
-                                    "title": "Captur",
-                                    "value": "1.804.2000268",
-                                    "total-results": 58
-                                    },
-                                    {
-                                    "title": "Clio",
-                                    "value": "1.804.1322",
-                                    "total-results": 105
-                                    },
-                                    {
-                                    "title": "Espace",
-                                    "value": "1.804.1324",
-                                    "total-results": 4
-                                    },
-                                    {
-                                    "title": "Grand Espace",
-                                    "value": "1.804.7648",
-                                    "total-results": 12
-                                    },
-                                    {
-                                    "title": "Grand Scenic",
-                                    "value": "1.804.8172",
-                                    "total-results": 44
-                                    },
-                                    {
-                                    "title": "Kadjar",
-                                    "value": "1.804.2000326",
-                                    "total-results": 40
-                                    },
-                                    {
-                                    "title": "Kangoo",
-                                    "value": "1.804.3820",
-                                    "total-results": 59
-                                    },
-                                    {
-                                    "title": "Kangoo Electric",
-                                    "value": "1.804.7769",
-                                    "total-results": 12
-                                    },
-                                    {
-                                    "title": "Kangoo Express",
-                                    "value": "1.804.7241",
-                                    "total-results": 5
-                                    },
-                                    {
-                                    "title": "Koleos",
-                                    "value": "1.804.2000427",
-                                    "total-results": 19
-                                    },
-                                    {
-                                    "title": "Laguna",
-                                    "value": "1.804.1328",
-                                    "total-results": 38
-                                    },
-                                    {
-                                    "title": "Master",
-                                    "value": "1.804.7455",
-                                    "total-results": 39
-                                    },
-                                    {
-                                    "title": "Megane",
-                                    "value": "1.804.1331",
-                                    "total-results": 164
-                                    },
-                                    {
-                                    "title": "Megane CC",
-                                    "value": "1.804.2000078",
-                                    "total-results": 9
-                                    },
-                                    {
-                                    "title": "Modus",
-                                    "value": "1.804.8171",
-                                    "total-results": 7
-                                    },
-                                    {
-                                    "title": "Scenic",
-                                    "value": "1.804.3956",
-                                    "total-results": 34
-                                    },
-                                    {
-                                    "title": "Talisman",
-                                    "value": "1.804.2000372",
-                                    "total-results": 30
-                                    },
-                                    {
-                                    "title": "Trafic",
-                                    "value": "1.804.1332",
-                                    "total-results": 43
-                                    },
-                                    {
-                                    "title": "Twingo",
-                                    "value": "1.804.7782",
-                                    "total-results": 3
-                                    },
-                                    {
-                                    "title": "Zoe",
-                                    "value": "1.804.2000301",
-                                    "total-results": 105
-                                    },
-                                    {
-                                    "title": "5",
-                                    "value": "1.804.1319",
-                                    "total-results": 3
-                                    },
-                                    {
-                                    "title": "12",
-                                    "value": "1.804.1309",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "18",
-                                    "value": "1.804.1314",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "19",
-                                    "value": "1.804.1315",
-                                    "total-results": 1
-                                    }
-                                    ]
-                        },
-                        "total-results": 849
-                        },
-                        {
-                        "title": "Rolls Royce",
-                        "value": "0.7170",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Andre",
-                                    "value": "1.7170.7172",
-                                    "total-results": 4
-                                    },
-                                    {
-                                    "title": "Silver Shadow",
-                                    "value": "1.7170.7171",
-                                    "total-results": 6
-                                    },
-                                    {
-                                    "title": "Wraith",
-                                    "value": "1.7170.2000398",
-                                    "total-results": 1
-                                    }
-                                    ]
-                        },
-                        "total-results": 11
-                        },
-                        {
-                        "title": "Rover",
-                        "value": "0.805",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Andre",
-                                    "value": "1.805.2114",
-                                    "total-results": 4
-                                    },
-                                    {
-                                    "title": "25",
-                                    "value": "1.805.6744",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "75",
-                                    "value": "1.805.3821",
-                                    "total-results": 11
-                                    },
-                                    {
-                                    "title": "400-serie",
-                                    "value": "1.805.1333",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "600-serie",
-                                    "value": "1.805.1335",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "800-serie",
-                                    "value": "1.805.2000028",
-                                    "total-results": 1
-                                    }
-                                    ]
-                        },
-                        "total-results": 19
-                        },
-                        {
-                        "title": "Scion",
-                        "value": "0.822",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "xB",
-                                    "value": "1.822.983",
-                                    "total-results": 1
-                                    }
-                                    ]
-                        },
-                        "total-results": 1
-                        },
-                        {
-                        "title": "Seat",
-                        "value": "0.807",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Alhambra",
-                                    "value": "1.807.3825",
-                                    "total-results": 5
-                                    },
-                                    {
-                                    "title": "Andre",
-                                    "value": "1.807.2116",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "Cordoba",
-                                    "value": "1.807.1345",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "Cordoba Vario",
-                                    "value": "1.807.7175",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "Ibiza",
-                                    "value": "1.807.1346",
-                                    "total-results": 8
-                                    },
-                                    {
-                                    "title": "Leon",
-                                    "value": "1.807.6746",
-                                    "total-results": 21
-                                    },
-                                    {
-                                    "title": "Toledo",
-                                    "value": "1.807.1347",
-                                    "total-results": 5
-                                    }
-                                    ]
-                        },
-                        "total-results": 42
-                        },
-                        {
-                        "title": "Skoda",
-                        "value": "0.808",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Andre",
-                                    "value": "1.808.2117",
-                                    "total-results": 2
-                                    },
-                                    {
-                                    "title": "Citigo",
-                                    "value": "1.808.2000224",
-                                    "total-results": 38
-                                    },
-                                    {
-                                    "title": "Fabia",
-                                    "value": "1.808.6747",
-                                    "total-results": 239
-                                    },
-                                    {
-                                    "title": "Felicia",
-                                    "value": "1.808.1354",
-                                    "total-results": 2
-                                    },
-                                    {
-                                    "title": "Karoq",
-                                    "value": "1.808.2000424",
-                                    "total-results": 13
-                                    },
-                                    {
-                                    "title": "Kodiaq",
-                                    "value": "1.808.2000409",
-                                    "total-results": 33
-                                    },
-                                    {
-                                    "title": "Octavia",
-                                    "value": "1.808.1355",
-                                    "total-results": 702
-                                    },
-                                    {
-                                    "title": "Octavia RS",
-                                    "value": "1.808.2000335",
-                                    "total-results": 28
-                                    },
-                                    {
-                                    "title": "Octavia Scout",
-                                    "value": "1.808.2000336",
-                                    "total-results": 65
-                                    },
-                                    {
-                                    "title": "Pickup",
-                                    "value": "1.808.2000337",
-                                    "total-results": 5
-                                    },
-                                    {
-                                    "title": "Rapid",
-                                    "value": "1.808.2000242",
-                                    "total-results": 30
-                                    },
-                                    {
-                                    "title": "Rapid Spaceback",
-                                    "value": "1.808.2000338",
-                                    "total-results": 38
-                                    },
-                                    {
-                                    "title": "Roomster",
-                                    "value": "1.808.1490",
-                                    "total-results": 30
-                                    },
-                                    {
-                                    "title": "Superb",
-                                    "value": "1.808.7532",
-                                    "total-results": 331
-                                    },
-                                    {
-                                    "title": "Yeti",
-                                    "value": "1.808.2000128",
-                                    "total-results": 126
-                                    }
-                                    ]
-                        },
-                        "total-results": 1683
-                        },
-                        {
-                        "title": "Smart",
-                        "value": "0.7137",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Forfour",
-                                    "value": "1.7137.8190",
-                                    "total-results": 10
-                                    },
-                                    {
-                                    "title": "Fortwo",
-                                    "value": "1.7137.1483",
-                                    "total-results": 68
-                                    },
-                                    {
-                                    "title": "Fortwo cabrio",
-                                    "value": "1.7137.8189",
-                                    "total-results": 9
-                                    },
-                                    {
-                                    "title": "Fortwo coupe",
-                                    "value": "1.7137.1484",
-                                    "total-results": 22
-                                    },
-                                    {
-                                    "title": "Roadster",
-                                    "value": "1.7137.7956",
-                                    "total-results": 13
-                                    }
-                                    ]
-                        },
-                        "total-results": 125
-                        },
-                        {
-                        "title": "Ssangyong",
-                        "value": "0.7190",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Actyon Sport",
-                                    "value": "1.7190.8302",
-                                    "total-results": 9
-                                    },
-                                    {
-                                    "title": "Korando",
-                                    "value": "1.7190.7510",
-                                    "total-results": 12
-                                    },
-                                    {
-                                    "title": "Kyron",
-                                    "value": "1.7190.8301",
-                                    "total-results": 12
-                                    },
-                                    {
-                                    "title": "Rexton",
-                                    "value": "1.7190.7511",
-                                    "total-results": 94
-                                    },
-                                    {
-                                    "title": "Rexton W",
-                                    "value": "1.7190.2000316",
-                                    "total-results": 18
-                                    },
-                                    {
-                                    "title": "Rodius",
-                                    "value": "1.7190.8173",
-                                    "total-results": 15
-                                    },
-                                    {
-                                    "title": "Tivoli",
-                                    "value": "1.7190.2000343",
-                                    "total-results": 21
-                                    },
-                                    {
-                                    "title": "XLV",
-                                    "value": "1.7190.2000381",
-                                    "total-results": 14
-                                    }
-                                    ]
-                        },
-                        "total-results": 200
-                        },
-                        {
-                        "title": "Subaru",
-                        "value": "0.810",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Andre",
-                                    "value": "1.810.2119",
-                                    "total-results": 3
-                                    },
-                                    {
-                                    "title": "B9 Tribeca",
-                                    "value": "1.810.2000047",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "BRZ",
-                                    "value": "1.810.2000228",
-                                    "total-results": 2
-                                    },
-                                    {
-                                    "title": "Forester",
-                                    "value": "1.810.3655",
-                                    "total-results": 266
-                                    },
-                                    {
-                                    "title": "Impreza",
-                                    "value": "1.810.1368",
-                                    "total-results": 112
-                                    },
-                                    {
-                                    "title": "Justy",
-                                    "value": "1.810.1369",
-                                    "total-results": 23
-                                    },
-                                    {
-                                    "title": "Legacy",
-                                    "value": "1.810.1370",
-                                    "total-results": 112
-                                    },
-                                    {
-                                    "title": "Levorg",
-                                    "value": "1.810.2000344",
-                                    "total-results": 54
-                                    },
-                                    {
-                                    "title": "Outback",
-                                    "value": "1.810.7141",
-                                    "total-results": 140
-                                    },
-                                    {
-                                    "title": "Trezia",
-                                    "value": "1.810.2000196",
-                                    "total-results": 12
-                                    },
-                                    {
-                                    "title": "XV",
-                                    "value": "1.810.2000206",
-                                    "total-results": 126
-                                    }
-                                    ]
-                        },
-                        "total-results": 854
-                        },
-                        {
-                        "title": "Suzuki",
-                        "value": "0.811",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Alto",
-                                    "value": "1.811.1372",
-                                    "total-results": 9
-                                    },
-                                    {
-                                    "title": "Baleno",
-                                    "value": "1.811.1373",
-                                    "total-results": 15
-                                    },
-                                    {
-                                    "title": "Grand Vitara",
-                                    "value": "1.811.3757",
-                                    "total-results": 149
-                                    },
-                                    {
-                                    "title": "Ignis",
-                                    "value": "1.811.6748",
-                                    "total-results": 73
-                                    },
-                                    {
-                                    "title": "Kizashi",
-                                    "value": "1.811.2000146",
-                                    "total-results": 11
-                                    },
-                                    {
-                                    "title": "Liana",
-                                    "value": "1.811.7177",
-                                    "total-results": 57
-                                    },
-                                    {
-                                    "title": "SJ",
-                                    "value": "1.811.1376",
-                                    "total-results": 6
-                                    },
-                                    {
-                                    "title": "Swift",
-                                    "value": "1.811.1377",
-                                    "total-results": 189
-                                    },
-                                    {
-                                    "title": "SX4",
-                                    "value": "1.811.8269",
-                                    "total-results": 93
-                                    },
-                                    {
-                                    "title": "SX4 S-Cross",
-                                    "value": "1.811.2000284",
-                                    "total-results": 149
-                                    },
-                                    {
-                                    "title": "Vitara",
-                                    "value": "1.811.1378",
-                                    "total-results": 143
-                                    },
-                                    {
-                                    "title": "XL7",
-                                    "value": "1.811.8081",
-                                    "total-results": 39
-                                    }
-                                    ]
-                        },
-                        "total-results": 935
-                        },
-                        {
-                        "title": "Saab",
-                        "value": "0.806",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Andre",
-                                    "value": "1.806.2115",
-                                    "total-results": 6
-                                    },
-                                    {
-                                    "title": "9-3",
-                                    "value": "1.806.3224",
-                                    "total-results": 181
-                                    },
-                                    {
-                                    "title": "9-5",
-                                    "value": "1.806.3057",
-                                    "total-results": 115
-                                    },
-                                    {
-                                    "title": "99",
-                                    "value": "1.806.1341",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "900",
-                                    "value": "1.806.1339",
-                                    "total-results": 31
-                                    },
-                                    {
-                                    "title": "9000",
-                                    "value": "1.806.1340",
-                                    "total-results": 5
-                                    }
-                                    ]
-                        },
-                        "total-results": 339
-                        },
-                        {
-                        "title": "Tesla",
-                        "value": "0.8078",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Model S",
-                                    "value": "1.8078.2000138",
-                                    "total-results": 375
-                                    },
-                                    {
-                                    "title": "Model X",
-                                    "value": "1.8078.2000379",
-                                    "total-results": 95
-                                    },
-                                    {
-                                    "title": "Roadster",
-                                    "value": "1.8078.2000137",
-                                    "total-results": 2
-                                    }
-                                    ]
-                        },
-                        "total-results": 472
-                        },
-                        {
-                        "title": "Think",
-                        "value": "0.6734",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "City",
-                                    "value": "1.6734.7139",
-                                    "total-results": 4
-                                    }
-                                    ]
-                        },
-                        "total-results": 4
-                        },
-                        {
-                        "title": "Toyota",
-                        "value": "0.813",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Andre",
-                                    "value": "1.813.2122",
-                                    "total-results": 3
-                                    },
-                                    {
-                                    "title": "Auris",
-                                    "value": "1.813.2000062",
-                                    "total-results": 794
-                                    },
-                                    {
-                                    "title": "Avensis",
-                                    "value": "1.813.3252",
-                                    "total-results": 843
-                                    },
-                                    {
-                                    "title": "Avensis Verso",
-                                    "value": "1.813.7537",
-                                    "total-results": 10
-                                    },
-                                    {
-                                    "title": "Aygo",
-                                    "value": "1.813.1480",
-                                    "total-results": 108
-                                    },
-                                    {
-                                    "title": "Camry",
-                                    "value": "1.813.1386",
-                                    "total-results": 20
-                                    },
-                                    {
-                                    "title": "Carina",
-                                    "value": "1.813.1387",
-                                    "total-results": 19
-                                    },
-                                    {
-                                    "title": "Celica",
-                                    "value": "1.813.1388",
-                                    "total-results": 29
-                                    },
-                                    {
-                                    "title": "Corolla",
-                                    "value": "1.813.1389",
-                                    "total-results": 304
-                                    },
-                                    {
-                                    "title": "Corolla Verso",
-                                    "value": "1.813.8110",
-                                    "total-results": 81
-                                    },
-                                    {
-                                    "title": "Crown",
-                                    "value": "1.813.1392",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "C-HR",
-                                    "value": "1.813.2000401",
-                                    "total-results": 73
-                                    },
-                                    {
-                                    "title": "Dyna",
-                                    "value": "1.813.1393",
-                                    "total-results": 5
-                                    },
-                                    {
-                                    "title": "GT86",
-                                    "value": "1.813.2000229",
-                                    "total-results": 14
-                                    },
-                                    {
-                                    "title": "HiAce",
-                                    "value": "1.813.1394",
-                                    "total-results": 256
-                                    },
-                                    {
-                                    "title": "HiClass",
-                                    "value": "1.813.1395",
-                                    "total-results": 6
-                                    },
-                                    {
-                                    "title": "Highlander",
-                                    "value": "1.813.2000072",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "HiLux",
-                                    "value": "1.813.1396",
-                                    "total-results": 209
-                                    },
-                                    {
-                                    "title": "IQ",
-                                    "value": "1.813.2000104",
-                                    "total-results": 25
-                                    },
-                                    {
-                                    "title": "Land Cruiser",
-                                    "value": "1.813.1397",
-                                    "total-results": 378
-                                    },
-                                    {
-                                    "title": "Land Cruiser V8",
-                                    "value": "1.813.2000240",
-                                    "total-results": 12
-                                    },
-                                    {
-                                    "title": "Mirai",
-                                    "value": "1.813.2000442",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "MR2",
-                                    "value": "1.813.1398",
-                                    "total-results": 19
-                                    },
-                                    {
-                                    "title": "Picnic",
-                                    "value": "1.813.3073",
-                                    "total-results": 2
-                                    },
-                                    {
-                                    "title": "Previa",
-                                    "value": "1.813.1399",
-                                    "total-results": 18
-                                    },
-                                    {
-                                    "title": "Prius",
-                                    "value": "1.813.6749",
-                                    "total-results": 188
-                                    },
-                                    {
-                                    "title": "Prius Plug-in Hybrid",
-                                    "value": "1.813.2000426",
-                                    "total-results": 23
-                                    },
-                                    {
-                                    "title": "Prius+ Seven",
-                                    "value": "1.813.2000227",
-                                    "total-results": 89
-                                    },
-                                    {
-                                    "title": "Proace",
-                                    "value": "1.813.2000267",
-                                    "total-results": 86
-                                    },
-                                    {
-                                    "title": "Proace Verso",
-                                    "value": "1.813.2000423",
-                                    "total-results": 5
-                                    },
-                                    {
-                                    "title": "RAV4",
-                                    "value": "1.813.3074",
-                                    "total-results": 667
-                                    },
-                                    {
-                                    "title": "Starlet",
-                                    "value": "1.813.1401",
-                                    "total-results": 4
-                                    },
-                                    {
-                                    "title": "Supra",
-                                    "value": "1.813.1402",
-                                    "total-results": 10
-                                    },
-                                    {
-                                    "title": "Tercel",
-                                    "value": "1.813.1403",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "Tundra",
-                                    "value": "1.813.8256",
-                                    "total-results": 4
-                                    },
-                                    {
-                                    "title": "Urban Cruiser",
-                                    "value": "1.813.2000118",
-                                    "total-results": 79
-                                    },
-                                    {
-                                    "title": "Verso",
-                                    "value": "1.813.2000134",
-                                    "total-results": 47
-                                    },
-                                    {
-                                    "title": "Verso-S",
-                                    "value": "1.813.2000198",
-                                    "total-results": 27
-                                    },
-                                    {
-                                    "title": "Yaris",
-                                    "value": "1.813.3759",
-                                    "total-results": 621
-                                    },
-                                    {
-                                    "title": "Yaris Verso",
-                                    "value": "1.813.8109",
-                                    "total-results": 56
-                                    },
-                                    {
-                                    "title": "4-Runner",
-                                    "value": "1.813.1385",
-                                    "total-results": 11
-                                    }
-                                    ]
-                        },
-                        "total-results": 5156
-                        },
-                        {
-                        "title": "Triumph",
-                        "value": "0.814",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Andre",
-                                    "value": "1.814.8285",
-                                    "total-results": 3
-                                    },
-                                    {
-                                    "title": "Spitfire",
-                                    "value": "1.814.8284",
-                                    "total-results": 3
-                                    },
-                                    {
-                                    "title": "TR7",
-                                    "value": "1.814.2000253",
-                                    "total-results": 2
-                                    }
-                                    ]
-                        },
-                        "total-results": 9
-                        },
-                        {
-                        "title": "TVR",
-                        "value": "0.820",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Andre",
-                                    "value": "1.820.8295",
-                                    "total-results": 1
-                                    }
-                                    ]
-                        },
-                        "total-results": 1
-                        },
-                        {
-                        "title": "Volkswagen",
-                        "value": "0.817",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Amarok",
-                                    "value": "1.817.2000170",
-                                    "total-results": 132
-                                    },
-                                    {
-                                    "title": "Andre",
-                                    "value": "1.817.2126",
-                                    "total-results": 3
-                                    },
-                                    {
-                                    "title": "Arteon",
-                                    "value": "1.817.2000415",
-                                    "total-results": 41
-                                    },
-                                    {
-                                    "title": "Beetle",
-                                    "value": "1.817.3761",
-                                    "total-results": 74
-                                    },
-                                    {
-                                    "title": "Boble (gml. type)",
-                                    "value": "1.817.2781",
-                                    "total-results": 56
-                                    },
-                                    {
-                                    "title": "Bora",
-                                    "value": "1.817.3762",
-                                    "total-results": 15
-                                    },
-                                    {
-                                    "title": "Caddy",
-                                    "value": "1.817.6709",
-                                    "total-results": 444
-                                    },
-                                    {
-                                    "title": "Caddy Alltrack",
-                                    "value": "1.817.2000430",
-                                    "total-results": 8
-                                    },
-                                    {
-                                    "title": "Caddy Maxi",
-                                    "value": "1.817.2000231",
-                                    "total-results": 253
-                                    },
-                                    {
-                                    "title": "Caravelle",
-                                    "value": "1.817.1430",
-                                    "total-results": 272
-                                    },
-                                    {
-                                    "title": "CC",
-                                    "value": "1.817.2000210",
-                                    "total-results": 17
-                                    },
-                                    {
-                                    "title": "Corrado",
-                                    "value": "1.817.1431",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "Crafter",
-                                    "value": "1.817.2000048",
-                                    "total-results": 82
-                                    },
-                                    {
-                                    "title": "Eos",
-                                    "value": "1.817.8290",
-                                    "total-results": 9
-                                    },
-                                    {
-                                    "title": "Golf",
-                                    "value": "1.817.1433",
-                                    "total-results": 2506
-                                    },
-                                    {
-                                    "title": "Golf Alltrack",
-                                    "value": "1.817.2000331",
-                                    "total-results": 46
-                                    },
-                                    {
-                                    "title": "Golf Cross",
-                                    "value": "1.817.2000261",
-                                    "total-results": 7
-                                    },
-                                    {
-                                    "title": "Golf Plus",
-                                    "value": "1.817.2000235",
-                                    "total-results": 83
-                                    },
-                                    {
-                                    "title": "Golf Sportsvan",
-                                    "value": "1.817.2000297",
-                                    "total-results": 73
-                                    },
-                                    {
-                                    "title": "Jetta",
-                                    "value": "1.817.1434",
-                                    "total-results": 29
-                                    },
-                                    {
-                                    "title": "K 70",
-                                    "value": "1.817.1435",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "LT",
-                                    "value": "1.817.7650",
-                                    "total-results": 10
-                                    },
-                                    {
-                                    "title": "Lupo",
-                                    "value": "1.817.3760",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "Multivan",
-                                    "value": "1.817.7952",
-                                    "total-results": 88
-                                    },
-                                    {
-                                    "title": "Passat",
-                                    "value": "1.817.1437",
-                                    "total-results": 1248
-                                    },
-                                    {
-                                    "title": "Passat Alltrack",
-                                    "value": "1.817.2000209",
-                                    "total-results": 103
-                                    },
-                                    {
-                                    "title": "Passat CC",
-                                    "value": "1.817.2000111",
-                                    "total-results": 47
-                                    },
-                                    {
-                                    "title": "Polo",
-                                    "value": "1.817.1438",
-                                    "total-results": 504
-                                    },
-                                    {
-                                    "title": "Polo Cross",
-                                    "value": "1.817.2000388",
-                                    "total-results": 33
-                                    },
-                                    {
-                                    "title": "Santana",
-                                    "value": "1.817.1440",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "Scirocco",
-                                    "value": "1.817.1441",
-                                    "total-results": 33
-                                    },
-                                    {
-                                    "title": "Sharan",
-                                    "value": "1.817.1442",
-                                    "total-results": 112
-                                    },
-                                    {
-                                    "title": "Taro",
-                                    "value": "1.817.2000269",
-                                    "total-results": 5
-                                    },
-                                    {
-                                    "title": "Tiguan",
-                                    "value": "1.817.8329",
-                                    "total-results": 501
-                                    },
-                                    {
-                                    "title": "Tiguan Allspace",
-                                    "value": "1.817.2000444",
-                                    "total-results": 17
-                                    },
-                                    {
-                                    "title": "Touareg",
-                                    "value": "1.817.7592",
-                                    "total-results": 57
-                                    },
-                                    {
-                                    "title": "Touran",
-                                    "value": "1.817.7593",
-                                    "total-results": 586
-                                    },
-                                    {
-                                    "title": "Transporter",
-                                    "value": "1.817.1444",
-                                    "total-results": 666
-                                    },
-                                    {
-                                    "title": "T-Roc",
-                                    "value": "1.817.2000431",
-                                    "total-results": 18
-                                    },
-                                    {
-                                    "title": "UP!",
-                                    "value": "1.817.2000208",
-                                    "total-results": 214
-                                    },
-                                    {
-                                    "title": "Variant",
-                                    "value": "1.817.1445",
-                                    "total-results": 2
-                                    }
-                                    ]
-                        },
-                        "total-results": 8407
-                        },
-                        {
-                        "title": "Volvo",
-                        "value": "0.818",
-                        "filter": {
-                        "title": "Modell",
-                        "name": "model",
-                        "queries": [
-                                    {
-                                    "title": "Amazon",
-                                    "value": "1.818.2145",
-                                    "total-results": 13
-                                    },
-                                    {
-                                    "title": "Andre",
-                                    "value": "1.818.2127",
-                                    "total-results": 28
-                                    },
-                                    {
-                                    "title": "C30",
-                                    "value": "1.818.2000045",
-                                    "total-results": 70
-                                    },
-                                    {
-                                    "title": "C70",
-                                    "value": "1.818.3763",
-                                    "total-results": 19
-                                    },
-                                    {
-                                    "title": "Duett",
-                                    "value": "1.818.1478",
-                                    "total-results": 5
-                                    },
-                                    {
-                                    "title": "PV",
-                                    "value": "1.818.1479",
-                                    "total-results": 9
-                                    },
-                                    {
-                                    "title": "S40",
-                                    "value": "1.818.2784",
-                                    "total-results": 66
-                                    },
-                                    {
-                                    "title": "S60",
-                                    "value": "1.818.6718",
-                                    "total-results": 141
-                                    },
-                                    {
-                                    "title": "S60 Cross Country",
-                                    "value": "1.818.2000347",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "S70",
-                                    "value": "1.818.3083",
-                                    "total-results": 17
-                                    },
-                                    {
-                                    "title": "S80",
-                                    "value": "1.818.3769",
-                                    "total-results": 85
-                                    },
-                                    {
-                                    "title": "S90",
-                                    "value": "1.818.3768",
-                                    "total-results": 52
-                                    },
-                                    {
-                                    "title": "V40",
-                                    "value": "1.818.2783",
-                                    "total-results": 298
-                                    },
-                                    {
-                                    "title": "V40 Cross Country",
-                                    "value": "1.818.2000238",
-                                    "total-results": 190
-                                    },
-                                    {
-                                    "title": "V50",
-                                    "value": "1.818.7849",
-                                    "total-results": 342
-                                    },
-                                    {
-                                    "title": "V60",
-                                    "value": "1.818.2000172",
-                                    "total-results": 614
-                                    },
-                                    {
-                                    "title": "V60 Cross Country",
-                                    "value": "1.818.2000346",
-                                    "total-results": 26
-                                    },
-                                    {
-                                    "title": "V70",
-                                    "value": "1.818.3077",
-                                    "total-results": 708
-                                    },
-                                    {
-                                    "title": "V90",
-                                    "value": "1.818.2000386",
-                                    "total-results": 150
-                                    },
-                                    {
-                                    "title": "V90 Cross Country",
-                                    "value": "1.818.2000390",
-                                    "total-results": 57
-                                    },
-                                    {
-                                    "title": "XC 40",
-                                    "value": "1.818.2000437",
-                                    "total-results": 14
-                                    },
-                                    {
-                                    "title": "XC 60",
-                                    "value": "1.818.2000093",
-                                    "total-results": 555
-                                    },
-                                    {
-                                    "title": "XC 70",
-                                    "value": "1.818.7781",
-                                    "total-results": 378
-                                    },
-                                    {
-                                    "title": "XC 90",
-                                    "value": "1.818.7651",
-                                    "total-results": 331
-                                    },
-                                    {
-                                    "title": "142",
-                                    "value": "1.818.1450",
-                                    "total-results": 10
-                                    },
-                                    {
-                                    "title": "144",
-                                    "value": "1.818.1451",
-                                    "total-results": 4
-                                    },
-                                    {
-                                    "title": "145",
-                                    "value": "1.818.1452",
-                                    "total-results": 3
-                                    },
-                                    {
-                                    "title": "164",
-                                    "value": "1.818.1453",
-                                    "total-results": 4
-                                    },
-                                    {
-                                    "title": "240",
-                                    "value": "1.818.1456",
-                                    "total-results": 36
-                                    },
-                                    {
-                                    "title": "242",
-                                    "value": "1.818.1457",
-                                    "total-results": 9
-                                    },
-                                    {
-                                    "title": "244",
-                                    "value": "1.818.1458",
-                                    "total-results": 3
-                                    },
-                                    {
-                                    "title": "245",
-                                    "value": "1.818.1459",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "265",
-                                    "value": "1.818.1462",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "340",
-                                    "value": "1.818.1463",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "360",
-                                    "value": "1.818.1466",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "460",
-                                    "value": "1.818.1468",
-                                    "total-results": 2
-                                    },
-                                    {
-                                    "title": "740",
-                                    "value": "1.818.1472",
-                                    "total-results": 7
-                                    },
-                                    {
-                                    "title": "760",
-                                    "value": "1.818.1473",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "780",
-                                    "value": "1.818.1474",
-                                    "total-results": 1
-                                    },
-                                    {
-                                    "title": "850",
-                                    "value": "1.818.1475",
-                                    "total-results": 39
-                                    },
-                                    {
-                                    "title": "940",
-                                    "value": "1.818.1476",
-                                    "total-results": 26
-                                    },
-                                    {
-                                    "title": "960",
-                                    "value": "1.818.1477",
-                                    "total-results": 2
-                                    }
-                                    ]
-                        },
-                        "total-results": 4320
-                        }
+                {
+                    "title": "Abarth",
+                    "value": "0.8093",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "124 Spider",
+                                "value": "1.8093.2000412",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "595",
+                                "value": "1.8093.2000413",
+                                "total-results": 6
+                            }
                         ]
+                    },
+                    "total-results": 8
+                },
+                {
+                    "title": "Alfa Romeo",
+                    "value": "0.3233",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Brera",
+                                "value": "1.3233.8251",
+                                "total-results": 3
+                            },
+                            {
+                                "title": "Giulia",
+                                "value": "1.3233.2000373",
+                                "total-results": 34
+                            },
+                            {
+                                "title": "Giulietta",
+                                "value": "1.3233.3785",
+                                "total-results": 43
+                            },
+                            {
+                                "title": "GT",
+                                "value": "1.3233.8082",
+                                "total-results": 5
+                            },
+                            {
+                                "title": "GTV",
+                                "value": "1.3233.3239",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "MiTo",
+                                "value": "1.3233.2000094",
+                                "total-results": 19
+                            },
+                            {
+                                "title": "Spider",
+                                "value": "1.3233.3238",
+                                "total-results": 3
+                            },
+                            {
+                                "title": "Stelvio",
+                                "value": "1.3233.2000407",
+                                "total-results": 52
+                            },
+                            {
+                                "title": "4C",
+                                "value": "1.3233.2000289",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "147",
+                                "value": "1.3233.7176",
+                                "total-results": 11
+                            },
+                            {
+                                "title": "156",
+                                "value": "1.3233.3730",
+                                "total-results": 8
+                            },
+                            {
+                                "title": "159",
+                                "value": "1.3233.8169",
+                                "total-results": 21
+                            },
+                            {
+                                "title": "159 SportWagon",
+                                "value": "1.3233.6735",
+                                "total-results": 16
+                            },
+                            {
+                                "title": "166",
+                                "value": "1.3233.3729",
+                                "total-results": 2
+                            }
+                        ]
+                    },
+                    "total-results": 222
+                },
+                {
+                    "title": "Alpina",
+                    "value": "0.8092",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "B3",
+                                "value": "1.8092.2000357",
+                                "total-results": 3
+                            },
+                            {
+                                "title": "B4",
+                                "value": "1.8092.2000358",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "B10",
+                                "value": "1.8092.2000355",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "D3",
+                                "value": "1.8092.2000364",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "D5",
+                                "value": "1.8092.2000366",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 8
+                },
+                {
+                    "title": "Andre",
+                    "value": "0.2252",
+                    "total-results": 122
+                },
+                {
+                    "title": "Aston Martin",
+                    "value": "0.6733",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Andre",
+                                "value": "1.6733.7107",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Cygnet",
+                                "value": "1.6733.2000262",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "DB7",
+                                "value": "1.6733.8318",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "DB9",
+                                "value": "1.6733.8319",
+                                "total-results": 4
+                            },
+                            {
+                                "title": "Rapide",
+                                "value": "1.6733.2000257",
+                                "total-results": 4
+                            },
+                            {
+                                "title": "V8 Vantage",
+                                "value": "1.6733.8320",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "V12 Vantage",
+                                "value": "1.6733.2000345",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Vanquish",
+                                "value": "1.6733.8321",
+                                "total-results": 2
+                            }
+                        ]
+                    },
+                    "total-results": 19
+                },
+                {
+                    "title": "Audi",
+                    "value": "0.744",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "A1",
+                                "value": "1.744.2000166",
+                                "total-results": 204
+                            },
+                            {
+                                "title": "A2",
+                                "value": "1.744.6720",
+                                "total-results": 14
+                            },
+                            {
+                                "title": "A3",
+                                "value": "1.744.2046",
+                                "total-results": 790
+                            },
+                            {
+                                "title": "A4",
+                                "value": "1.744.839",
+                                "total-results": 680
+                            },
+                            {
+                                "title": "A4 allroad",
+                                "value": "1.744.2000140",
+                                "total-results": 184
+                            },
+                            {
+                                "title": "A5",
+                                "value": "1.744.8314",
+                                "total-results": 212
+                            },
+                            {
+                                "title": "A6",
+                                "value": "1.744.840",
+                                "total-results": 506
+                            },
+                            {
+                                "title": "A6 allroad",
+                                "value": "1.744.6736",
+                                "total-results": 177
+                            },
+                            {
+                                "title": "A7",
+                                "value": "1.744.2000174",
+                                "total-results": 76
+                            },
+                            {
+                                "title": "A8",
+                                "value": "1.744.841",
+                                "total-results": 109
+                            },
+                            {
+                                "title": "Andre",
+                                "value": "1.744.2053",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "Q2",
+                                "value": "1.744.2000400",
+                                "total-results": 23
+                            },
+                            {
+                                "title": "Q3",
+                                "value": "1.744.2000190",
+                                "total-results": 96
+                            },
+                            {
+                                "title": "Q5",
+                                "value": "1.744.2000097",
+                                "total-results": 364
+                            },
+                            {
+                                "title": "Q7",
+                                "value": "1.744.8149",
+                                "total-results": 130
+                            },
+                            {
+                                "title": "Q8",
+                                "value": "1.744.2000455",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "R8",
+                                "value": "1.744.8340",
+                                "total-results": 24
+                            },
+                            {
+                                "title": "RS3",
+                                "value": "1.744.2000184",
+                                "total-results": 11
+                            },
+                            {
+                                "title": "RS4",
+                                "value": "1.744.6721",
+                                "total-results": 16
+                            },
+                            {
+                                "title": "RS5",
+                                "value": "1.744.2000185",
+                                "total-results": 6
+                            },
+                            {
+                                "title": "RS6",
+                                "value": "1.744.7709",
+                                "total-results": 48
+                            },
+                            {
+                                "title": "RS7",
+                                "value": "1.744.2000291",
+                                "total-results": 4
+                            },
+                            {
+                                "title": "S2",
+                                "value": "1.744.7557",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "S3",
+                                "value": "1.744.3731",
+                                "total-results": 30
+                            },
+                            {
+                                "title": "S4",
+                                "value": "1.744.2891",
+                                "total-results": 18
+                            },
+                            {
+                                "title": "S5",
+                                "value": "1.744.2000082",
+                                "total-results": 12
+                            },
+                            {
+                                "title": "S6",
+                                "value": "1.744.843",
+                                "total-results": 14
+                            },
+                            {
+                                "title": "S7",
+                                "value": "1.744.2000246",
+                                "total-results": 3
+                            },
+                            {
+                                "title": "S8",
+                                "value": "1.744.3786",
+                                "total-results": 24
+                            },
+                            {
+                                "title": "SQ5",
+                                "value": "1.744.2000296",
+                                "total-results": 7
+                            },
+                            {
+                                "title": "SQ7",
+                                "value": "1.744.2000402",
+                                "total-results": 3
+                            },
+                            {
+                                "title": "TT",
+                                "value": "1.744.3732",
+                                "total-results": 80
+                            },
+                            {
+                                "title": "V8",
+                                "value": "1.744.8313",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "80",
+                                "value": "1.744.837",
+                                "total-results": 7
+                            },
+                            {
+                                "title": "90",
+                                "value": "1.744.838",
+                                "total-results": 3
+                            },
+                            {
+                                "title": "100",
+                                "value": "1.744.833",
+                                "total-results": 6
+                            },
+                            {
+                                "title": "200",
+                                "value": "1.744.834",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 3902
+                },
+                {
+                    "title": "Austin",
+                    "value": "0.8076",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Andre",
+                                "value": "1.8076.2000180",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "Healey 100 6",
+                                "value": "1.8076.2000323",
+                                "total-results": 2
+                            }
+                        ]
+                    },
+                    "total-results": 4
+                },
+                {
+                    "title": "Bentley",
+                    "value": "0.7166",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Andre",
+                                "value": "1.7166.7169",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "Bentayga",
+                                "value": "1.7166.2000397",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Continental",
+                                "value": "1.7166.7168",
+                                "total-results": 17
+                            },
+                            {
+                                "title": "Flying Spur",
+                                "value": "1.7166.2000325",
+                                "total-results": 3
+                            }
+                        ]
+                    },
+                    "total-results": 24
+                },
+                {
+                    "title": "BMW",
+                    "value": "0.749",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Andre",
+                                "value": "1.749.2058",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "i3",
+                                "value": "1.749.2000264",
+                                "total-results": 864
+                            },
+                            {
+                                "title": "i8",
+                                "value": "1.749.2000309",
+                                "total-results": 18
+                            },
+                            {
+                                "title": "M2",
+                                "value": "1.749.2000370",
+                                "total-results": 21
+                            },
+                            {
+                                "title": "M3",
+                                "value": "1.749.893",
+                                "total-results": 44
+                            },
+                            {
+                                "title": "M4",
+                                "value": "1.749.2000295",
+                                "total-results": 29
+                            },
+                            {
+                                "title": "M5",
+                                "value": "1.749.2133",
+                                "total-results": 43
+                            },
+                            {
+                                "title": "M6",
+                                "value": "1.749.8288",
+                                "total-results": 10
+                            },
+                            {
+                                "title": "X1",
+                                "value": "1.749.2000133",
+                                "total-results": 202
+                            },
+                            {
+                                "title": "X2",
+                                "value": "1.749.2000440",
+                                "total-results": 47
+                            },
+                            {
+                                "title": "X3",
+                                "value": "1.749.7798",
+                                "total-results": 415
+                            },
+                            {
+                                "title": "X4",
+                                "value": "1.749.2000294",
+                                "total-results": 85
+                            },
+                            {
+                                "title": "X5",
+                                "value": "1.749.6737",
+                                "total-results": 493
+                            },
+                            {
+                                "title": "X6",
+                                "value": "1.749.2000085",
+                                "total-results": 63
+                            },
+                            {
+                                "title": "Z3",
+                                "value": "1.749.3003",
+                                "total-results": 5
+                            },
+                            {
+                                "title": "Z4",
+                                "value": "1.749.7683",
+                                "total-results": 9
+                            },
+                            {
+                                "title": "1M",
+                                "value": "1.749.2000204",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "1-serie",
+                                "value": "1.749.7967",
+                                "total-results": 435
+                            },
+                            {
+                                "title": "2-serie",
+                                "value": "1.749.2000283",
+                                "total-results": 323
+                            },
+                            {
+                                "title": "3-serie",
+                                "value": "1.749.2132",
+                                "total-results": 1112
+                            },
+                            {
+                                "title": "4-serie",
+                                "value": "1.749.2000265",
+                                "total-results": 108
+                            },
+                            {
+                                "title": "5-serie",
+                                "value": "1.749.2131",
+                                "total-results": 1161
+                            },
+                            {
+                                "title": "6-serie",
+                                "value": "1.749.3004",
+                                "total-results": 70
+                            },
+                            {
+                                "title": "7-serie",
+                                "value": "1.749.2130",
+                                "total-results": 145
+                            },
+                            {
+                                "title": "8-serie",
+                                "value": "1.749.2129",
+                                "total-results": 4
+                            },
+                            {
+                                "title": "1502",
+                                "value": "1.749.863",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "1800",
+                                "value": "1.749.866",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "2002",
+                                "value": "1.749.868",
+                                "total-results": 2
+                            }
+                        ]
+                    },
+                    "total-results": 5723
+                },
+                {
+                    "title": "Buddy",
+                    "value": "0.8066",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Basic",
+                                "value": "1.8066.2000141",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 1
+                },
+                {
+                    "title": "Buick",
+                    "value": "0.750",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Andre",
+                                "value": "1.750.2059",
+                                "total-results": 5
+                            },
+                            {
+                                "title": "Century",
+                                "value": "1.750.894",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Le Sabre",
+                                "value": "1.750.895",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "Skylark",
+                                "value": "1.750.898",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 11
+                },
+                {
+                    "title": "Cadillac",
+                    "value": "0.752",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Andre",
+                                "value": "1.752.2061",
+                                "total-results": 13
+                            },
+                            {
+                                "title": "BLS",
+                                "value": "1.752.979",
+                                "total-results": 3
+                            },
+                            {
+                                "title": "CTS",
+                                "value": "1.752.7987",
+                                "total-results": 3
+                            },
+                            {
+                                "title": "Deville",
+                                "value": "1.752.900",
+                                "total-results": 12
+                            },
+                            {
+                                "title": "Eldorado",
+                                "value": "1.752.2000168",
+                                "total-results": 6
+                            },
+                            {
+                                "title": "Escalade",
+                                "value": "1.752.7670",
+                                "total-results": 8
+                            },
+                            {
+                                "title": "Seville",
+                                "value": "1.752.3787",
+                                "total-results": 5
+                            },
+                            {
+                                "title": "SRX",
+                                "value": "1.752.7988",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "XLR",
+                                "value": "1.752.2000103",
+                                "total-results": 2
+                            }
+                        ]
+                    },
+                    "total-results": 57
+                },
+                {
+                    "title": "Chevrolet",
+                    "value": "0.753",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Alero",
+                                "value": "1.753.3736",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Andre",
+                                "value": "1.753.2062",
+                                "total-results": 11
+                            },
+                            {
+                                "title": "Astro",
+                                "value": "1.753.901",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "Avalanche",
+                                "value": "1.753.7539",
+                                "total-results": 8
+                            },
+                            {
+                                "title": "Aveo",
+                                "value": "1.753.2000098",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "Beauville",
+                                "value": "1.753.902",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Bel Air",
+                                "value": "1.753.2000406",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "Big Dooley",
+                                "value": "1.753.7624",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Blazer",
+                                "value": "1.753.904",
+                                "total-results": 8
+                            },
+                            {
+                                "title": "Bolt",
+                                "value": "1.753.2000410",
+                                "total-results": 43
+                            },
+                            {
+                                "title": "Camaro",
+                                "value": "1.753.905",
+                                "total-results": 33
+                            },
+                            {
+                                "title": "Captiva",
+                                "value": "1.753.1486",
+                                "total-results": 16
+                            },
+                            {
+                                "title": "Cargovan",
+                                "value": "1.753.2000053",
+                                "total-results": 3
+                            },
+                            {
+                                "title": "Chevelle",
+                                "value": "1.753.3864",
+                                "total-results": 4
+                            },
+                            {
+                                "title": "Cheyenne",
+                                "value": "1.753.2000394",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Colorado",
+                                "value": "1.753.3828",
+                                "total-results": 6
+                            },
+                            {
+                                "title": "Corvette",
+                                "value": "1.753.912",
+                                "total-results": 93
+                            },
+                            {
+                                "title": "Cruze",
+                                "value": "1.753.2000233",
+                                "total-results": 6
+                            },
+                            {
+                                "title": "C-10",
+                                "value": "1.753.2000263",
+                                "total-results": 11
+                            },
+                            {
+                                "title": "El Camino",
+                                "value": "1.753.3862",
+                                "total-results": 6
+                            },
+                            {
+                                "title": "Epica",
+                                "value": "1.753.2000044",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "Express",
+                                "value": "1.753.2000287",
+                                "total-results": 6
+                            },
+                            {
+                                "title": "Extended Cab",
+                                "value": "1.753.7329",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Impala",
+                                "value": "1.753.3860",
+                                "total-results": 6
+                            },
+                            {
+                                "title": "Kalos",
+                                "value": "1.753.8094",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "Lacetti",
+                                "value": "1.753.8095",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Master",
+                                "value": "1.753.2000417",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Matiz",
+                                "value": "1.753.8093",
+                                "total-results": 3
+                            },
+                            {
+                                "title": "Nubira",
+                                "value": "1.753.8096",
+                                "total-results": 11
+                            },
+                            {
+                                "title": "Regular Cab",
+                                "value": "1.753.7542",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Silverado",
+                                "value": "1.753.7540",
+                                "total-results": 69
+                            },
+                            {
+                                "title": "Spark",
+                                "value": "1.753.2000179",
+                                "total-results": 12
+                            },
+                            {
+                                "title": "Starcraft",
+                                "value": "1.753.916",
+                                "total-results": 9
+                            },
+                            {
+                                "title": "Suburban",
+                                "value": "1.753.917",
+                                "total-results": 36
+                            },
+                            {
+                                "title": "Tahoe",
+                                "value": "1.753.4338",
+                                "total-results": 72
+                            },
+                            {
+                                "title": "Trax",
+                                "value": "1.753.2000254",
+                                "total-results": 11
+                            },
+                            {
+                                "title": "Van",
+                                "value": "1.753.7330",
+                                "total-results": 11
+                            }
+                        ]
+                    },
+                    "total-results": 514
+                },
+                {
+                    "title": "Chrysler",
+                    "value": "0.754",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Andre",
+                                "value": "1.754.2063",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Grand Voyager",
+                                "value": "1.754.918",
+                                "total-results": 11
+                            },
+                            {
+                                "title": "Neon",
+                                "value": "1.754.921",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "New Yorker",
+                                "value": "1.754.922",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Pacifica",
+                                "value": "1.754.7946",
+                                "total-results": 7
+                            },
+                            {
+                                "title": "Prowler",
+                                "value": "1.754.7622",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "PT Cruiser",
+                                "value": "1.754.6738",
+                                "total-results": 6
+                            },
+                            {
+                                "title": "Sebring",
+                                "value": "1.754.7173",
+                                "total-results": 4
+                            },
+                            {
+                                "title": "Stratus",
+                                "value": "1.754.926",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "Voyager",
+                                "value": "1.754.928",
+                                "total-results": 11
+                            },
+                            {
+                                "title": "300C",
+                                "value": "1.754.7945",
+                                "total-results": 3
+                            }
+                        ]
+                    },
+                    "total-results": 50
+                },
+                {
+                    "title": "Citroen",
+                    "value": "0.757",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Andre",
+                                "value": "1.757.2066",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "Berlingo",
+                                "value": "1.757.3255",
+                                "total-results": 273
+                            },
+                            {
+                                "title": "Berlingo Electrique",
+                                "value": "1.757.7768",
+                                "total-results": 4
+                            },
+                            {
+                                "title": "C1",
+                                "value": "1.757.8237",
+                                "total-results": 47
+                            },
+                            {
+                                "title": "C2",
+                                "value": "1.757.7793",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "C3",
+                                "value": "1.757.7521",
+                                "total-results": 143
+                            },
+                            {
+                                "title": "C3 Aircross",
+                                "value": "1.757.2000446",
+                                "total-results": 29
+                            },
+                            {
+                                "title": "C3 Picasso",
+                                "value": "1.757.2000116",
+                                "total-results": 20
+                            },
+                            {
+                                "title": "C4",
+                                "value": "1.757.7986",
+                                "total-results": 75
+                            },
+                            {
+                                "title": "C4 Aircross",
+                                "value": "1.757.2000211",
+                                "total-results": 16
+                            },
+                            {
+                                "title": "C4 Cactus",
+                                "value": "1.757.2000292",
+                                "total-results": 120
+                            },
+                            {
+                                "title": "C4 Picasso",
+                                "value": "1.757.1492",
+                                "total-results": 53
+                            },
+                            {
+                                "title": "C5",
+                                "value": "1.757.7115",
+                                "total-results": 77
+                            },
+                            {
+                                "title": "C8",
+                                "value": "1.757.7660",
+                                "total-results": 7
+                            },
+                            {
+                                "title": "CX",
+                                "value": "1.757.943",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "C-Crosser",
+                                "value": "1.757.8339",
+                                "total-results": 9
+                            },
+                            {
+                                "title": "C-Zero",
+                                "value": "1.757.2000187",
+                                "total-results": 55
+                            },
+                            {
+                                "title": "DS3",
+                                "value": "1.757.2000154",
+                                "total-results": 64
+                            },
+                            {
+                                "title": "DS4",
+                                "value": "1.757.2000195",
+                                "total-results": 12
+                            },
+                            {
+                                "title": "DS5",
+                                "value": "1.757.2000207",
+                                "total-results": 26
+                            },
+                            {
+                                "title": "Evasion",
+                                "value": "1.757.3010",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Grand C4 Picasso",
+                                "value": "1.757.2000080",
+                                "total-results": 102
+                            },
+                            {
+                                "title": "Grand C4 Spacetourer",
+                                "value": "1.757.2000449",
+                                "total-results": 4
+                            },
+                            {
+                                "title": "Jumper",
+                                "value": "1.757.950",
+                                "total-results": 29
+                            },
+                            {
+                                "title": "Jumpy",
+                                "value": "1.757.7517",
+                                "total-results": 91
+                            },
+                            {
+                                "title": "Saxo",
+                                "value": "1.757.3012",
+                                "total-results": 4
+                            },
+                            {
+                                "title": "SpaceTourer",
+                                "value": "1.757.2000434",
+                                "total-results": 4
+                            },
+                            {
+                                "title": "Xantia",
+                                "value": "1.757.953",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "XM",
+                                "value": "1.757.954",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "Xsara",
+                                "value": "1.757.3011",
+                                "total-results": 6
+                            },
+                            {
+                                "title": "Xsara Picasso",
+                                "value": "1.757.7861",
+                                "total-results": 14
+                            },
+                            {
+                                "title": "2CV",
+                                "value": "1.757.937",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 1300
+                },
+                {
+                    "title": "Dacia",
+                    "value": "0.8079",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Andre",
+                                "value": "1.8079.2000245",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Duster",
+                                "value": "1.8079.2000191",
+                                "total-results": 22
+                            }
+                        ]
+                    },
+                    "total-results": 23
+                },
+                {
+                    "title": "Daewoo",
+                    "value": "0.760",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Kalos",
+                                "value": "1.760.7991",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Matiz",
+                                "value": "1.760.3790",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Nexia",
+                                "value": "1.760.965",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Nubira",
+                                "value": "1.760.3206",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Tacuma",
+                                "value": "1.760.6751",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 5
+                },
+                {
+                    "title": "Daihatsu",
+                    "value": "0.762",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Sirion",
+                                "value": "1.762.3794",
+                                "total-results": 3
+                            },
+                            {
+                                "title": "Terios",
+                                "value": "1.762.3795",
+                                "total-results": 7
+                            }
+                        ]
+                    },
+                    "total-results": 10
+                },
+                {
+                    "title": "Datsun",
+                    "value": "0.8089",
+                    "total-results": 1
+                },
+                {
+                    "title": "De Tomaso",
+                    "value": "0.8069",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Pantera",
+                                "value": "1.8069.2000106",
+                                "total-results": 3
+                            }
+                        ]
+                    },
+                    "total-results": 3
+                },
+                {
+                    "title": "Dodge",
+                    "value": "0.764",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Andre",
+                                "value": "1.764.2073",
+                                "total-results": 4
+                            },
+                            {
+                                "title": "Avenger",
+                                "value": "1.764.2000095",
+                                "total-results": 4
+                            },
+                            {
+                                "title": "Caliber",
+                                "value": "1.764.1494",
+                                "total-results": 7
+                            },
+                            {
+                                "title": "Challenger",
+                                "value": "1.764.2074",
+                                "total-results": 10
+                            },
+                            {
+                                "title": "Charger",
+                                "value": "1.764.2077",
+                                "total-results": 3
+                            },
+                            {
+                                "title": "Dakota",
+                                "value": "1.764.1001",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Durango",
+                                "value": "1.764.3796",
+                                "total-results": 11
+                            },
+                            {
+                                "title": "Journey",
+                                "value": "1.764.2000089",
+                                "total-results": 11
+                            },
+                            {
+                                "title": "Magnum",
+                                "value": "1.764.7982",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "RAM",
+                                "value": "1.764.3797",
+                                "total-results": 70
+                            },
+                            {
+                                "title": "RAM SRT-10",
+                                "value": "1.764.8283",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Viper",
+                                "value": "1.764.7860",
+                                "total-results": 7
+                            }
+                        ]
+                    },
+                    "total-results": 130
+                },
+                {
+                    "title": "DS",
+                    "value": "0.8091",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "DS 3",
+                                "value": "1.8091.2000340",
+                                "total-results": 5
+                            },
+                            {
+                                "title": "DS 4",
+                                "value": "1.8091.2000341",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "DS 5",
+                                "value": "1.8091.2000342",
+                                "total-results": 4
+                            },
+                            {
+                                "title": "DS 7 Crossback",
+                                "value": "1.8091.2000443",
+                                "total-results": 8
+                            }
+                        ]
+                    },
+                    "total-results": 19
+                },
+                {
+                    "title": "Ferrari",
+                    "value": "0.2999",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "California",
+                                "value": "1.2999.2000151",
+                                "total-results": 6
+                            },
+                            {
+                                "title": "FF",
+                                "value": "1.2999.2000199",
+                                "total-results": 7
+                            },
+                            {
+                                "title": "GTC4Lusso",
+                                "value": "1.2999.2000450",
+                                "total-results": 3
+                            },
+                            {
+                                "title": "348",
+                                "value": "1.2999.7162",
+                                "total-results": 4
+                            },
+                            {
+                                "title": "355",
+                                "value": "1.2999.3801",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "360",
+                                "value": "1.2999.3800",
+                                "total-results": 7
+                            },
+                            {
+                                "title": "430",
+                                "value": "1.2999.8330",
+                                "total-results": 6
+                            },
+                            {
+                                "title": "456",
+                                "value": "1.2999.3799",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "458 Italia",
+                                "value": "1.2999.2000148",
+                                "total-results": 3
+                            },
+                            {
+                                "title": "458 Spider",
+                                "value": "1.2999.2000306",
+                                "total-results": 4
+                            },
+                            {
+                                "title": "488 GTB",
+                                "value": "1.2999.2000321",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "488 Spider",
+                                "value": "1.2999.2000351",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "599",
+                                "value": "1.2999.2000153",
+                                "total-results": 3
+                            },
+                            {
+                                "title": "812 Superfast",
+                                "value": "1.2999.2000458",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 49
+                },
+                {
+                    "title": "Fiat",
+                    "value": "0.766",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Andre",
+                                "value": "1.766.2075",
+                                "total-results": 3
+                            },
+                            {
+                                "title": "Bravo",
+                                "value": "1.766.3225",
+                                "total-results": 10
+                            },
+                            {
+                                "title": "Croma",
+                                "value": "1.766.1030",
+                                "total-results": 14
+                            },
+                            {
+                                "title": "Doblo",
+                                "value": "1.766.200036",
+                                "total-results": 130
+                            },
+                            {
+                                "title": "Ducato",
+                                "value": "1.766.1031",
+                                "total-results": 38
+                            },
+                            {
+                                "title": "Freemont",
+                                "value": "1.766.2000201",
+                                "total-results": 14
+                            },
+                            {
+                                "title": "Fullback",
+                                "value": "1.766.2000374",
+                                "total-results": 11
+                            },
+                            {
+                                "title": "Grande Punto",
+                                "value": "1.766.8325",
+                                "total-results": 5
+                            },
+                            {
+                                "title": "Panda",
+                                "value": "1.766.1033",
+                                "total-results": 17
+                            },
+                            {
+                                "title": "Punto",
+                                "value": "1.766.1034",
+                                "total-results": 7
+                            },
+                            {
+                                "title": "Punto Evo",
+                                "value": "1.766.2000221",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "Scudo",
+                                "value": "1.766.8323",
+                                "total-results": 34
+                            },
+                            {
+                                "title": "Sedici",
+                                "value": "1.766.8324",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "Stilo",
+                                "value": "1.766.7465",
+                                "total-results": 3
+                            },
+                            {
+                                "title": "Strada",
+                                "value": "1.766.2000063",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "Talento",
+                                "value": "1.766.2000403",
+                                "total-results": 25
+                            },
+                            {
+                                "title": "Tipo",
+                                "value": "1.766.1039",
+                                "total-results": 9
+                            },
+                            {
+                                "title": "124 Spider",
+                                "value": "1.766.2000411",
+                                "total-results": 7
+                            },
+                            {
+                                "title": "500",
+                                "value": "1.766.2000071",
+                                "total-results": 456
+                            },
+                            {
+                                "title": "500L",
+                                "value": "1.766.2000241",
+                                "total-results": 25
+                            },
+                            {
+                                "title": "500X",
+                                "value": "1.766.2000322",
+                                "total-results": 30
+                            }
+                        ]
+                    },
+                    "total-results": 844
+                },
+                {
+                    "title": "Fisker",
+                    "value": "0.8073",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Karma",
+                                "value": "1.8073.2000115",
+                                "total-results": 2
+                            }
+                        ]
+                    },
+                    "total-results": 2
+                },
+                {
+                    "title": "Ford",
+                    "value": "0.767",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Andre",
+                                "value": "1.767.2076",
+                                "total-results": 26
+                            },
+                            {
+                                "title": "Bronco",
+                                "value": "1.767.2850",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "B-MAX",
+                                "value": "1.767.2000232",
+                                "total-results": 41
+                            },
+                            {
+                                "title": "Courier",
+                                "value": "1.767.1050",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "Custom Line",
+                                "value": "1.767.7326",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "C-Max",
+                                "value": "1.767.7995",
+                                "total-results": 138
+                            },
+                            {
+                                "title": "Econoline",
+                                "value": "1.767.2849",
+                                "total-results": 8
+                            },
+                            {
+                                "title": "Ecosport",
+                                "value": "1.767.2000348",
+                                "total-results": 45
+                            },
+                            {
+                                "title": "Edge",
+                                "value": "1.767.2000385",
+                                "total-results": 40
+                            },
+                            {
+                                "title": "Escort",
+                                "value": "1.767.1051",
+                                "total-results": 7
+                            },
+                            {
+                                "title": "Excursion",
+                                "value": "1.767.7109",
+                                "total-results": 11
+                            },
+                            {
+                                "title": "Expedition",
+                                "value": "1.767.7512",
+                                "total-results": 10
+                            },
+                            {
+                                "title": "Explorer",
+                                "value": "1.767.2848",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Fiesta",
+                                "value": "1.767.1052",
+                                "total-results": 444
+                            },
+                            {
+                                "title": "Focus",
+                                "value": "1.767.3739",
+                                "total-results": 777
+                            },
+                            {
+                                "title": "Fusion",
+                                "value": "1.767.7600",
+                                "total-results": 14
+                            },
+                            {
+                                "title": "F-serie",
+                                "value": "1.767.7160",
+                                "total-results": 80
+                            },
+                            {
+                                "title": "Galaxy",
+                                "value": "1.767.1053",
+                                "total-results": 140
+                            },
+                            {
+                                "title": "Granada",
+                                "value": "1.767.1054",
+                                "total-results": 4
+                            },
+                            {
+                                "title": "Grand C-MAX",
+                                "value": "1.767.2000218",
+                                "total-results": 32
+                            },
+                            {
+                                "title": "Grand Tourneo Connect",
+                                "value": "1.767.2000350",
+                                "total-results": 6
+                            },
+                            {
+                                "title": "Ka",
+                                "value": "1.767.3020",
+                                "total-results": 17
+                            },
+                            {
+                                "title": "Ka+",
+                                "value": "1.767.2000408",
+                                "total-results": 38
+                            },
+                            {
+                                "title": "Kuga",
+                                "value": "1.767.2000084",
+                                "total-results": 302
+                            },
+                            {
+                                "title": "Maverick",
+                                "value": "1.767.8101",
+                                "total-results": 4
+                            },
+                            {
+                                "title": "Mondeo",
+                                "value": "1.767.1055",
+                                "total-results": 756
+                            },
+                            {
+                                "title": "Mustang",
+                                "value": "1.767.1056",
+                                "total-results": 82
+                            },
+                            {
+                                "title": "Orion",
+                                "value": "1.767.1057",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Puma",
+                                "value": "1.767.3257",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "Ranger",
+                                "value": "1.767.2854",
+                                "total-results": 153
+                            },
+                            {
+                                "title": "Scorpio",
+                                "value": "1.767.1059",
+                                "total-results": 3
+                            },
+                            {
+                                "title": "Sierra",
+                                "value": "1.767.1060",
+                                "total-results": 7
+                            },
+                            {
+                                "title": "SVT Lightning",
+                                "value": "1.767.8268",
+                                "total-results": 3
+                            },
+                            {
+                                "title": "S-MAX",
+                                "value": "1.767.1065",
+                                "total-results": 345
+                            },
+                            {
+                                "title": "Taunus",
+                                "value": "1.767.1061",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "Taurus",
+                                "value": "1.767.2853",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Thunderbird",
+                                "value": "1.767.2852",
+                                "total-results": 6
+                            },
+                            {
+                                "title": "Tourneo Connect",
+                                "value": "1.767.2000290",
+                                "total-results": 11
+                            },
+                            {
+                                "title": "Tourneo Courier",
+                                "value": "1.767.2000339",
+                                "total-results": 3
+                            },
+                            {
+                                "title": "Tourneo Custom",
+                                "value": "1.767.2000272",
+                                "total-results": 16
+                            },
+                            {
+                                "title": "Transit",
+                                "value": "1.767.1063",
+                                "total-results": 155
+                            },
+                            {
+                                "title": "Transit Connect",
+                                "value": "1.767.8191",
+                                "total-results": 292
+                            },
+                            {
+                                "title": "Transit Courier",
+                                "value": "1.767.2000310",
+                                "total-results": 77
+                            },
+                            {
+                                "title": "Transit Custom",
+                                "value": "1.767.2000266",
+                                "total-results": 169
+                            }
+                        ]
+                    },
+                    "total-results": 4279
+                },
+                {
+                    "title": "GMC",
+                    "value": "0.7547",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Andre",
+                                "value": "1.7547.7556",
+                                "total-results": 5
+                            },
+                            {
+                                "title": "Envoy",
+                                "value": "1.7547.7872",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Sierra",
+                                "value": "1.7547.2000251",
+                                "total-results": 5
+                            },
+                            {
+                                "title": "Syclone",
+                                "value": "1.7547.2000286",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Yukon",
+                                "value": "1.7547.7551",
+                                "total-results": 9
+                            }
+                        ]
+                    },
+                    "total-results": 22
+                },
+                {
+                    "title": "Honda",
+                    "value": "0.771",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Accord",
+                                "value": "1.771.1087",
+                                "total-results": 52
+                            },
+                            {
+                                "title": "Andre",
+                                "value": "1.771.2080",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Civic",
+                                "value": "1.771.1088",
+                                "total-results": 202
+                            },
+                            {
+                                "title": "CR-V",
+                                "value": "1.771.3027",
+                                "total-results": 366
+                            },
+                            {
+                                "title": "CR-Z",
+                                "value": "1.771.2000167",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "Element",
+                                "value": "1.771.8089",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "FR-V",
+                                "value": "1.771.8088",
+                                "total-results": 4
+                            },
+                            {
+                                "title": "HR-V",
+                                "value": "1.771.3744",
+                                "total-results": 63
+                            },
+                            {
+                                "title": "Insight",
+                                "value": "1.771.2000117",
+                                "total-results": 4
+                            },
+                            {
+                                "title": "Jazz",
+                                "value": "1.771.7514",
+                                "total-results": 80
+                            },
+                            {
+                                "title": "Nsx",
+                                "value": "1.771.1091",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Prelude",
+                                "value": "1.771.1092",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "Ridgeline",
+                                "value": "1.771.8097",
+                                "total-results": 3
+                            },
+                            {
+                                "title": "Stream",
+                                "value": "1.771.2000040",
+                                "total-results": 2
+                            }
+                        ]
+                    },
+                    "total-results": 783
+                },
+                {
+                    "title": "Hummer",
+                    "value": "0.7672",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "H1",
+                                "value": "1.7672.7674",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "H2",
+                                "value": "1.7672.7675",
+                                "total-results": 11
+                            },
+                            {
+                                "title": "H3",
+                                "value": "1.7672.8180",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 14
+                },
+                {
+                    "title": "Hyundai",
+                    "value": "0.772",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Accent",
+                                "value": "1.772.1095",
+                                "total-results": 9
+                            },
+                            {
+                                "title": "Atos",
+                                "value": "1.772.3746",
+                                "total-results": 4
+                            },
+                            {
+                                "title": "Coupe",
+                                "value": "1.772.3804",
+                                "total-results": 7
+                            },
+                            {
+                                "title": "Elantra",
+                                "value": "1.772.1096",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "Galloper",
+                                "value": "1.772.7184",
+                                "total-results": 7
+                            },
+                            {
+                                "title": "Getz",
+                                "value": "1.772.7588",
+                                "total-results": 22
+                            },
+                            {
+                                "title": "Grand Santa Fe",
+                                "value": "1.772.2000349",
+                                "total-results": 21
+                            },
+                            {
+                                "title": "H-1",
+                                "value": "1.772.2899",
+                                "total-results": 43
+                            },
+                            {
+                                "title": "i10",
+                                "value": "1.772.2000091",
+                                "total-results": 56
+                            },
+                            {
+                                "title": "i20",
+                                "value": "1.772.2000102",
+                                "total-results": 172
+                            },
+                            {
+                                "title": "i30",
+                                "value": "1.772.2000069",
+                                "total-results": 179
+                            },
+                            {
+                                "title": "i40",
+                                "value": "1.772.2000194",
+                                "total-results": 71
+                            },
+                            {
+                                "title": "Ioniq",
+                                "value": "1.772.2000393",
+                                "total-results": 425
+                            },
+                            {
+                                "title": "ix20",
+                                "value": "1.772.2000171",
+                                "total-results": 34
+                            },
+                            {
+                                "title": "ix35",
+                                "value": "1.772.2000157",
+                                "total-results": 111
+                            },
+                            {
+                                "title": "ix55",
+                                "value": "1.772.2000132",
+                                "total-results": 4
+                            },
+                            {
+                                "title": "Kona",
+                                "value": "1.772.2000438",
+                                "total-results": 70
+                            },
+                            {
+                                "title": "Matrix",
+                                "value": "1.772.7178",
+                                "total-results": 12
+                            },
+                            {
+                                "title": "Santa Fe",
+                                "value": "1.772.6739",
+                                "total-results": 104
+                            },
+                            {
+                                "title": "Sonata",
+                                "value": "1.772.1097",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "Terracan",
+                                "value": "1.772.7246",
+                                "total-results": 12
+                            },
+                            {
+                                "title": "Trajet",
+                                "value": "1.772.6740",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "Tucson",
+                                "value": "1.772.7951",
+                                "total-results": 110
+                            },
+                            {
+                                "title": "Veloster",
+                                "value": "1.772.2000193",
+                                "total-results": 9
+                            }
+                        ]
+                    },
+                    "total-results": 1488
+                },
+                {
+                    "title": "Infiniti",
+                    "value": "0.8065",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "FX37",
+                                "value": "1.8065.2000375",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "QX56",
+                                "value": "1.8065.2000059",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 2
+                },
+                {
+                    "title": "Isuzu",
+                    "value": "0.7179",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Andre",
+                                "value": "1.7179.7181",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "D-max",
+                                "value": "1.7179.2000077",
+                                "total-results": 276
+                            },
+                            {
+                                "title": "Trooper",
+                                "value": "1.7179.7180",
+                                "total-results": 2
+                            }
+                        ]
+                    },
+                    "total-results": 280
+                },
+                {
+                    "title": "Iveco",
+                    "value": "0.7280",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Andre",
+                                "value": "1.7280.7296",
+                                "total-results": 4
+                            },
+                            {
+                                "title": "Daily",
+                                "value": "1.7280.7294",
+                                "total-results": 59
+                            },
+                            {
+                                "title": "3510",
+                                "value": "1.7280.7580",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 66
+                },
+                {
+                    "title": "Jaguar",
+                    "value": "0.775",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Andre",
+                                "value": "1.775.2084",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "E-PACE",
+                                "value": "1.775.2000432",
+                                "total-results": 13
+                            },
+                            {
+                                "title": "E-TYPE",
+                                "value": "1.775.2000124",
+                                "total-results": 3
+                            },
+                            {
+                                "title": "F-PACE",
+                                "value": "1.775.2000371",
+                                "total-results": 75
+                            },
+                            {
+                                "title": "F-TYPE",
+                                "value": "1.775.2000252",
+                                "total-results": 15
+                            },
+                            {
+                                "title": "I-PACE",
+                                "value": "1.775.2000447",
+                                "total-results": 45
+                            },
+                            {
+                                "title": "S-TYPE",
+                                "value": "1.775.3747",
+                                "total-results": 10
+                            },
+                            {
+                                "title": "XE",
+                                "value": "1.775.2000324",
+                                "total-results": 26
+                            },
+                            {
+                                "title": "XF",
+                                "value": "1.775.8317",
+                                "total-results": 46
+                            },
+                            {
+                                "title": "XJ",
+                                "value": "1.775.3806",
+                                "total-results": 36
+                            },
+                            {
+                                "title": "XJR",
+                                "value": "1.775.2000389",
+                                "total-results": 6
+                            },
+                            {
+                                "title": "XJS",
+                                "value": "1.775.1112",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "XK",
+                                "value": "1.775.3035",
+                                "total-results": 18
+                            },
+                            {
+                                "title": "X-TYPE",
+                                "value": "1.775.2000042",
+                                "total-results": 17
+                            }
+                        ]
+                    },
+                    "total-results": 312
+                },
+                {
+                    "title": "Jeep",
+                    "value": "0.776",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Andre",
+                                "value": "1.776.2085",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "Cherokee",
+                                "value": "1.776.1113",
+                                "total-results": 24
+                            },
+                            {
+                                "title": "Comanche",
+                                "value": "1.776.1114",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Commander",
+                                "value": "1.776.1496",
+                                "total-results": 16
+                            },
+                            {
+                                "title": "Compass",
+                                "value": "1.776.8315",
+                                "total-results": 47
+                            },
+                            {
+                                "title": "Grand Cherokee",
+                                "value": "1.776.2143",
+                                "total-results": 29
+                            },
+                            {
+                                "title": "J 20",
+                                "value": "1.776.1115",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Patriot",
+                                "value": "1.776.8316",
+                                "total-results": 6
+                            },
+                            {
+                                "title": "Renegade",
+                                "value": "1.776.2000317",
+                                "total-results": 34
+                            },
+                            {
+                                "title": "Wrangler",
+                                "value": "1.776.1116",
+                                "total-results": 40
+                            }
+                        ]
+                    },
+                    "total-results": 200
+                },
+                {
+                    "title": "Kia",
+                    "value": "0.777",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Andre",
+                                "value": "1.777.2086",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Besta",
+                                "value": "1.777.1117",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Carens",
+                                "value": "1.777.7566",
+                                "total-results": 18
+                            },
+                            {
+                                "title": "Carnival",
+                                "value": "1.777.6741",
+                                "total-results": 7
+                            },
+                            {
+                                "title": "Cee'd",
+                                "value": "1.777.2000064",
+                                "total-results": 196
+                            },
+                            {
+                                "title": "Cerato",
+                                "value": "1.777.8179",
+                                "total-results": 4
+                            },
+                            {
+                                "title": "Magentis",
+                                "value": "1.777.7324",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Niro",
+                                "value": "1.777.2000392",
+                                "total-results": 83
+                            },
+                            {
+                                "title": "Optima",
+                                "value": "1.777.2000223",
+                                "total-results": 70
+                            },
+                            {
+                                "title": "Picanto",
+                                "value": "1.777.8178",
+                                "total-results": 83
+                            },
+                            {
+                                "title": "Rio",
+                                "value": "1.777.7117",
+                                "total-results": 79
+                            },
+                            {
+                                "title": "Shuma",
+                                "value": "1.777.3808",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "Sorento",
+                                "value": "1.777.7711",
+                                "total-results": 26
+                            },
+                            {
+                                "title": "Soul",
+                                "value": "1.777.2000300",
+                                "total-results": 283
+                            },
+                            {
+                                "title": "Sportage",
+                                "value": "1.777.1119",
+                                "total-results": 253
+                            },
+                            {
+                                "title": "Stinger",
+                                "value": "1.777.2000435",
+                                "total-results": 15
+                            },
+                            {
+                                "title": "Stonic",
+                                "value": "1.777.2000433",
+                                "total-results": 11
+                            },
+                            {
+                                "title": "Venga",
+                                "value": "1.777.2000164",
+                                "total-results": 18
+                            }
+                        ]
+                    },
+                    "total-results": 1155
+                },
+                {
+                    "title": "Lada",
+                    "value": "0.779",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Niva",
+                                "value": "1.779.1125",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Samara",
+                                "value": "1.779.1126",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "1500",
+                                "value": "1.779.1123",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 3
+                },
+                {
+                    "title": "Lamborghini",
+                    "value": "0.6731",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Aventador",
+                                "value": "1.6731.2000222",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Gallardo",
+                                "value": "1.6731.2000112",
+                                "total-results": 4
+                            },
+                            {
+                                "title": "Huracan",
+                                "value": "1.6731.2000298",
+                                "total-results": 4
+                            },
+                            {
+                                "title": "Urus",
+                                "value": "1.6731.2000452",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 10
+                },
+                {
+                    "title": "Lancia",
+                    "value": "0.780",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Andre",
+                                "value": "1.780.2089",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Delta",
+                                "value": "1.780.1130",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Kappa",
+                                "value": "1.780.3811",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Ypsilon",
+                                "value": "1.780.2000049",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 4
+                },
+                {
+                    "title": "Land Rover",
+                    "value": "0.781",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Andre",
+                                "value": "1.781.2090",
+                                "total-results": 3
+                            },
+                            {
+                                "title": "Defender",
+                                "value": "1.781.6742",
+                                "total-results": 21
+                            },
+                            {
+                                "title": "Discovery",
+                                "value": "1.781.1135",
+                                "total-results": 165
+                            },
+                            {
+                                "title": "Discovery Sport",
+                                "value": "1.781.2000319",
+                                "total-results": 37
+                            },
+                            {
+                                "title": "Freelander",
+                                "value": "1.781.3750",
+                                "total-results": 34
+                            },
+                            {
+                                "title": "Range Rover",
+                                "value": "1.781.1136",
+                                "total-results": 71
+                            },
+                            {
+                                "title": "Range Rover Evoque",
+                                "value": "1.781.2000197",
+                                "total-results": 101
+                            },
+                            {
+                                "title": "Range Rover Sport",
+                                "value": "1.781.8265",
+                                "total-results": 86
+                            },
+                            {
+                                "title": "Range Rover Velar",
+                                "value": "1.781.2000416",
+                                "total-results": 38
+                            }
+                        ]
+                    },
+                    "total-results": 557
+                },
+                {
+                    "title": "Lexus",
+                    "value": "0.782",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "CT200h",
+                                "value": "1.782.2000186",
+                                "total-results": 67
+                            },
+                            {
+                                "title": "GS",
+                                "value": "1.782.3040",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "IS",
+                                "value": "1.782.3812",
+                                "total-results": 52
+                            },
+                            {
+                                "title": "LC",
+                                "value": "1.782.2000419",
+                                "total-results": 5
+                            },
+                            {
+                                "title": "LS",
+                                "value": "1.782.1137",
+                                "total-results": 8
+                            },
+                            {
+                                "title": "NX 300h",
+                                "value": "1.782.2000305",
+                                "total-results": 47
+                            },
+                            {
+                                "title": "RC",
+                                "value": "1.782.2000387",
+                                "total-results": 4
+                            },
+                            {
+                                "title": "RX300",
+                                "value": "1.782.7949",
+                                "total-results": 5
+                            },
+                            {
+                                "title": "RX400h",
+                                "value": "1.782.2000070",
+                                "total-results": 13
+                            },
+                            {
+                                "title": "RX450h",
+                                "value": "1.782.2000149",
+                                "total-results": 45
+                            }
+                        ]
+                    },
+                    "total-results": 248
+                },
+                {
+                    "title": "Lincoln",
+                    "value": "0.7153",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Andre",
+                                "value": "1.7153.7154",
+                                "total-results": 7
+                            },
+                            {
+                                "title": "Town Car",
+                                "value": "1.7153.7152",
+                                "total-results": 6
+                            }
+                        ]
+                    },
+                    "total-results": 17
+                },
+                {
+                    "title": "Lotus",
+                    "value": "0.7191",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Andre",
+                                "value": "1.7191.7196",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "Elise",
+                                "value": "1.7191.7195",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 3
+                },
+                {
+                    "title": "Maserati",
+                    "value": "0.3001",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Andre",
+                                "value": "1.3001.3041",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Biturbo",
+                                "value": "1.3001.7123",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Ghibli",
+                                "value": "1.3001.7120",
+                                "total-results": 15
+                            },
+                            {
+                                "title": "GranTurismo",
+                                "value": "1.3001.2000256",
+                                "total-results": 6
+                            },
+                            {
+                                "title": "Levante",
+                                "value": "1.3001.2000353",
+                                "total-results": 11
+                            },
+                            {
+                                "title": "Quattroporte",
+                                "value": "1.3001.7581",
+                                "total-results": 13
+                            }
+                        ]
+                    },
+                    "total-results": 47
+                },
+                {
+                    "title": "Maybach",
+                    "value": "0.8082",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "57",
+                                "value": "1.8082.2000203",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 1
+                },
+                {
+                    "title": "Mazda",
+                    "value": "0.784",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Andre",
+                                "value": "1.784.2093",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "BT-50",
+                                "value": "1.784.2000068",
+                                "total-results": 4
+                            },
+                            {
+                                "title": "B 2500 Freestyle Cab",
+                                "value": "1.784.8238",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "CX-3",
+                                "value": "1.784.2000328",
+                                "total-results": 122
+                            },
+                            {
+                                "title": "CX-5",
+                                "value": "1.784.2000214",
+                                "total-results": 316
+                            },
+                            {
+                                "title": "CX-7",
+                                "value": "1.784.2000152",
+                                "total-results": 9
+                            },
+                            {
+                                "title": "Demio",
+                                "value": "1.784.3751",
+                                "total-results": 3
+                            },
+                            {
+                                "title": "MPV",
+                                "value": "1.784.3815",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "MX-3",
+                                "value": "1.784.1154",
+                                "total-results": 3
+                            },
+                            {
+                                "title": "MX-5",
+                                "value": "1.784.1155",
+                                "total-results": 34
+                            },
+                            {
+                                "title": "Premacy",
+                                "value": "1.784.3816",
+                                "total-results": 5
+                            },
+                            {
+                                "title": "RX-7",
+                                "value": "1.784.1158",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "RX-8",
+                                "value": "1.784.7797",
+                                "total-results": 8
+                            },
+                            {
+                                "title": "2",
+                                "value": "1.784.8063",
+                                "total-results": 45
+                            },
+                            {
+                                "title": "3",
+                                "value": "1.784.7795",
+                                "total-results": 156
+                            },
+                            {
+                                "title": "5",
+                                "value": "1.784.8147",
+                                "total-results": 54
+                            },
+                            {
+                                "title": "6",
+                                "value": "1.784.7513",
+                                "total-results": 299
+                            },
+                            {
+                                "title": "323",
+                                "value": "1.784.1145",
+                                "total-results": 11
+                            },
+                            {
+                                "title": "626",
+                                "value": "1.784.1147",
+                                "total-results": 11
+                            },
+                            {
+                                "title": "929",
+                                "value": "1.784.1149",
+                                "total-results": 2
+                            }
+                        ]
+                    },
+                    "total-results": 1088
+                },
+                {
+                    "title": "McLaren",
+                    "value": "0.8087",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Andre",
+                                "value": "1.8087.2000303",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "570GT",
+                                "value": "1.8087.2000453",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "570S",
+                                "value": "1.8087.2000395",
+                                "total-results": 2
+                            }
+                        ]
+                    },
+                    "total-results": 5
+                },
+                {
+                    "title": "Mercedes-Benz",
+                    "value": "0.785",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "AMG GT",
+                                "value": "1.785.2000369",
+                                "total-results": 18
+                            },
+                            {
+                                "title": "Andre",
+                                "value": "1.785.2094",
+                                "total-results": 10
+                            },
+                            {
+                                "title": "A-Klasse",
+                                "value": "1.785.3777",
+                                "total-results": 404
+                            },
+                            {
+                                "title": "B-Klasse",
+                                "value": "1.785.8111",
+                                "total-results": 283
+                            },
+                            {
+                                "title": "Citan",
+                                "value": "1.785.2000230",
+                                "total-results": 67
+                            },
+                            {
+                                "title": "CL",
+                                "value": "1.785.7112",
+                                "total-results": 24
+                            },
+                            {
+                                "title": "CLA",
+                                "value": "1.785.2000250",
+                                "total-results": 198
+                            },
+                            {
+                                "title": "CLC",
+                                "value": "1.785.2000100",
+                                "total-results": 6
+                            },
+                            {
+                                "title": "CLK",
+                                "value": "1.785.6713",
+                                "total-results": 43
+                            },
+                            {
+                                "title": "CLS",
+                                "value": "1.785.7960",
+                                "total-results": 78
+                            },
+                            {
+                                "title": "C-Klasse",
+                                "value": "1.785.3776",
+                                "total-results": 704
+                            },
+                            {
+                                "title": "E-Klasse",
+                                "value": "1.785.3775",
+                                "total-results": 1001
+                            },
+                            {
+                                "title": "E-klasse All-Terrain",
+                                "value": "1.785.2000421",
+                                "total-results": 24
+                            },
+                            {
+                                "title": "Geländewagen",
+                                "value": "1.785.2259",
+                                "total-results": 112
+                            },
+                            {
+                                "title": "GL",
+                                "value": "1.785.8289",
+                                "total-results": 96
+                            },
+                            {
+                                "title": "GLA",
+                                "value": "1.785.2000285",
+                                "total-results": 103
+                            },
+                            {
+                                "title": "GLC",
+                                "value": "1.785.2000332",
+                                "total-results": 186
+                            },
+                            {
+                                "title": "GLE",
+                                "value": "1.785.2000327",
+                                "total-results": 44
+                            },
+                            {
+                                "title": "GLK",
+                                "value": "1.785.2000096",
+                                "total-results": 44
+                            },
+                            {
+                                "title": "GLS",
+                                "value": "1.785.2000384",
+                                "total-results": 21
+                            },
+                            {
+                                "title": "M-Klasse",
+                                "value": "1.785.3774",
+                                "total-results": 153
+                            },
+                            {
+                                "title": "R-Klasse",
+                                "value": "1.785.8121",
+                                "total-results": 43
+                            },
+                            {
+                                "title": "SL",
+                                "value": "1.785.7113",
+                                "total-results": 53
+                            },
+                            {
+                                "title": "SLC",
+                                "value": "1.785.2000333",
+                                "total-results": 9
+                            },
+                            {
+                                "title": "SLK",
+                                "value": "1.785.6712",
+                                "total-results": 16
+                            },
+                            {
+                                "title": "SLS",
+                                "value": "1.785.2000177",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Sprinter",
+                                "value": "1.785.1187",
+                                "total-results": 318
+                            },
+                            {
+                                "title": "S-Klasse",
+                                "value": "1.785.3773",
+                                "total-results": 177
+                            },
+                            {
+                                "title": "Vaneo",
+                                "value": "1.785.7601",
+                                "total-results": 4
+                            },
+                            {
+                                "title": "Viano",
+                                "value": "1.785.7871",
+                                "total-results": 26
+                            },
+                            {
+                                "title": "Vito",
+                                "value": "1.785.2897",
+                                "total-results": 320
+                            },
+                            {
+                                "title": "V-Klasse",
+                                "value": "1.785.3772",
+                                "total-results": 42
+                            },
+                            {
+                                "title": "X-Klasse",
+                                "value": "1.785.2000422",
+                                "total-results": 34
+                            },
+                            {
+                                "title": "190",
+                                "value": "1.785.8112",
+                                "total-results": 8
+                            }
+                        ]
+                    },
+                    "total-results": 4705
+                },
+                {
+                    "title": "Mercury",
+                    "value": "0.7554",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Andre",
+                                "value": "1.7554.7555",
+                                "total-results": 3
+                            }
+                        ]
+                    },
+                    "total-results": 3
+                },
+                {
+                    "title": "MG",
+                    "value": "0.786",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Andre",
+                                "value": "1.786.2095",
+                                "total-results": 3
+                            }
+                        ]
+                    },
+                    "total-results": 4
+                },
+                {
+                    "title": "MINI",
+                    "value": "0.7147",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Andre",
+                                "value": "1.7147.7151",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Cabrio",
+                                "value": "1.7147.2000271",
+                                "total-results": 11
+                            },
+                            {
+                                "title": "Clubman",
+                                "value": "1.7147.2000105",
+                                "total-results": 55
+                            },
+                            {
+                                "title": "Cooper",
+                                "value": "1.7147.7150",
+                                "total-results": 126
+                            },
+                            {
+                                "title": "Cooper S",
+                                "value": "1.7147.2000043",
+                                "total-results": 41
+                            },
+                            {
+                                "title": "Countryman",
+                                "value": "1.7147.2000173",
+                                "total-results": 171
+                            },
+                            {
+                                "title": "Coupe",
+                                "value": "1.7147.2000236",
+                                "total-results": 3
+                            },
+                            {
+                                "title": "One",
+                                "value": "1.7147.7149",
+                                "total-results": 53
+                            },
+                            {
+                                "title": "Paceman",
+                                "value": "1.7147.2000247",
+                                "total-results": 5
+                            },
+                            {
+                                "title": "3-dørs",
+                                "value": "1.7147.2000270",
+                                "total-results": 8
+                            }
+                        ]
+                    },
+                    "total-results": 475
+                },
+                {
+                    "title": "Mitsubishi",
+                    "value": "0.787",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Andre",
+                                "value": "1.787.2096",
+                                "total-results": 3
+                            },
+                            {
+                                "title": "ASX",
+                                "value": "1.787.2000165",
+                                "total-results": 135
+                            },
+                            {
+                                "title": "Carisma",
+                                "value": "1.787.1190",
+                                "total-results": 17
+                            },
+                            {
+                                "title": "Colt",
+                                "value": "1.787.1191",
+                                "total-results": 65
+                            },
+                            {
+                                "title": "Eclipse",
+                                "value": "1.787.1193",
+                                "total-results": 7
+                            },
+                            {
+                                "title": "Eclipse Cross",
+                                "value": "1.787.2000439",
+                                "total-results": 26
+                            },
+                            {
+                                "title": "Galant",
+                                "value": "1.787.1194",
+                                "total-results": 5
+                            },
+                            {
+                                "title": "Grandis",
+                                "value": "1.787.7994",
+                                "total-results": 37
+                            },
+                            {
+                                "title": "i-Miev",
+                                "value": "1.787.2000181",
+                                "total-results": 42
+                            },
+                            {
+                                "title": "L200",
+                                "value": "1.787.1195",
+                                "total-results": 63
+                            },
+                            {
+                                "title": "L300",
+                                "value": "1.787.1196",
+                                "total-results": 4
+                            },
+                            {
+                                "title": "L400",
+                                "value": "1.787.3046",
+                                "total-results": 4
+                            },
+                            {
+                                "title": "Lancer",
+                                "value": "1.787.1197",
+                                "total-results": 47
+                            },
+                            {
+                                "title": "Outlander",
+                                "value": "1.787.7713",
+                                "total-results": 901
+                            },
+                            {
+                                "title": "Pajero",
+                                "value": "1.787.1198",
+                                "total-results": 229
+                            },
+                            {
+                                "title": "Pajero Pinin",
+                                "value": "1.787.7992",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Pajero Sport",
+                                "value": "1.787.7953",
+                                "total-results": 7
+                            },
+                            {
+                                "title": "Space Star",
+                                "value": "1.787.3752",
+                                "total-results": 51
+                            },
+                            {
+                                "title": "Space Star I",
+                                "value": "1.787.2000239",
+                                "total-results": 5
+                            },
+                            {
+                                "title": "Space Wagon",
+                                "value": "1.787.1201",
+                                "total-results": 5
+                            },
+                            {
+                                "title": "3000 gt",
+                                "value": "1.787.7155",
+                                "total-results": 4
+                            }
+                        ]
+                    },
+                    "total-results": 1664
+                },
+                {
+                    "title": "Morgan",
+                    "value": "0.788",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Plus 4",
+                                "value": "1.788.3049",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Plus 8",
+                                "value": "1.788.1204",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "3-wheeler",
+                                "value": "1.788.2000258",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "4/4",
+                                "value": "1.788.7762",
+                                "total-results": 2
+                            }
+                        ]
+                    },
+                    "total-results": 6
+                },
+                {
+                    "title": "Morris",
+                    "value": "0.789",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Andre",
+                                "value": "1.789.2098",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Mini",
+                                "value": "1.789.1209",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 2
+                },
+                {
+                    "title": "Nissan",
+                    "value": "0.792",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Almera",
+                                "value": "1.792.1217",
+                                "total-results": 12
+                            },
+                            {
+                                "title": "Andre",
+                                "value": "1.792.2101",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "e-NV200",
+                                "value": "1.792.2000311",
+                                "total-results": 64
+                            },
+                            {
+                                "title": "GT-R",
+                                "value": "1.792.2000200",
+                                "total-results": 9
+                            },
+                            {
+                                "title": "Interstar",
+                                "value": "1.792.7984",
+                                "total-results": 6
+                            },
+                            {
+                                "title": "Juke",
+                                "value": "1.792.2000175",
+                                "total-results": 73
+                            },
+                            {
+                                "title": "King Cab",
+                                "value": "1.792.1220",
+                                "total-results": 27
+                            },
+                            {
+                                "title": "Kubistar",
+                                "value": "1.792.7983",
+                                "total-results": 8
+                            },
+                            {
+                                "title": "Laurel",
+                                "value": "1.792.1221",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "Leaf",
+                                "value": "1.792.2000183",
+                                "total-results": 1273
+                            },
+                            {
+                                "title": "Maxima",
+                                "value": "1.792.1222",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "Micra",
+                                "value": "1.792.1223",
+                                "total-results": 86
+                            },
+                            {
+                                "title": "Murano",
+                                "value": "1.792.2000046",
+                                "total-results": 6
+                            },
+                            {
+                                "title": "Navara",
+                                "value": "1.792.8234",
+                                "total-results": 119
+                            },
+                            {
+                                "title": "Note",
+                                "value": "1.792.6753",
+                                "total-results": 60
+                            },
+                            {
+                                "title": "NP300",
+                                "value": "1.792.2000260",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "NV200",
+                                "value": "1.792.2000162",
+                                "total-results": 60
+                            },
+                            {
+                                "title": "NV300",
+                                "value": "1.792.2000405",
+                                "total-results": 27
+                            },
+                            {
+                                "title": "NV400",
+                                "value": "1.792.2000234",
+                                "total-results": 11
+                            },
+                            {
+                                "title": "Pathfinder",
+                                "value": "1.792.7985",
+                                "total-results": 53
+                            },
+                            {
+                                "title": "Patrol",
+                                "value": "1.792.1224",
+                                "total-results": 28
+                            },
+                            {
+                                "title": "Pixo",
+                                "value": "1.792.2000161",
+                                "total-results": 6
+                            },
+                            {
+                                "title": "Primastar",
+                                "value": "1.792.7685",
+                                "total-results": 19
+                            },
+                            {
+                                "title": "Primera",
+                                "value": "1.792.1226",
+                                "total-results": 37
+                            },
+                            {
+                                "title": "Pulsar",
+                                "value": "1.792.2000308",
+                                "total-results": 38
+                            },
+                            {
+                                "title": "Qashqai",
+                                "value": "1.792.2000061",
+                                "total-results": 630
+                            },
+                            {
+                                "title": "Qashqai +2",
+                                "value": "1.792.2000160",
+                                "total-results": 94
+                            },
+                            {
+                                "title": "Skyline",
+                                "value": "1.792.8142",
+                                "total-results": 5
+                            },
+                            {
+                                "title": "Sunny",
+                                "value": "1.792.1230",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Terrano",
+                                "value": "1.792.1231",
+                                "total-results": 4
+                            },
+                            {
+                                "title": "Tino",
+                                "value": "1.792.7595",
+                                "total-results": 4
+                            },
+                            {
+                                "title": "X-Trail",
+                                "value": "1.792.7188",
+                                "total-results": 210
+                            },
+                            {
+                                "title": "200 SX",
+                                "value": "1.792.1215",
+                                "total-results": 7
+                            },
+                            {
+                                "title": "300 ZX",
+                                "value": "1.792.1216",
+                                "total-results": 3
+                            },
+                            {
+                                "title": "350 Z",
+                                "value": "1.792.7950",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 2995
+                },
+                {
+                    "title": "Oldsmobile",
+                    "value": "0.794",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Andre",
+                                "value": "1.794.2103",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Cutlass",
+                                "value": "1.794.1238",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "Delta",
+                                "value": "1.794.1239",
+                                "total-results": 2
+                            }
+                        ]
+                    },
+                    "total-results": 5
+                },
+                {
+                    "title": "Opel",
+                    "value": "0.795",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "ADAM",
+                                "value": "1.795.2000248",
+                                "total-results": 25
+                            },
+                            {
+                                "title": "Agila",
+                                "value": "1.795.6750",
+                                "total-results": 12
+                            },
+                            {
+                                "title": "Ampera",
+                                "value": "1.795.2000205",
+                                "total-results": 61
+                            },
+                            {
+                                "title": "Andre",
+                                "value": "1.795.2104",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "Antara",
+                                "value": "1.795.2000065",
+                                "total-results": 36
+                            },
+                            {
+                                "title": "Ascona",
+                                "value": "1.795.1246",
+                                "total-results": 4
+                            },
+                            {
+                                "title": "Astra",
+                                "value": "1.795.1247",
+                                "total-results": 459
+                            },
+                            {
+                                "title": "Combo",
+                                "value": "1.795.1252",
+                                "total-results": 84
+                            },
+                            {
+                                "title": "Commodore",
+                                "value": "1.795.1253",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Corsa",
+                                "value": "1.795.1254",
+                                "total-results": 153
+                            },
+                            {
+                                "title": "Crossland X",
+                                "value": "1.795.2000429",
+                                "total-results": 16
+                            },
+                            {
+                                "title": "Frontera",
+                                "value": "1.795.1255",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "Grandland X",
+                                "value": "1.795.2000428",
+                                "total-results": 41
+                            },
+                            {
+                                "title": "GT",
+                                "value": "1.795.2000081",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "Insignia",
+                                "value": "1.795.2000099",
+                                "total-results": 328
+                            },
+                            {
+                                "title": "Insignia Country Tourer",
+                                "value": "1.795.2000288",
+                                "total-results": 25
+                            },
+                            {
+                                "title": "Kadett",
+                                "value": "1.795.1259",
+                                "total-results": 7
+                            },
+                            {
+                                "title": "Manta",
+                                "value": "1.795.1261",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Meriva",
+                                "value": "1.795.7715",
+                                "total-results": 77
+                            },
+                            {
+                                "title": "Mokka",
+                                "value": "1.795.2000226",
+                                "total-results": 163
+                            },
+                            {
+                                "title": "Movano",
+                                "value": "1.795.7186",
+                                "total-results": 21
+                            },
+                            {
+                                "title": "Omega",
+                                "value": "1.795.1264",
+                                "total-results": 3
+                            },
+                            {
+                                "title": "Rekord",
+                                "value": "1.795.1265",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Signum",
+                                "value": "1.795.7796",
+                                "total-results": 9
+                            },
+                            {
+                                "title": "Speedster",
+                                "value": "1.795.7187",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Tigra",
+                                "value": "1.795.1267",
+                                "total-results": 5
+                            },
+                            {
+                                "title": "Vectra",
+                                "value": "1.795.1268",
+                                "total-results": 97
+                            },
+                            {
+                                "title": "Vivaro",
+                                "value": "1.795.7623",
+                                "total-results": 139
+                            },
+                            {
+                                "title": "Zafira",
+                                "value": "1.795.3753",
+                                "total-results": 109
+                            },
+                            {
+                                "title": "Zafira Tourer",
+                                "value": "1.795.2000274",
+                                "total-results": 43
+                            }
+                        ]
+                    },
+                    "total-results": 1938
+                },
+                {
+                    "title": "Packard",
+                    "value": "0.8077",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Andre",
+                                "value": "1.8077.2000249",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 2
+                },
+                {
+                    "title": "Peugeot",
+                    "value": "0.796",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Bipper",
+                                "value": "1.796.2000329",
+                                "total-results": 5
+                            },
+                            {
+                                "title": "Boxer",
+                                "value": "1.796.1285",
+                                "total-results": 50
+                            },
+                            {
+                                "title": "Expert",
+                                "value": "1.796.7621",
+                                "total-results": 127
+                            },
+                            {
+                                "title": "iOn",
+                                "value": "1.796.2000189",
+                                "total-results": 31
+                            },
+                            {
+                                "title": "Partner",
+                                "value": "1.796.3754",
+                                "total-results": 393
+                            },
+                            {
+                                "title": "Partner Electric",
+                                "value": "1.796.7767",
+                                "total-results": 15
+                            },
+                            {
+                                "title": "RCZ",
+                                "value": "1.796.2000169",
+                                "total-results": 3
+                            },
+                            {
+                                "title": "Traveller",
+                                "value": "1.796.2000420",
+                                "total-results": 6
+                            },
+                            {
+                                "title": "106",
+                                "value": "1.796.1270",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "107",
+                                "value": "1.796.8293",
+                                "total-results": 54
+                            },
+                            {
+                                "title": "108",
+                                "value": "1.796.2000299",
+                                "total-results": 32
+                            },
+                            {
+                                "title": "205",
+                                "value": "1.796.1272",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "206",
+                                "value": "1.796.3755",
+                                "total-results": 59
+                            },
+                            {
+                                "title": "206 CC",
+                                "value": "1.796.7586",
+                                "total-results": 3
+                            },
+                            {
+                                "title": "206 SW",
+                                "value": "1.796.7585",
+                                "total-results": 5
+                            },
+                            {
+                                "title": "207",
+                                "value": "1.796.8294",
+                                "total-results": 116
+                            },
+                            {
+                                "title": "207 CC",
+                                "value": "1.796.2000391",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "207 SW",
+                                "value": "1.796.2000073",
+                                "total-results": 8
+                            },
+                            {
+                                "title": "208",
+                                "value": "1.796.2000212",
+                                "total-results": 166
+                            },
+                            {
+                                "title": "306",
+                                "value": "1.796.1275",
+                                "total-results": 10
+                            },
+                            {
+                                "title": "307",
+                                "value": "1.796.7138",
+                                "total-results": 90
+                            },
+                            {
+                                "title": "307 CC",
+                                "value": "1.796.7993",
+                                "total-results": 5
+                            },
+                            {
+                                "title": "307 SW",
+                                "value": "1.796.7716",
+                                "total-results": 62
+                            },
+                            {
+                                "title": "308",
+                                "value": "1.796.2000079",
+                                "total-results": 309
+                            },
+                            {
+                                "title": "308 SW",
+                                "value": "1.796.2000101",
+                                "total-results": 78
+                            },
+                            {
+                                "title": "405",
+                                "value": "1.796.1279",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "406",
+                                "value": "1.796.1280",
+                                "total-results": 12
+                            },
+                            {
+                                "title": "407",
+                                "value": "1.796.7958",
+                                "total-results": 73
+                            },
+                            {
+                                "title": "508",
+                                "value": "1.796.2000188",
+                                "total-results": 152
+                            },
+                            {
+                                "title": "605",
+                                "value": "1.796.1284",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "607",
+                                "value": "1.796.6714",
+                                "total-results": 4
+                            },
+                            {
+                                "title": "807",
+                                "value": "1.796.7634",
+                                "total-results": 15
+                            },
+                            {
+                                "title": "1007",
+                                "value": "1.796.8120",
+                                "total-results": 4
+                            },
+                            {
+                                "title": "2008",
+                                "value": "1.796.2000259",
+                                "total-results": 105
+                            },
+                            {
+                                "title": "3008",
+                                "value": "1.796.2000131",
+                                "total-results": 201
+                            },
+                            {
+                                "title": "4007",
+                                "value": "1.796.2000074",
+                                "total-results": 10
+                            },
+                            {
+                                "title": "4008",
+                                "value": "1.796.2000213",
+                                "total-results": 32
+                            },
+                            {
+                                "title": "5008",
+                                "value": "1.796.2000139",
+                                "total-results": 148
+                            }
+                        ]
+                    },
+                    "total-results": 2398
+                },
+                {
+                    "title": "Plymouth",
+                    "value": "0.797",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Andre",
+                                "value": "1.797.2106",
+                                "total-results": 3
+                            }
+                        ]
+                    },
+                    "total-results": 3
+                },
+                {
+                    "title": "Pontiac",
+                    "value": "0.800",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Andre",
+                                "value": "1.800.2109",
+                                "total-results": 7
+                            },
+                            {
+                                "title": "Bonneville",
+                                "value": "1.800.1294",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "Firebird",
+                                "value": "1.800.1296",
+                                "total-results": 3
+                            },
+                            {
+                                "title": "Trans Am",
+                                "value": "1.800.1299",
+                                "total-results": 4
+                            }
+                        ]
+                    },
+                    "total-results": 16
+                },
+                {
+                    "title": "Porsche",
+                    "value": "0.801",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Andre",
+                                "value": "1.801.2110",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Boxster",
+                                "value": "1.801.3756",
+                                "total-results": 26
+                            },
+                            {
+                                "title": "Cayenne",
+                                "value": "1.801.7714",
+                                "total-results": 213
+                            },
+                            {
+                                "title": "Cayman",
+                                "value": "1.801.2000067",
+                                "total-results": 29
+                            },
+                            {
+                                "title": "Macan",
+                                "value": "1.801.2000276",
+                                "total-results": 95
+                            },
+                            {
+                                "title": "Panamera",
+                                "value": "1.801.2000121",
+                                "total-results": 171
+                            },
+                            {
+                                "title": "911",
+                                "value": "1.801.1301",
+                                "total-results": 223
+                            },
+                            {
+                                "title": "928",
+                                "value": "1.801.7342",
+                                "total-results": 3
+                            },
+                            {
+                                "title": "944",
+                                "value": "1.801.1303",
+                                "total-results": 8
+                            }
+                        ]
+                    },
+                    "total-results": 773
+                },
+                {
+                    "title": "Radical",
+                    "value": "0.8088",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "SR3",
+                                "value": "1.8088.2000313",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 1
+                },
+                {
+                    "title": "Renault",
+                    "value": "0.804",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Andre",
+                                "value": "1.804.2113",
+                                "total-results": 7
+                            },
+                            {
+                                "title": "Captur",
+                                "value": "1.804.2000268",
+                                "total-results": 75
+                            },
+                            {
+                                "title": "Clio",
+                                "value": "1.804.1322",
+                                "total-results": 106
+                            },
+                            {
+                                "title": "Clio Electrique",
+                                "value": "1.804.7878",
+                                "total-results": 6
+                            },
+                            {
+                                "title": "Espace",
+                                "value": "1.804.1324",
+                                "total-results": 8
+                            },
+                            {
+                                "title": "Grand Espace",
+                                "value": "1.804.7648",
+                                "total-results": 3
+                            },
+                            {
+                                "title": "Grand Scenic",
+                                "value": "1.804.8172",
+                                "total-results": 41
+                            },
+                            {
+                                "title": "Kadjar",
+                                "value": "1.804.2000326",
+                                "total-results": 45
+                            },
+                            {
+                                "title": "Kangoo",
+                                "value": "1.804.3820",
+                                "total-results": 58
+                            },
+                            {
+                                "title": "Kangoo Electric",
+                                "value": "1.804.7769",
+                                "total-results": 8
+                            },
+                            {
+                                "title": "Kangoo Express",
+                                "value": "1.804.7241",
+                                "total-results": 5
+                            },
+                            {
+                                "title": "Koleos",
+                                "value": "1.804.2000427",
+                                "total-results": 17
+                            },
+                            {
+                                "title": "Laguna",
+                                "value": "1.804.1328",
+                                "total-results": 19
+                            },
+                            {
+                                "title": "Master",
+                                "value": "1.804.7455",
+                                "total-results": 35
+                            },
+                            {
+                                "title": "Megane",
+                                "value": "1.804.1331",
+                                "total-results": 130
+                            },
+                            {
+                                "title": "Megane CC",
+                                "value": "1.804.2000078",
+                                "total-results": 4
+                            },
+                            {
+                                "title": "Modus",
+                                "value": "1.804.8171",
+                                "total-results": 3
+                            },
+                            {
+                                "title": "Scenic",
+                                "value": "1.804.3956",
+                                "total-results": 20
+                            },
+                            {
+                                "title": "Talisman",
+                                "value": "1.804.2000372",
+                                "total-results": 33
+                            },
+                            {
+                                "title": "Trafic",
+                                "value": "1.804.1332",
+                                "total-results": 55
+                            },
+                            {
+                                "title": "Twingo",
+                                "value": "1.804.7782",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "Twizy",
+                                "value": "1.804.2000243",
+                                "total-results": 8
+                            },
+                            {
+                                "title": "Zoe",
+                                "value": "1.804.2000301",
+                                "total-results": 205
+                            },
+                            {
+                                "title": "19",
+                                "value": "1.804.1315",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "20",
+                                "value": "1.804.1316",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 899
+                },
+                {
+                    "title": "Rolls Royce",
+                    "value": "0.7170",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Silver Shadow",
+                                "value": "1.7170.7171",
+                                "total-results": 4
+                            }
+                        ]
+                    },
+                    "total-results": 4
+                },
+                {
+                    "title": "Rover",
+                    "value": "0.805",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Andre",
+                                "value": "1.805.2114",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Mini",
+                                "value": "1.805.2000255",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "75",
+                                "value": "1.805.3821",
+                                "total-results": 8
+                            },
+                            {
+                                "title": "200-serie",
+                                "value": "1.805.3054",
+                                "total-results": 2
+                            }
+                        ]
+                    },
+                    "total-results": 12
+                },
+                {
+                    "title": "Seat",
+                    "value": "0.807",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Alhambra",
+                                "value": "1.807.3825",
+                                "total-results": 3
+                            },
+                            {
+                                "title": "Andre",
+                                "value": "1.807.2116",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Ateca",
+                                "value": "1.807.2000448",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Cordoba",
+                                "value": "1.807.1345",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Cordoba Vario",
+                                "value": "1.807.7175",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "Ibiza",
+                                "value": "1.807.1346",
+                                "total-results": 5
+                            },
+                            {
+                                "title": "Leon",
+                                "value": "1.807.6746",
+                                "total-results": 12
+                            },
+                            {
+                                "title": "Toledo",
+                                "value": "1.807.1347",
+                                "total-results": 3
+                            }
+                        ]
+                    },
+                    "total-results": 28
+                },
+                {
+                    "title": "Skoda",
+                    "value": "0.808",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Citigo",
+                                "value": "1.808.2000224",
+                                "total-results": 46
+                            },
+                            {
+                                "title": "Fabia",
+                                "value": "1.808.6747",
+                                "total-results": 266
+                            },
+                            {
+                                "title": "Felicia",
+                                "value": "1.808.1354",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "Karoq",
+                                "value": "1.808.2000424",
+                                "total-results": 24
+                            },
+                            {
+                                "title": "Kodiaq",
+                                "value": "1.808.2000409",
+                                "total-results": 47
+                            },
+                            {
+                                "title": "Octavia",
+                                "value": "1.808.1355",
+                                "total-results": 695
+                            },
+                            {
+                                "title": "Octavia RS",
+                                "value": "1.808.2000335",
+                                "total-results": 37
+                            },
+                            {
+                                "title": "Octavia Scout",
+                                "value": "1.808.2000336",
+                                "total-results": 46
+                            },
+                            {
+                                "title": "Pickup",
+                                "value": "1.808.2000337",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Rapid",
+                                "value": "1.808.2000242",
+                                "total-results": 26
+                            },
+                            {
+                                "title": "Rapid Spaceback",
+                                "value": "1.808.2000338",
+                                "total-results": 104
+                            },
+                            {
+                                "title": "Roomster",
+                                "value": "1.808.1490",
+                                "total-results": 41
+                            },
+                            {
+                                "title": "Superb",
+                                "value": "1.808.7532",
+                                "total-results": 352
+                            },
+                            {
+                                "title": "Yeti",
+                                "value": "1.808.2000128",
+                                "total-results": 87
+                            }
+                        ]
+                    },
+                    "total-results": 1775
+                },
+                {
+                    "title": "Smart",
+                    "value": "0.7137",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Forfour",
+                                "value": "1.7137.8190",
+                                "total-results": 13
+                            },
+                            {
+                                "title": "Fortwo",
+                                "value": "1.7137.1483",
+                                "total-results": 58
+                            },
+                            {
+                                "title": "Fortwo cabrio",
+                                "value": "1.7137.8189",
+                                "total-results": 7
+                            },
+                            {
+                                "title": "Fortwo coupe",
+                                "value": "1.7137.1484",
+                                "total-results": 9
+                            },
+                            {
+                                "title": "Roadster",
+                                "value": "1.7137.7956",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 90
+                },
+                {
+                    "title": "Ssangyong",
+                    "value": "0.7190",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Actyon Sport",
+                                "value": "1.7190.8302",
+                                "total-results": 13
+                            },
+                            {
+                                "title": "Korando",
+                                "value": "1.7190.7510",
+                                "total-results": 8
+                            },
+                            {
+                                "title": "Kyron",
+                                "value": "1.7190.8301",
+                                "total-results": 9
+                            },
+                            {
+                                "title": "Musso",
+                                "value": "1.7190.7192",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "Rexton",
+                                "value": "1.7190.7511",
+                                "total-results": 107
+                            },
+                            {
+                                "title": "Rexton W",
+                                "value": "1.7190.2000316",
+                                "total-results": 19
+                            },
+                            {
+                                "title": "Rodius",
+                                "value": "1.7190.8173",
+                                "total-results": 26
+                            },
+                            {
+                                "title": "Tivoli",
+                                "value": "1.7190.2000343",
+                                "total-results": 14
+                            },
+                            {
+                                "title": "XLV",
+                                "value": "1.7190.2000381",
+                                "total-results": 12
+                            }
+                        ]
+                    },
+                    "total-results": 215
+                },
+                {
+                    "title": "Subaru",
+                    "value": "0.810",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "B9 Tribeca",
+                                "value": "1.810.2000047",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "BRZ",
+                                "value": "1.810.2000228",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Forester",
+                                "value": "1.810.3655",
+                                "total-results": 257
+                            },
+                            {
+                                "title": "Impreza",
+                                "value": "1.810.1368",
+                                "total-results": 81
+                            },
+                            {
+                                "title": "Justy",
+                                "value": "1.810.1369",
+                                "total-results": 21
+                            },
+                            {
+                                "title": "Legacy",
+                                "value": "1.810.1370",
+                                "total-results": 75
+                            },
+                            {
+                                "title": "Levorg",
+                                "value": "1.810.2000344",
+                                "total-results": 47
+                            },
+                            {
+                                "title": "Outback",
+                                "value": "1.810.7141",
+                                "total-results": 153
+                            },
+                            {
+                                "title": "Trezia",
+                                "value": "1.810.2000196",
+                                "total-results": 8
+                            },
+                            {
+                                "title": "XV",
+                                "value": "1.810.2000206",
+                                "total-results": 204
+                            }
+                        ]
+                    },
+                    "total-results": 849
+                },
+                {
+                    "title": "Suzuki",
+                    "value": "0.811",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Alto",
+                                "value": "1.811.1372",
+                                "total-results": 25
+                            },
+                            {
+                                "title": "Baleno",
+                                "value": "1.811.1373",
+                                "total-results": 6
+                            },
+                            {
+                                "title": "Grand Vitara",
+                                "value": "1.811.3757",
+                                "total-results": 110
+                            },
+                            {
+                                "title": "Ignis",
+                                "value": "1.811.6748",
+                                "total-results": 87
+                            },
+                            {
+                                "title": "Jimny",
+                                "value": "1.811.7142",
+                                "total-results": 6
+                            },
+                            {
+                                "title": "Kizashi",
+                                "value": "1.811.2000146",
+                                "total-results": 7
+                            },
+                            {
+                                "title": "Liana",
+                                "value": "1.811.7177",
+                                "total-results": 33
+                            },
+                            {
+                                "title": "SJ",
+                                "value": "1.811.1376",
+                                "total-results": 3
+                            },
+                            {
+                                "title": "Swift",
+                                "value": "1.811.1377",
+                                "total-results": 258
+                            },
+                            {
+                                "title": "SX4",
+                                "value": "1.811.8269",
+                                "total-results": 69
+                            },
+                            {
+                                "title": "SX4 S-Cross",
+                                "value": "1.811.2000284",
+                                "total-results": 192
+                            },
+                            {
+                                "title": "Vitara",
+                                "value": "1.811.1378",
+                                "total-results": 210
+                            },
+                            {
+                                "title": "Wagon R+",
+                                "value": "1.811.3826",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "XL7",
+                                "value": "1.811.8081",
+                                "total-results": 36
+                            }
+                        ]
+                    },
+                    "total-results": 1045
+                },
+                {
+                    "title": "Saab",
+                    "value": "0.806",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Andre",
+                                "value": "1.806.2115",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "9-3",
+                                "value": "1.806.3224",
+                                "total-results": 108
+                            },
+                            {
+                                "title": "9-5",
+                                "value": "1.806.3057",
+                                "total-results": 68
+                            },
+                            {
+                                "title": "900",
+                                "value": "1.806.1339",
+                                "total-results": 12
+                            },
+                            {
+                                "title": "9000",
+                                "value": "1.806.1340",
+                                "total-results": 3
+                            }
+                        ]
+                    },
+                    "total-results": 193
+                },
+                {
+                    "title": "Tazzari",
+                    "value": "0.8080",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Zero",
+                                "value": "1.8080.2000192",
+                                "total-results": 5
+                            }
+                        ]
+                    },
+                    "total-results": 5
+                },
+                {
+                    "title": "Tesla",
+                    "value": "0.8078",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Model S",
+                                "value": "1.8078.2000138",
+                                "total-results": 366
+                            },
+                            {
+                                "title": "Model X",
+                                "value": "1.8078.2000379",
+                                "total-results": 118
+                            },
+                            {
+                                "title": "Roadster",
+                                "value": "1.8078.2000137",
+                                "total-results": 3
+                            }
+                        ]
+                    },
+                    "total-results": 487
+                },
+                {
+                    "title": "Think",
+                    "value": "0.6734",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "City",
+                                "value": "1.6734.7139",
+                                "total-results": 2
+                            }
+                        ]
+                    },
+                    "total-results": 2
+                },
+                {
+                    "title": "Toyota",
+                    "value": "0.813",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Auris",
+                                "value": "1.813.2000062",
+                                "total-results": 1031
+                            },
+                            {
+                                "title": "Avensis",
+                                "value": "1.813.3252",
+                                "total-results": 686
+                            },
+                            {
+                                "title": "Avensis Verso",
+                                "value": "1.813.7537",
+                                "total-results": 5
+                            },
+                            {
+                                "title": "Aygo",
+                                "value": "1.813.1480",
+                                "total-results": 92
+                            },
+                            {
+                                "title": "Camry",
+                                "value": "1.813.1386",
+                                "total-results": 13
+                            },
+                            {
+                                "title": "Carina",
+                                "value": "1.813.1387",
+                                "total-results": 10
+                            },
+                            {
+                                "title": "Celica",
+                                "value": "1.813.1388",
+                                "total-results": 10
+                            },
+                            {
+                                "title": "Corolla",
+                                "value": "1.813.1389",
+                                "total-results": 208
+                            },
+                            {
+                                "title": "Corolla Verso",
+                                "value": "1.813.8110",
+                                "total-results": 46
+                            },
+                            {
+                                "title": "Cressida",
+                                "value": "1.813.2000330",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Crown",
+                                "value": "1.813.1392",
+                                "total-results": 3
+                            },
+                            {
+                                "title": "C-HR",
+                                "value": "1.813.2000401",
+                                "total-results": 163
+                            },
+                            {
+                                "title": "Dyna",
+                                "value": "1.813.1393",
+                                "total-results": 10
+                            },
+                            {
+                                "title": "GT86",
+                                "value": "1.813.2000229",
+                                "total-results": 17
+                            },
+                            {
+                                "title": "HiAce",
+                                "value": "1.813.1394",
+                                "total-results": 225
+                            },
+                            {
+                                "title": "HiClass",
+                                "value": "1.813.1395",
+                                "total-results": 5
+                            },
+                            {
+                                "title": "HiLux",
+                                "value": "1.813.1396",
+                                "total-results": 252
+                            },
+                            {
+                                "title": "IQ",
+                                "value": "1.813.2000104",
+                                "total-results": 13
+                            },
+                            {
+                                "title": "Land Cruiser",
+                                "value": "1.813.1397",
+                                "total-results": 360
+                            },
+                            {
+                                "title": "Land Cruiser V8",
+                                "value": "1.813.2000240",
+                                "total-results": 16
+                            },
+                            {
+                                "title": "Mirai",
+                                "value": "1.813.2000442",
+                                "total-results": 6
+                            },
+                            {
+                                "title": "MR2",
+                                "value": "1.813.1398",
+                                "total-results": 6
+                            },
+                            {
+                                "title": "Picnic",
+                                "value": "1.813.3073",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Previa",
+                                "value": "1.813.1399",
+                                "total-results": 16
+                            },
+                            {
+                                "title": "Prius",
+                                "value": "1.813.6749",
+                                "total-results": 192
+                            },
+                            {
+                                "title": "Prius Plug-in Hybrid",
+                                "value": "1.813.2000426",
+                                "total-results": 29
+                            },
+                            {
+                                "title": "Prius+ Seven",
+                                "value": "1.813.2000227",
+                                "total-results": 111
+                            },
+                            {
+                                "title": "Proace",
+                                "value": "1.813.2000267",
+                                "total-results": 118
+                            },
+                            {
+                                "title": "Proace Verso",
+                                "value": "1.813.2000423",
+                                "total-results": 3
+                            },
+                            {
+                                "title": "RAV4",
+                                "value": "1.813.3074",
+                                "total-results": 566
+                            },
+                            {
+                                "title": "Sienna",
+                                "value": "1.813.2000425",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Starlet",
+                                "value": "1.813.1401",
+                                "total-results": 6
+                            },
+                            {
+                                "title": "Supra",
+                                "value": "1.813.1402",
+                                "total-results": 4
+                            },
+                            {
+                                "title": "Tercel",
+                                "value": "1.813.1403",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Tundra",
+                                "value": "1.813.8256",
+                                "total-results": 9
+                            },
+                            {
+                                "title": "Urban Cruiser",
+                                "value": "1.813.2000118",
+                                "total-results": 52
+                            },
+                            {
+                                "title": "Verso",
+                                "value": "1.813.2000134",
+                                "total-results": 32
+                            },
+                            {
+                                "title": "Verso-S",
+                                "value": "1.813.2000198",
+                                "total-results": 20
+                            },
+                            {
+                                "title": "Yaris",
+                                "value": "1.813.3759",
+                                "total-results": 822
+                            },
+                            {
+                                "title": "Yaris Verso",
+                                "value": "1.813.8109",
+                                "total-results": 49
+                            },
+                            {
+                                "title": "4-Runner",
+                                "value": "1.813.1385",
+                                "total-results": 3
+                            }
+                        ]
+                    },
+                    "total-results": 5222
+                },
+                {
+                    "title": "Triumph",
+                    "value": "0.814",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Andre",
+                                "value": "1.814.8285",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "TR7",
+                                "value": "1.814.2000253",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 2
+                },
+                {
+                    "title": "TVR",
+                    "value": "0.820",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Andre",
+                                "value": "1.820.8295",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 1
+                },
+                {
+                    "title": "Volkswagen",
+                    "value": "0.817",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Amarok",
+                                "value": "1.817.2000170",
+                                "total-results": 158
+                            },
+                            {
+                                "title": "Andre",
+                                "value": "1.817.2126",
+                                "total-results": 4
+                            },
+                            {
+                                "title": "Arteon",
+                                "value": "1.817.2000415",
+                                "total-results": 31
+                            },
+                            {
+                                "title": "Beetle",
+                                "value": "1.817.3761",
+                                "total-results": 62
+                            },
+                            {
+                                "title": "Boble (gml. type)",
+                                "value": "1.817.2781",
+                                "total-results": 19
+                            },
+                            {
+                                "title": "Bora",
+                                "value": "1.817.3762",
+                                "total-results": 15
+                            },
+                            {
+                                "title": "Caddy",
+                                "value": "1.817.6709",
+                                "total-results": 504
+                            },
+                            {
+                                "title": "Caddy Alltrack",
+                                "value": "1.817.2000430",
+                                "total-results": 6
+                            },
+                            {
+                                "title": "Caddy Maxi",
+                                "value": "1.817.2000231",
+                                "total-results": 260
+                            },
+                            {
+                                "title": "Caravelle",
+                                "value": "1.817.1430",
+                                "total-results": 281
+                            },
+                            {
+                                "title": "CC",
+                                "value": "1.817.2000210",
+                                "total-results": 12
+                            },
+                            {
+                                "title": "Crafter",
+                                "value": "1.817.2000048",
+                                "total-results": 87
+                            },
+                            {
+                                "title": "Eos",
+                                "value": "1.817.8290",
+                                "total-results": 7
+                            },
+                            {
+                                "title": "Golf",
+                                "value": "1.817.1433",
+                                "total-results": 2997
+                            },
+                            {
+                                "title": "Golf Alltrack",
+                                "value": "1.817.2000331",
+                                "total-results": 52
+                            },
+                            {
+                                "title": "Golf Cross",
+                                "value": "1.817.2000261",
+                                "total-results": 6
+                            },
+                            {
+                                "title": "Golf Plus",
+                                "value": "1.817.2000235",
+                                "total-results": 58
+                            },
+                            {
+                                "title": "Golf Sportsvan",
+                                "value": "1.817.2000297",
+                                "total-results": 87
+                            },
+                            {
+                                "title": "Jetta",
+                                "value": "1.817.1434",
+                                "total-results": 23
+                            },
+                            {
+                                "title": "LT",
+                                "value": "1.817.7650",
+                                "total-results": 12
+                            },
+                            {
+                                "title": "Lupo",
+                                "value": "1.817.3760",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "Multivan",
+                                "value": "1.817.7952",
+                                "total-results": 90
+                            },
+                            {
+                                "title": "Passat",
+                                "value": "1.817.1437",
+                                "total-results": 1104
+                            },
+                            {
+                                "title": "Passat Alltrack",
+                                "value": "1.817.2000209",
+                                "total-results": 139
+                            },
+                            {
+                                "title": "Passat CC",
+                                "value": "1.817.2000111",
+                                "total-results": 44
+                            },
+                            {
+                                "title": "Polo",
+                                "value": "1.817.1438",
+                                "total-results": 519
+                            },
+                            {
+                                "title": "Polo Cross",
+                                "value": "1.817.2000388",
+                                "total-results": 31
+                            },
+                            {
+                                "title": "Scirocco",
+                                "value": "1.817.1441",
+                                "total-results": 29
+                            },
+                            {
+                                "title": "Sharan",
+                                "value": "1.817.1442",
+                                "total-results": 128
+                            },
+                            {
+                                "title": "Taro",
+                                "value": "1.817.2000269",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "Tiguan",
+                                "value": "1.817.8329",
+                                "total-results": 408
+                            },
+                            {
+                                "title": "Tiguan Allspace",
+                                "value": "1.817.2000444",
+                                "total-results": 17
+                            },
+                            {
+                                "title": "Touareg",
+                                "value": "1.817.7592",
+                                "total-results": 53
+                            },
+                            {
+                                "title": "Touran",
+                                "value": "1.817.7593",
+                                "total-results": 562
+                            },
+                            {
+                                "title": "Transporter",
+                                "value": "1.817.1444",
+                                "total-results": 780
+                            },
+                            {
+                                "title": "T-Roc",
+                                "value": "1.817.2000431",
+                                "total-results": 31
+                            },
+                            {
+                                "title": "UP!",
+                                "value": "1.817.2000208",
+                                "total-results": 298
+                            }
+                        ]
+                    },
+                    "total-results": 8924
+                },
+                {
+                    "title": "Volvo",
+                    "value": "0.818",
+                    "filter": {
+                        "title": "Modell",
+                        "name": "model",
+                        "queries": [
+                            {
+                                "title": "Amazon",
+                                "value": "1.818.2145",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "Andre",
+                                "value": "1.818.2127",
+                                "total-results": 15
+                            },
+                            {
+                                "title": "C30",
+                                "value": "1.818.2000045",
+                                "total-results": 46
+                            },
+                            {
+                                "title": "C70",
+                                "value": "1.818.3763",
+                                "total-results": 8
+                            },
+                            {
+                                "title": "PV",
+                                "value": "1.818.1479",
+                                "total-results": 3
+                            },
+                            {
+                                "title": "S40",
+                                "value": "1.818.2784",
+                                "total-results": 63
+                            },
+                            {
+                                "title": "S60",
+                                "value": "1.818.6718",
+                                "total-results": 106
+                            },
+                            {
+                                "title": "S60 Cross Country",
+                                "value": "1.818.2000347",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "S70",
+                                "value": "1.818.3083",
+                                "total-results": 9
+                            },
+                            {
+                                "title": "S80",
+                                "value": "1.818.3769",
+                                "total-results": 76
+                            },
+                            {
+                                "title": "S90",
+                                "value": "1.818.3768",
+                                "total-results": 83
+                            },
+                            {
+                                "title": "V40",
+                                "value": "1.818.2783",
+                                "total-results": 342
+                            },
+                            {
+                                "title": "V40 Cross Country",
+                                "value": "1.818.2000238",
+                                "total-results": 267
+                            },
+                            {
+                                "title": "V50",
+                                "value": "1.818.7849",
+                                "total-results": 279
+                            },
+                            {
+                                "title": "V60",
+                                "value": "1.818.2000172",
+                                "total-results": 651
+                            },
+                            {
+                                "title": "V60 Cross Country",
+                                "value": "1.818.2000346",
+                                "total-results": 41
+                            },
+                            {
+                                "title": "V70",
+                                "value": "1.818.3077",
+                                "total-results": 648
+                            },
+                            {
+                                "title": "V90",
+                                "value": "1.818.2000386",
+                                "total-results": 270
+                            },
+                            {
+                                "title": "V90 Cross Country",
+                                "value": "1.818.2000390",
+                                "total-results": 95
+                            },
+                            {
+                                "title": "X60",
+                                "value": "1.818.2000092",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "XC 40",
+                                "value": "1.818.2000437",
+                                "total-results": 22
+                            },
+                            {
+                                "title": "XC 60",
+                                "value": "1.818.2000093",
+                                "total-results": 649
+                            },
+                            {
+                                "title": "XC 70",
+                                "value": "1.818.7781",
+                                "total-results": 364
+                            },
+                            {
+                                "title": "XC 90",
+                                "value": "1.818.7651",
+                                "total-results": 381
+                            },
+                            {
+                                "title": "142",
+                                "value": "1.818.1450",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "144",
+                                "value": "1.818.1451",
+                                "total-results": 3
+                            },
+                            {
+                                "title": "145",
+                                "value": "1.818.1452",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "164",
+                                "value": "1.818.1453",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "240",
+                                "value": "1.818.1456",
+                                "total-results": 20
+                            },
+                            {
+                                "title": "242",
+                                "value": "1.818.1457",
+                                "total-results": 4
+                            },
+                            {
+                                "title": "740",
+                                "value": "1.818.1472",
+                                "total-results": 7
+                            },
+                            {
+                                "title": "760",
+                                "value": "1.818.1473",
+                                "total-results": 2
+                            },
+                            {
+                                "title": "780",
+                                "value": "1.818.1474",
+                                "total-results": 1
+                            },
+                            {
+                                "title": "850",
+                                "value": "1.818.1475",
+                                "total-results": 15
+                            },
+                            {
+                                "title": "940",
+                                "value": "1.818.1476",
+                                "total-results": 16
+                            },
+                            {
+                                "title": "960",
+                                "value": "1.818.1477",
+                                "total-results": 1
+                            }
+                        ]
+                    },
+                    "total-results": 4495
+                }
+            ]
         },
         "registration_class": {
             "title": "Avgiftsklasse",
             "name": "registration_class",
             "queries": [
-                        {
-                        "title": "Annet",
-                        "value": "6",
-                        "total-results": 379
-                        },
-                        {
-                        "title": "Kombinertbil",
-                        "value": "3",
-                        "total-results": 67
-                        },
-                        {
-                        "title": "Lett lastebil",
-                        "value": "5",
-                        "total-results": 159
-                        },
-                        {
-                        "title": "Minibuss",
-                        "value": "4",
-                        "total-results": 73
-                        },
-                        {
-                        "title": "Personbil",
-                        "value": "1",
-                        "total-results": 56712
-                        },
-                        {
-                        "title": "Varebil",
-                        "value": "2",
-                        "total-results": 6053
-                        }
-                        ]
+                {
+                    "title": "Annet",
+                    "value": "6",
+                    "total-results": 285
+                },
+                {
+                    "title": "Kombinertbil",
+                    "value": "3",
+                    "total-results": 55
+                },
+                {
+                    "title": "Lett lastebil",
+                    "value": "5",
+                    "total-results": 131
+                },
+                {
+                    "title": "Minibuss",
+                    "value": "4",
+                    "total-results": 90
+                },
+                {
+                    "title": "Personbil",
+                    "value": "1",
+                    "total-results": 55312
+                },
+                {
+                    "title": "Varebil",
+                    "value": "2",
+                    "total-results": 7000
+                }
+            ]
         },
         "engine_fuel": {
             "title": "Drivstoff",
             "name": "engine_fuel",
             "queries": [
-                        {
-                        "title": "Bensin",
-                        "value": "0/1",
-                        "total-results": 22083
-                        },
-                        {
-                        "title": "Diesel",
-                        "value": "0/2",
-                        "total-results": 34711
-                        },
-                        {
-                        "title": "Elektrisitet",
-                        "value": "0/4",
-                        "total-results": 2615
-                        },
-                        {
-                        "title": "Gass",
-                        "value": "0/3",
-                        "total-results": 12
-                        },
-                        {
-                        "title": "Gass+bensin",
-                        "value": "0/5",
-                        "total-results": 81
-                        },
-                        {
-                        "title": "Hybrid",
-                        "value": "0/11111",
-                        "total-results": 3941
-                        }
-                        ]
+                {
+                    "title": "Bensin",
+                    "value": "0/1",
+                    "total-results": 19421
+                },
+                {
+                    "title": "Diesel",
+                    "value": "0/2",
+                    "total-results": 32469
+                },
+                {
+                    "title": "Elektrisitet",
+                    "value": "0/4",
+                    "total-results": 5550
+                },
+                {
+                    "title": "Gass",
+                    "value": "0/3",
+                    "total-results": 8
+                },
+                {
+                    "title": "Gass+bensin",
+                    "value": "0/5",
+                    "total-results": 40
+                },
+                {
+                    "title": "Hybrid",
+                    "value": "0/11111",
+                    "total-results": 5383
+                }
+            ]
         },
         "warranty_insurance": {
             "title": "Garanti og forsikringer",
             "name": "warranty_insurance",
             "queries": [
-                        {
-                        "title": "Bytterett",
-                        "value": "42",
-                        "total-results": 5132
-                        },
-                        {
-                        "title": "Garanti",
-                        "value": "1",
-                        "total-results": 29592
-                        },
-                        {
-                        "title": "Privat bilbytteforsikring",
-                        "value": "2",
-                        "total-results": 1
-                        },
-                        {
-                        "title": "Programbil",
-                        "value": "41",
-                        "total-results": 1861
-                        }
-                        ]
+                {
+                    "title": "Bytterett",
+                    "value": "42",
+                    "total-results": 8072
+                },
+                {
+                    "title": "Garanti",
+                    "value": "1",
+                    "total-results": 35988
+                },
+                {
+                    "title": "Programbil",
+                    "value": "41",
+                    "total-results": 3433
+                }
+            ]
         },
         "wheel_sets": {
             "title": "Hjulsett",
             "name": "wheel_sets",
             "queries": [
-                        {
-                        "title": "Ett hjulsett",
-                        "value": "1",
-                        "total-results": 5950
-                        },
-                        {
-                        "title": "To hjulsett",
-                        "value": "2",
-                        "total-results": 44714
-                        }
-                        ]
+                {
+                    "title": "Ett hjulsett",
+                    "value": "1",
+                    "total-results": 5755
+                },
+                {
+                    "title": "To hjulsett",
+                    "value": "2",
+                    "total-results": 45451
+                }
+            ]
         },
         "sales_form": {
             "title": "Salgsform",
             "name": "sales_form",
             "queries": [
-                        {
-                        "title": "Auksjon",
-                        "value": "7",
-                        "total-results": 366
-                        },
-                        {
-                        "title": "Bruktbil til salgs",
-                        "value": "1",
-                        "total-results": 61903
-                        },
-                        {
-                        "title": "Bud ønskes",
-                        "value": "4",
-                        "total-results": 1
-                        },
-                        {
-                        "title": "Leasing",
-                        "value": "5",
-                        "total-results": 1063
-                        },
-                        {
-                        "title": "Nybil til salgs",
-                        "value": "2",
-                        "total-results": 119
-                        }
-                        ]
+                {
+                    "title": "Auksjon",
+                    "value": "7",
+                    "total-results": 400
+                },
+                {
+                    "title": "Bruktbil til salgs",
+                    "value": "1",
+                    "total-results": 60847
+                },
+                {
+                    "title": "Leasing",
+                    "value": "5",
+                    "total-results": 1475
+                },
+                {
+                    "title": "Nybil til salgs",
+                    "value": "2",
+                    "total-results": 158
+                }
+            ]
         },
         "exterior_colour": {
             "title": "Farge",
             "name": "exterior_colour",
             "queries": [
-                        {
-                        "title": "Beige",
-                        "value": "1",
-                        "total-results": 915
-                        },
-                        {
-                        "title": "Blå",
-                        "value": "2",
-                        "total-results": 6208
-                        },
-                        {
-                        "title": "Bronse",
-                        "value": "3",
-                        "total-results": 111
-                        },
-                        {
-                        "title": "Brun",
-                        "value": "4",
-                        "total-results": 1798
-                        },
-                        {
-                        "title": "Grønn",
-                        "value": "5",
-                        "total-results": 1388
-                        },
-                        {
-                        "title": "Grå",
-                        "value": "6",
-                        "total-results": 12789
-                        },
-                        {
-                        "title": "Gul",
-                        "value": "7",
-                        "total-results": 306
-                        },
-                        {
-                        "title": "Gull",
-                        "value": "8",
-                        "total-results": 187
-                        },
-                        {
-                        "title": "Hvit",
-                        "value": "9",
-                        "total-results": 8229
-                        },
-                        {
-                        "title": "Lilla",
-                        "value": "10",
-                        "total-results": 115
-                        },
-                        {
-                        "title": "Oransje",
-                        "value": "11",
-                        "total-results": 386
-                        },
-                        {
-                        "title": "Rosa",
-                        "value": "12",
-                        "total-results": 12
-                        },
-                        {
-                        "title": "Rød",
-                        "value": "13",
-                        "total-results": 4380
-                        },
-                        {
-                        "title": "Svart",
-                        "value": "14",
-                        "total-results": 16789
-                        },
-                        {
-                        "title": "Sølv",
-                        "value": "15",
-                        "total-results": 9588
-                        },
-                        {
-                        "title": "Turkis",
-                        "value": "16",
-                        "total-results": 39
-                        }
-                        ]
+                {
+                    "title": "Beige",
+                    "value": "1",
+                    "total-results": 795
+                },
+                {
+                    "title": "Blå",
+                    "value": "2",
+                    "total-results": 5761
+                },
+                {
+                    "title": "Bronse",
+                    "value": "3",
+                    "total-results": 127
+                },
+                {
+                    "title": "Brun",
+                    "value": "4",
+                    "total-results": 1817
+                },
+                {
+                    "title": "Grønn",
+                    "value": "5",
+                    "total-results": 1010
+                },
+                {
+                    "title": "Grå",
+                    "value": "6",
+                    "total-results": 13433
+                },
+                {
+                    "title": "Gul",
+                    "value": "7",
+                    "total-results": 228
+                },
+                {
+                    "title": "Gull",
+                    "value": "8",
+                    "total-results": 121
+                },
+                {
+                    "title": "Hvit",
+                    "value": "9",
+                    "total-results": 9599
+                },
+                {
+                    "title": "Lilla",
+                    "value": "10",
+                    "total-results": 85
+                },
+                {
+                    "title": "Oransje",
+                    "value": "11",
+                    "total-results": 360
+                },
+                {
+                    "title": "Rosa",
+                    "value": "12",
+                    "total-results": 17
+                },
+                {
+                    "title": "Rød",
+                    "value": "13",
+                    "total-results": 3985
+                },
+                {
+                    "title": "Svart",
+                    "value": "14",
+                    "total-results": 16392
+                },
+                {
+                    "title": "Sølv",
+                    "value": "15",
+                    "total-results": 8866
+                },
+                {
+                    "title": "Turkis",
+                    "value": "16",
+                    "total-results": 21
+                }
+            ]
         },
         "published": {
             "title": "Publisert",
             "name": "published",
             "queries": [
-                        {
-                        "title": "Nye i dag",
-                        "value": "1",
-                        "total-results": 2307
-                        }
-                        ]
+                {
+                    "title": "Nye i dag",
+                    "value": "1",
+                    "total-results": 1574
+                }
+            ]
         },
         "car_equipment": {
             "title": "Utstyr",
             "name": "car_equipment",
             "queries": [
-                        {
-                        "title": "Hengerfeste",
-                        "value": "23",
-                        "total-results": 24660
-                        },
-                        {
-                        "title": "Motorvarmer",
-                        "value": "35",
-                        "total-results": 12942
-                        },
-                        {
-                        "title": "Navigasjonssystem",
-                        "value": "40",
-                        "total-results": 26265
-                        },
-                        {
-                        "title": "Radio DAB+",
-                        "value": "77",
-                        "total-results": 22000
-                        },
-                        {
-                        "title": "Skinninteriør",
-                        "value": "12",
-                        "total-results": 25911
-                        }
-                        ]
+                {
+                    "title": "Hengerfeste",
+                    "value": "23",
+                    "total-results": 23695
+                },
+                {
+                    "title": "Motorvarmer",
+                    "value": "35",
+                    "total-results": 13564
+                },
+                {
+                    "title": "Navigasjonssystem",
+                    "value": "40",
+                    "total-results": 30624
+                },
+                {
+                    "title": "Radio DAB+",
+                    "value": "77",
+                    "total-results": 26245
+                },
+                {
+                    "title": "Skinninteriør",
+                    "value": "12",
+                    "total-results": 26764
+                }
+            ]
         },
         "transmission": {
             "title": "Girkasse",
             "name": "transmission",
             "queries": [
-                        {
-                        "title": "Automat",
-                        "value": "2",
-                        "total-results": 33282
-                        },
-                        {
-                        "title": "Manuell",
-                        "value": "1",
-                        "total-results": 30078
-                        }
-                        ]
+                {
+                    "title": "Automat",
+                    "value": "2",
+                    "total-results": 37538
+                },
+                {
+                    "title": "Manuell",
+                    "value": "1",
+                    "total-results": 25254
+                }
+            ]
         },
         "dealer_segment": {
             "title": "Annonsør",
             "name": "dealer_segment",
             "queries": [
-                        {
-                        "title": "Annet bilutsalg",
-                        "value": "2",
-                        "total-results": 19928
-                        },
-                        {
-                        "title": "Merkeforhandler",
-                        "value": "1",
-                        "total-results": 20818
-                        },
-                        {
-                        "title": "Privat",
-                        "value": "3",
-                        "total-results": 22709
-                        }
-                        ]
+                {
+                    "title": "Annet bilutsalg",
+                    "value": "2",
+                    "total-results": 22553
+                },
+                {
+                    "title": "Merkeforhandler",
+                    "value": "1",
+                    "total-results": 25598
+                },
+                {
+                    "title": "Privat",
+                    "value": "3",
+                    "total-results": 14731
+                }
+            ]
         },
         "wheel_drive": {
             "title": "Hjuldrift",
             "name": "wheel_drive",
             "queries": [
-                        {
-                        "title": "Bakhjulsdrift",
-                        "value": "1",
-                        "total-results": 8976
-                        },
-                        {
-                        "title": "Firehjulsdrift",
-                        "value": "2",
-                        "total-results": 21364
-                        },
-                        {
-                        "title": "Forhjulsdrift",
-                        "value": "3",
-                        "total-results": 32670
-                        }
-                        ]
+                {
+                    "title": "Bakhjulsdrift",
+                    "value": "1",
+                    "total-results": 7169
+                },
+                {
+                    "title": "Firehjulsdrift",
+                    "value": "2",
+                    "total-results": 21352
+                },
+                {
+                    "title": "Forhjulsdrift",
+                    "value": "3",
+                    "total-results": 33941
+                }
+            ]
         },
         "condition": {
             "title": "Bilens tilstand",
             "name": "condition",
             "queries": [
-                        {
-                        "title": "Service",
-                        "value": "1",
-                        "total-results": 25439
-                        },
-                        {
-                        "title": "Testrapport",
-                        "value": "3",
-                        "total-results": 195
-                        },
-                        {
-                        "title": "Tilstandsrapport",
-                        "value": "2",
-                        "total-results": 2834
-                        }
-                        ]
+                {
+                    "title": "Service",
+                    "value": "1",
+                    "total-results": 28416
+                },
+                {
+                    "title": "Testrapport",
+                    "value": "3",
+                    "total-results": 108
+                },
+                {
+                    "title": "Tilstandsrapport",
+                    "value": "2",
+                    "total-results": 4521
+                }
+            ]
         },
         "motor_ad_location": {
             "title": "Kjøretøyet står i",
@@ -5927,212 +5644,212 @@
             "title": "Område",
             "name": "location",
             "queries": [
-                        {
-                        "title": "Akershus",
-                        "value": "20003",
-                        "total-results": 8394
-                        },
-                        {
-                        "title": "Aust-Agder",
-                        "value": "20010",
-                        "total-results": 1474
-                        },
-                        {
-                        "title": "Buskerud",
-                        "value": "20007",
-                        "total-results": 5443
-                        },
-                        {
-                        "title": "Finnmark",
-                        "value": "20020",
-                        "total-results": 673
-                        },
-                        {
-                        "title": "Hedmark",
-                        "value": "20005",
-                        "total-results": 2541
-                        },
-                        {
-                        "title": "Hordaland",
-                        "value": "20013",
-                        "total-results": 4693
-                        },
-                        {
-                        "title": "Møre og Romsdal",
-                        "value": "20015",
-                        "total-results": 2802
-                        },
-                        {
-                        "title": "Nordland",
-                        "value": "20018",
-                        "total-results": 1957
-                        },
-                        {
-                        "title": "Oppland",
-                        "value": "20006",
-                        "total-results": 2336
-                        },
-                        {
-                        "title": "Oslo",
-                        "value": "20061",
-                        "total-results": 5111
-                        },
-                        {
-                        "title": "Rogaland",
-                        "value": "20012",
-                        "total-results": 6078
-                        },
-                        {
-                        "title": "Sogn og Fjordane",
-                        "value": "20014",
-                        "total-results": 1024
-                        },
-                        {
-                        "title": "Telemark",
-                        "value": "20009",
-                        "total-results": 2901
-                        },
-                        {
-                        "title": "Troms",
-                        "value": "20019",
-                        "total-results": 1740
-                        },
-                        {
-                        "title": "Trøndelag",
-                        "value": "20016",
-                        "total-results": 5905
-                        },
-                        {
-                        "title": "Vestfold",
-                        "value": "20008",
-                        "total-results": 2823
-                        },
-                        {
-                        "title": "Vest-Agder",
-                        "value": "20011",
-                        "total-results": 2384
-                        },
-                        {
-                        "title": "Østfold",
-                        "value": "20002",
-                        "total-results": 5172
-                        }
-                        ]
+                {
+                    "title": "Akershus",
+                    "value": "20003",
+                    "total-results": 8643
+                },
+                {
+                    "title": "Aust-Agder",
+                    "value": "20010",
+                    "total-results": 1419
+                },
+                {
+                    "title": "Buskerud",
+                    "value": "20007",
+                    "total-results": 5548
+                },
+                {
+                    "title": "Finnmark",
+                    "value": "20020",
+                    "total-results": 603
+                },
+                {
+                    "title": "Hedmark",
+                    "value": "20005",
+                    "total-results": 2613
+                },
+                {
+                    "title": "Hordaland",
+                    "value": "20013",
+                    "total-results": 4617
+                },
+                {
+                    "title": "Møre og Romsdal",
+                    "value": "20015",
+                    "total-results": 2763
+                },
+                {
+                    "title": "Nordland",
+                    "value": "20018",
+                    "total-results": 1778
+                },
+                {
+                    "title": "Oppland",
+                    "value": "20006",
+                    "total-results": 2200
+                },
+                {
+                    "title": "Oslo",
+                    "value": "20061",
+                    "total-results": 5024
+                },
+                {
+                    "title": "Rogaland",
+                    "value": "20012",
+                    "total-results": 5982
+                },
+                {
+                    "title": "Sogn og Fjordane",
+                    "value": "20014",
+                    "total-results": 974
+                },
+                {
+                    "title": "Telemark",
+                    "value": "20009",
+                    "total-results": 2862
+                },
+                {
+                    "title": "Troms",
+                    "value": "20019",
+                    "total-results": 1648
+                },
+                {
+                    "title": "Trøndelag",
+                    "value": "20016",
+                    "total-results": 5434
+                },
+                {
+                    "title": "Vestfold",
+                    "value": "20008",
+                    "total-results": 2597
+                },
+                {
+                    "title": "Vest-Agder",
+                    "value": "20011",
+                    "total-results": 2483
+                },
+                {
+                    "title": "Østfold",
+                    "value": "20002",
+                    "total-results": 5685
+                }
+            ]
         },
         "price": {
             "title": "Pris",
             "range": true,
             "name": "price",
             "queries": [
-                        {
-                        "title": "0-50000",
-                        "value": "0-50000",
-                        "total-results": 12167
-                        },
-                        {
-                        "title": "50001-100000",
-                        "value": "50001-100000",
-                        "total-results": 9653
-                        },
-                        {
-                        "title": "100001-150000",
-                        "value": "100001-150000",
-                        "total-results": 8151
-                        },
-                        {
-                        "title": "150001-250000",
-                        "value": "150001-250000",
-                        "total-results": 13616
-                        },
-                        {
-                        "title": "250001-500000",
-                        "value": "250001-500000",
-                        "total-results": 14270
-                        },
-                        {
-                        "title": "500001-",
-                        "value": "500001-null",
-                        "total-results": 5593
-                        }
-                        ]
+                {
+                    "title": "0-50000",
+                    "value": "0-50000",
+                    "total-results": 9301
+                },
+                {
+                    "title": "50001-100000",
+                    "value": "50001-100000",
+                    "total-results": 8301
+                },
+                {
+                    "title": "100001-150000",
+                    "value": "100001-150000",
+                    "total-results": 7565
+                },
+                {
+                    "title": "150001-250000",
+                    "value": "150001-250000",
+                    "total-results": 14616
+                },
+                {
+                    "title": "250001-500000",
+                    "value": "250001-500000",
+                    "total-results": 17326
+                },
+                {
+                    "title": "500001-",
+                    "value": "500001-null",
+                    "total-results": 5769
+                }
+            ]
         },
         "body_type": {
             "title": "Karosseri",
             "name": "body_type",
             "queries": [
-                        {
-                        "title": "Annet",
-                        "value": "11",
-                        "total-results": 457
-                        },
-                        {
-                        "title": "Cabriolet",
-                        "value": "7",
-                        "total-results": 1213
-                        },
-                        {
-                        "title": "Coupe",
-                        "value": "6",
-                        "total-results": 2419
-                        },
-                        {
-                        "title": "Flerbruksbil",
-                        "value": "5",
-                        "total-results": 3033
-                        },
-                        {
-                        "title": "Kasse",
-                        "value": "10",
-                        "total-results": 4178
-                        },
-                        {
-                        "title": "Kombi 3-dørs",
-                        "value": "1",
-                        "total-results": 1452
-                        },
-                        {
-                        "title": "Kombi 5-dørs",
-                        "value": "2",
-                        "total-results": 15358
-                        },
-                        {
-                        "title": "Pickup",
-                        "value": "8",
-                        "total-results": 1372
-                        },
-                        {
-                        "title": "Sedan",
-                        "value": "3",
-                        "total-results": 5998
-                        },
-                        {
-                        "title": "Stasjonsvogn",
-                        "value": "4",
-                        "total-results": 15570
-                        },
-                        {
-                        "title": "SUV/Offroad",
-                        "value": "9",
-                        "total-results": 11752
-                        }
-                        ]
+                {
+                    "title": "Annet",
+                    "value": "11",
+                    "total-results": 308
+                },
+                {
+                    "title": "Cabriolet",
+                    "value": "7",
+                    "total-results": 729
+                },
+                {
+                    "title": "Coupe",
+                    "value": "6",
+                    "total-results": 1786
+                },
+                {
+                    "title": "Flerbruksbil",
+                    "value": "5",
+                    "total-results": 3025
+                },
+                {
+                    "title": "Kasse",
+                    "value": "10",
+                    "total-results": 4886
+                },
+                {
+                    "title": "Kombi 3-dørs",
+                    "value": "1",
+                    "total-results": 1263
+                },
+                {
+                    "title": "Kombi 5-dørs",
+                    "value": "2",
+                    "total-results": 17867
+                },
+                {
+                    "title": "Pickup",
+                    "value": "8",
+                    "total-results": 1536
+                },
+                {
+                    "title": "Sedan",
+                    "value": "3",
+                    "total-results": 4581
+                },
+                {
+                    "title": "Stasjonsvogn",
+                    "value": "4",
+                    "total-results": 14280
+                },
+                {
+                    "title": "SUV/Offroad",
+                    "value": "9",
+                    "total-results": 11952
+                }
+            ]
         },
         "price_changed": {
             "title": "Redusert pris",
             "name": "price_changed",
             "queries": [
-                        {
-                        "title": "Ny pris siste 5 dager",
-                        "value": "1",
-                        "total-results": 94
-                        }
-                        ]
+                {
+                    "title": "Ny pris siste 5 dager",
+                    "value": "1",
+                    "total-results": 102
+                }
+            ]
         }
     },
     "map": {
         "parameter": "bbox",
         "areaParameters": [
-                           "location"
-                           ]
+            "location"
+        ]
     }
 }

--- a/Demo/Resources/car/caravan.json
+++ b/Demo/Resources/car/caravan.json
@@ -1,0 +1,397 @@
+{
+    "market": "caravan",
+    "hits": 2566,
+    "label": "Campingvogner",
+    "type": "search",
+    "filters": [
+        "markets",
+        "q",
+        "published",
+        "make",
+        "sales_form",
+        "year",
+        "mileage",
+        "price",
+        "location",
+        "no_of_sleepers",
+        "caravan_segment",
+        "caravan_dealer_segment",
+        "length",
+        "width",
+        "weight"
+    ],
+    "filter-data": {
+        "price": {
+            "title": "Pris",
+            "range": true,
+            "name": "price"
+        },
+        "year": {
+            "title": "Årsmodell",
+            "range": true,
+            "name": "year"
+        },
+        "mileage": {
+            "title": "Kilometerstand",
+            "range": true,
+            "name": "mileage"
+        },
+        "no_of_sleepers": {
+            "title": "Sengeplasser",
+            "range": true,
+            "name": "no_of_sleepers"
+        },
+        "weight": {
+            "title": "Totalvekt",
+            "range": true,
+            "name": "weight"
+        },
+        "length": {
+            "title": "Lengde",
+            "range": true,
+            "name": "length"
+        },
+        "width": {
+            "title": "Bredde",
+            "range": true,
+            "name": "width"
+        },
+        "caravan_dealer_segment": {
+            "title": "Annonsør",
+            "name": "caravan_dealer_segment",
+            "queries": [
+                {
+                    "title": "Forhandler",
+                    "value": "2",
+                    "total-results": 2068
+                },
+                {
+                    "title": "Privat",
+                    "value": "3",
+                    "total-results": 498
+                }
+            ]
+        },
+        "dealer_segment": {
+            "title": "Annonsør",
+            "name": "dealer_segment",
+            "queries": [
+                {
+                    "title": "Annet bilutsalg",
+                    "value": "2",
+                    "total-results": 2068
+                },
+                {
+                    "title": "Privat",
+                    "value": "3",
+                    "total-results": 498
+                }
+            ]
+        },
+        "caravan_segment": {
+            "title": "Kjøretøygruppe",
+            "name": "caravan_segment",
+            "queries": [
+                {
+                    "title": "Annet",
+                    "value": "3",
+                    "total-results": 41
+                },
+                {
+                    "title": "Campingvogn",
+                    "value": "1",
+                    "total-results": 2525
+                }
+            ]
+        },
+        "motor_ad_location": {
+            "title": "Kjøretøyet står i",
+            "name": "motor_ad_location"
+        },
+        "location": {
+            "title": "Område",
+            "name": "location",
+            "queries": [
+                {
+                    "title": "Akershus",
+                    "value": "20003",
+                    "total-results": 274
+                },
+                {
+                    "title": "Aust-Agder",
+                    "value": "20010",
+                    "total-results": 38
+                },
+                {
+                    "title": "Buskerud",
+                    "value": "20007",
+                    "total-results": 141
+                },
+                {
+                    "title": "Finnmark",
+                    "value": "20020",
+                    "total-results": 69
+                },
+                {
+                    "title": "Hedmark",
+                    "value": "20005",
+                    "total-results": 205
+                },
+                {
+                    "title": "Hordaland",
+                    "value": "20013",
+                    "total-results": 152
+                },
+                {
+                    "title": "Møre og Romsdal",
+                    "value": "20015",
+                    "total-results": 172
+                },
+                {
+                    "title": "Nordland",
+                    "value": "20018",
+                    "total-results": 260
+                },
+                {
+                    "title": "Oppland",
+                    "value": "20006",
+                    "total-results": 142
+                },
+                {
+                    "title": "Oslo",
+                    "value": "20061",
+                    "total-results": 6
+                },
+                {
+                    "title": "Rogaland",
+                    "value": "20012",
+                    "total-results": 237
+                },
+                {
+                    "title": "Sogn og Fjordane",
+                    "value": "20014",
+                    "total-results": 23
+                },
+                {
+                    "title": "Telemark",
+                    "value": "20009",
+                    "total-results": 97
+                },
+                {
+                    "title": "Troms",
+                    "value": "20019",
+                    "total-results": 158
+                },
+                {
+                    "title": "Trøndelag",
+                    "value": "20016",
+                    "total-results": 242
+                },
+                {
+                    "title": "Vestfold",
+                    "value": "20008",
+                    "total-results": 71
+                },
+                {
+                    "title": "Vest-Agder",
+                    "value": "20011",
+                    "total-results": 58
+                },
+                {
+                    "title": "Østfold",
+                    "value": "20002",
+                    "total-results": 202
+                }
+            ]
+        },
+        "sales_form": {
+            "title": "Salgsform",
+            "name": "sales_form",
+            "queries": [
+                {
+                    "title": "Til leie",
+                    "value": "2",
+                    "total-results": 93
+                },
+                {
+                    "title": "Til salgs",
+                    "value": "1",
+                    "total-results": 2473
+                }
+            ]
+        },
+        "make": {
+            "title": "Merke",
+            "name": "make",
+            "queries": [
+                {
+                    "title": "Adria",
+                    "value": "10",
+                    "total-results": 379
+                },
+                {
+                    "title": "Andre",
+                    "value": "570",
+                    "total-results": 48
+                },
+                {
+                    "title": "Atlas",
+                    "value": "8268",
+                    "total-results": 4
+                },
+                {
+                    "title": "Bjølseth",
+                    "value": "30",
+                    "total-results": 29
+                },
+                {
+                    "title": "Bürstner",
+                    "value": "50",
+                    "total-results": 175
+                },
+                {
+                    "title": "Cabby",
+                    "value": "60",
+                    "total-results": 58
+                },
+                {
+                    "title": "Camp-Let",
+                    "value": "8365",
+                    "total-results": 3
+                },
+                {
+                    "title": "Carado",
+                    "value": "8341",
+                    "total-results": 1
+                },
+                {
+                    "title": "Caravelair",
+                    "value": "70",
+                    "total-results": 26
+                },
+                {
+                    "title": "Dethleffs",
+                    "value": "130",
+                    "total-results": 153
+                },
+                {
+                    "title": "Eifelland",
+                    "value": "140",
+                    "total-results": 2
+                },
+                {
+                    "title": "Fendt",
+                    "value": "7980",
+                    "total-results": 92
+                },
+                {
+                    "title": "Hobby",
+                    "value": "230",
+                    "total-results": 674
+                },
+                {
+                    "title": "Home-car",
+                    "value": "240",
+                    "total-results": 1
+                },
+                {
+                    "title": "Husvogner",
+                    "value": "8300",
+                    "total-results": 26
+                },
+                {
+                    "title": "Hymer",
+                    "value": "250",
+                    "total-results": 33
+                },
+                {
+                    "title": "KABE",
+                    "value": "7979",
+                    "total-results": 300
+                },
+                {
+                    "title": "Knaus",
+                    "value": "270",
+                    "total-results": 197
+                },
+                {
+                    "title": "LMC",
+                    "value": "8364",
+                    "total-results": 29
+                },
+                {
+                    "title": "LMC/Münsterland",
+                    "value": "290",
+                    "total-results": 68
+                },
+                {
+                    "title": "Polar",
+                    "value": "390",
+                    "total-results": 95
+                },
+                {
+                    "title": "Poletta",
+                    "value": "8165",
+                    "total-results": 1
+                },
+                {
+                    "title": "Savsjø",
+                    "value": "8083",
+                    "total-results": 2
+                },
+                {
+                    "title": "Solifer",
+                    "value": "460",
+                    "total-results": 98
+                },
+                {
+                    "title": "Sprite",
+                    "value": "470",
+                    "total-results": 3
+                },
+                {
+                    "title": "Tabbert",
+                    "value": "500",
+                    "total-results": 28
+                },
+                {
+                    "title": "Tec",
+                    "value": "8308",
+                    "total-results": 9
+                },
+                {
+                    "title": "Weinsberg",
+                    "value": "530",
+                    "total-results": 9
+                },
+                {
+                    "title": "Wilk",
+                    "value": "550",
+                    "total-results": 4
+                },
+                {
+                    "title": "Willerby",
+                    "value": "8252",
+                    "total-results": 3
+                }
+            ]
+        },
+        "published": {
+            "title": "Publisert",
+            "name": "published",
+            "queries": [
+                {
+                    "title": "Nye i dag",
+                    "value": "1",
+                    "total-results": 44
+                }
+            ]
+        }
+    },
+    "map": {
+        "parameter": "bbox",
+        "areaParameters": [
+            "location"
+        ]
+    }
+}

--- a/Demo/Resources/car/mobile-home.json
+++ b/Demo/Resources/car/mobile-home.json
@@ -1,0 +1,669 @@
+{
+    "market": "mobile-home",
+    "hits": 4858,
+    "label": "Bobiler",
+    "type": "search",
+    "filters": [
+        "markets",
+        "q",
+        "published",
+        "make",
+        "sales_form",
+        "year",
+        "mileage",
+        "price",
+        "location",
+        "no_of_sleepers",
+        "number_of_seats",
+        "engine_effect",
+        "mobile_home_segment",
+        "caravan_dealer_segment",
+        "transmission",
+        "wheel_drive",
+        "length",
+        "weight"
+    ],
+    "filter-data": {
+        "price": {
+            "title": "Pris",
+            "range": true,
+            "name": "price"
+        },
+        "year": {
+            "title": "Årsmodell",
+            "range": true,
+            "name": "year"
+        },
+        "engine_effect": {
+            "title": "Hestekrefter",
+            "range": true,
+            "name": "engine_effect"
+        },
+        "length": {
+            "title": "Lengde",
+            "range": true,
+            "name": "length"
+        },
+        "mileage": {
+            "title": "Kilometerstand",
+            "range": true,
+            "name": "mileage"
+        },
+        "no_of_sleepers": {
+            "title": "Sengeplasser",
+            "range": true,
+            "name": "no_of_sleepers"
+        },
+        "number_of_seats": {
+            "title": "Registrerte sitteplasser",
+            "range": true,
+            "name": "number_of_seats"
+        },
+        "weight": {
+            "title": "Totalvekt",
+            "range": true,
+            "name": "weight"
+        },
+        "motor_ad_location": {
+            "title": "Kjøretøyet står i",
+            "name": "motor_ad_location",
+            "queries": [
+                {
+                    "title": "Norge",
+                    "value": "1",
+                    "total-results": 2160
+                },
+                {
+                    "title": "Utlandet",
+                    "value": "2",
+                    "total-results": 373
+                }
+            ]
+        },
+        "transmission": {
+            "title": "Girkasse",
+            "name": "transmission",
+            "queries": [
+                {
+                    "title": "Automat",
+                    "value": "2",
+                    "total-results": 2362
+                },
+                {
+                    "title": "Manuell",
+                    "value": "1",
+                    "total-results": 2256
+                }
+            ]
+        },
+        "caravan_dealer_segment": {
+            "title": "Annonsør",
+            "name": "caravan_dealer_segment",
+            "queries": [
+                {
+                    "title": "Forhandler",
+                    "value": "2",
+                    "total-results": 4483
+                },
+                {
+                    "title": "Privat",
+                    "value": "3",
+                    "total-results": 375
+                }
+            ]
+        },
+        "mobile_home_segment": {
+            "title": "Type bobil",
+            "name": "mobile_home_segment",
+            "queries": [
+                {
+                    "title": "Alkove",
+                    "value": "3",
+                    "total-results": 233
+                },
+                {
+                    "title": "Bybobil",
+                    "value": "4",
+                    "total-results": 447
+                },
+                {
+                    "title": "Camper",
+                    "value": "5",
+                    "total-results": 26
+                },
+                {
+                    "title": "Delintegrert",
+                    "value": "2",
+                    "total-results": 2011
+                },
+                {
+                    "title": "Integrert",
+                    "value": "1",
+                    "total-results": 1852
+                }
+            ]
+        },
+        "dealer_segment": {
+            "title": "Annonsør",
+            "name": "dealer_segment",
+            "queries": [
+                {
+                    "title": "Annet bilutsalg",
+                    "value": "2",
+                    "total-results": 4483
+                },
+                {
+                    "title": "Privat",
+                    "value": "3",
+                    "total-results": 375
+                }
+            ]
+        },
+        "wheel_drive": {
+            "title": "Hjuldrift",
+            "name": "wheel_drive",
+            "queries": [
+                {
+                    "title": "Bakhjulsdrift",
+                    "value": "1",
+                    "total-results": 243
+                },
+                {
+                    "title": "Firehjulsdrift",
+                    "value": "2",
+                    "total-results": 17
+                },
+                {
+                    "title": "Forhjulsdrift",
+                    "value": "3",
+                    "total-results": 4189
+                }
+            ]
+        },
+        "location": {
+            "title": "Område",
+            "name": "location",
+            "queries": [
+                {
+                    "title": "Akershus",
+                    "value": "20003",
+                    "total-results": 328
+                },
+                {
+                    "title": "Aust-Agder",
+                    "value": "20010",
+                    "total-results": 122
+                },
+                {
+                    "title": "Buskerud",
+                    "value": "20007",
+                    "total-results": 123
+                },
+                {
+                    "title": "Finnmark",
+                    "value": "20020",
+                    "total-results": 89
+                },
+                {
+                    "title": "Hedmark",
+                    "value": "20005",
+                    "total-results": 133
+                },
+                {
+                    "title": "Hordaland",
+                    "value": "20013",
+                    "total-results": 447
+                },
+                {
+                    "title": "Møre og Romsdal",
+                    "value": "20015",
+                    "total-results": 491
+                },
+                {
+                    "title": "Nordland",
+                    "value": "20018",
+                    "total-results": 531
+                },
+                {
+                    "title": "Oppland",
+                    "value": "20006",
+                    "total-results": 184
+                },
+                {
+                    "title": "Oslo",
+                    "value": "20061",
+                    "total-results": 19
+                },
+                {
+                    "title": "Rogaland",
+                    "value": "20012",
+                    "total-results": 443
+                },
+                {
+                    "title": "Sogn og Fjordane",
+                    "value": "20014",
+                    "total-results": 26
+                },
+                {
+                    "title": "Telemark",
+                    "value": "20009",
+                    "total-results": 162
+                },
+                {
+                    "title": "Troms",
+                    "value": "20019",
+                    "total-results": 314
+                },
+                {
+                    "title": "Trøndelag",
+                    "value": "20016",
+                    "total-results": 619
+                },
+                {
+                    "title": "Vestfold",
+                    "value": "20008",
+                    "total-results": 184
+                },
+                {
+                    "title": "Vest-Agder",
+                    "value": "20011",
+                    "total-results": 155
+                },
+                {
+                    "title": "Østfold",
+                    "value": "20002",
+                    "total-results": 424
+                }
+            ]
+        },
+        "sales_form": {
+            "title": "Salgsform",
+            "name": "sales_form",
+            "queries": [
+                {
+                    "title": "Til leie",
+                    "value": "2",
+                    "total-results": 277
+                },
+                {
+                    "title": "Til salgs",
+                    "value": "1",
+                    "total-results": 4581
+                }
+            ]
+        },
+        "make": {
+            "title": "Merke",
+            "name": "make",
+            "queries": [
+                {
+                    "title": "Adria",
+                    "value": "10",
+                    "total-results": 319
+                },
+                {
+                    "title": "Ahorn",
+                    "value": "8257",
+                    "total-results": 1
+                },
+                {
+                    "title": "Andre",
+                    "value": "570",
+                    "total-results": 37
+                },
+                {
+                    "title": "Autostar",
+                    "value": "8338",
+                    "total-results": 7
+                },
+                {
+                    "title": "Bavaria",
+                    "value": "8340",
+                    "total-results": 6
+                },
+                {
+                    "title": "Benimar",
+                    "value": "20",
+                    "total-results": 96
+                },
+                {
+                    "title": "Bravia",
+                    "value": "8361",
+                    "total-results": 2
+                },
+                {
+                    "title": "Bürstner",
+                    "value": "50",
+                    "total-results": 400
+                },
+                {
+                    "title": "Cabby",
+                    "value": "60",
+                    "total-results": 3
+                },
+                {
+                    "title": "Carado",
+                    "value": "8341",
+                    "total-results": 188
+                },
+                {
+                    "title": "Carthago",
+                    "value": "8258",
+                    "total-results": 201
+                },
+                {
+                    "title": "Challenger",
+                    "value": "80",
+                    "total-results": 310
+                },
+                {
+                    "title": "Chausson",
+                    "value": "8267",
+                    "total-results": 13
+                },
+                {
+                    "title": "CI",
+                    "value": "100",
+                    "total-results": 11
+                },
+                {
+                    "title": "Concorde",
+                    "value": "110",
+                    "total-results": 28
+                },
+                {
+                    "title": "DAF",
+                    "value": "120",
+                    "total-results": 1
+                },
+                {
+                    "title": "Dethleffs",
+                    "value": "130",
+                    "total-results": 362
+                },
+                {
+                    "title": "Dreamer",
+                    "value": "8358",
+                    "total-results": 13
+                },
+                {
+                    "title": "Elnagh",
+                    "value": "150",
+                    "total-results": 11
+                },
+                {
+                    "title": "Eura Mobil",
+                    "value": "160",
+                    "total-results": 172
+                },
+                {
+                    "title": "Fendt",
+                    "value": "7980",
+                    "total-results": 2
+                },
+                {
+                    "title": "Fiat",
+                    "value": "170",
+                    "total-results": 32
+                },
+                {
+                    "title": "Ford",
+                    "value": "190",
+                    "total-results": 15
+                },
+                {
+                    "title": "Frankia",
+                    "value": "200",
+                    "total-results": 38
+                },
+                {
+                    "title": "Giottiline",
+                    "value": "8297",
+                    "total-results": 6
+                },
+                {
+                    "title": "Globecar",
+                    "value": "8348",
+                    "total-results": 13
+                },
+                {
+                    "title": "Glucksmobil",
+                    "value": "8359",
+                    "total-results": 2
+                },
+                {
+                    "title": "Hobby",
+                    "value": "230",
+                    "total-results": 117
+                },
+                {
+                    "title": "Hymer",
+                    "value": "250",
+                    "total-results": 536
+                },
+                {
+                    "title": "Itineo",
+                    "value": "8337",
+                    "total-results": 24
+                },
+                {
+                    "title": "KABE",
+                    "value": "7979",
+                    "total-results": 122
+                },
+                {
+                    "title": "Karmann",
+                    "value": "8266",
+                    "total-results": 22
+                },
+                {
+                    "title": "Knaus",
+                    "value": "270",
+                    "total-results": 175
+                },
+                {
+                    "title": "Laika",
+                    "value": "280",
+                    "total-results": 87
+                },
+                {
+                    "title": "La Strada",
+                    "value": "8186",
+                    "total-results": 15
+                },
+                {
+                    "title": "Le Voyageur",
+                    "value": "580",
+                    "total-results": 4
+                },
+                {
+                    "title": "LMC",
+                    "value": "8364",
+                    "total-results": 73
+                },
+                {
+                    "title": "LMC/Münsterland",
+                    "value": "290",
+                    "total-results": 38
+                },
+                {
+                    "title": "Malibu",
+                    "value": "8360",
+                    "total-results": 54
+                },
+                {
+                    "title": "Mclouis",
+                    "value": "8108",
+                    "total-results": 32
+                },
+                {
+                    "title": "Mercedes-Benz",
+                    "value": "300",
+                    "total-results": 8
+                },
+                {
+                    "title": "Mirage",
+                    "value": "320",
+                    "total-results": 2
+                },
+                {
+                    "title": "Mobilvetta",
+                    "value": "340",
+                    "total-results": 18
+                },
+                {
+                    "title": "Monaco",
+                    "value": "8192",
+                    "total-results": 1
+                },
+                {
+                    "title": "Morelo",
+                    "value": "8344",
+                    "total-results": 10
+                },
+                {
+                    "title": "Niesmann-Bischoff",
+                    "value": "350",
+                    "total-results": 98
+                },
+                {
+                    "title": "Nissan",
+                    "value": "360",
+                    "total-results": 1
+                },
+                {
+                    "title": "Orangecamp",
+                    "value": "8343",
+                    "total-results": 9
+                },
+                {
+                    "title": "Peugeot",
+                    "value": "8302",
+                    "total-results": 5
+                },
+                {
+                    "title": "Phoenix",
+                    "value": "8271",
+                    "total-results": 3
+                },
+                {
+                    "title": "Pilote",
+                    "value": "380",
+                    "total-results": 129
+                },
+                {
+                    "title": "Polar",
+                    "value": "390",
+                    "total-results": 2
+                },
+                {
+                    "title": "Pøssl",
+                    "value": "8272",
+                    "total-results": 70
+                },
+                {
+                    "title": "P.L.A",
+                    "value": "8351",
+                    "total-results": 10
+                },
+                {
+                    "title": "Rapido",
+                    "value": "400",
+                    "total-results": 228
+                },
+                {
+                    "title": "Rimor",
+                    "value": "410",
+                    "total-results": 51
+                },
+                {
+                    "title": "Roadcar",
+                    "value": "8362",
+                    "total-results": 1
+                },
+                {
+                    "title": "Roller Team",
+                    "value": "440",
+                    "total-results": 42
+                },
+                {
+                    "title": "Scania",
+                    "value": "450",
+                    "total-results": 2
+                },
+                {
+                    "title": "Solifer",
+                    "value": "460",
+                    "total-results": 200
+                },
+                {
+                    "title": "Sunlight",
+                    "value": "8306",
+                    "total-results": 188
+                },
+                {
+                    "title": "Sun Living",
+                    "value": "8357",
+                    "total-results": 58
+                },
+                {
+                    "title": "Swift",
+                    "value": "480",
+                    "total-results": 2
+                },
+                {
+                    "title": "Tec",
+                    "value": "8308",
+                    "total-results": 6
+                },
+                {
+                    "title": "Tourne",
+                    "value": "8363",
+                    "total-results": 17
+                },
+                {
+                    "title": "VANTourer",
+                    "value": "8356",
+                    "total-results": 3
+                },
+                {
+                    "title": "Volkswagen",
+                    "value": "520",
+                    "total-results": 7
+                },
+                {
+                    "title": "Weinsberg",
+                    "value": "530",
+                    "total-results": 67
+                },
+                {
+                    "title": "Westfalia",
+                    "value": "540",
+                    "total-results": 10
+                },
+                {
+                    "title": "Winnebago",
+                    "value": "560",
+                    "total-results": 1
+                }
+            ]
+        },
+        "published": {
+            "title": "Publisert",
+            "name": "published",
+            "queries": [
+                {
+                    "title": "Nye i dag",
+                    "value": "1",
+                    "total-results": 123
+                }
+            ]
+        }
+    },
+    "map": {
+        "parameter": "bbox",
+        "areaParameters": [
+            "location"
+        ]
+    }
+}

--- a/Demo/Root/DemoFilterRootViewControllerHelper.swift
+++ b/Demo/Root/DemoFilterRootViewControllerHelper.swift
@@ -14,11 +14,8 @@ class DemoFilter {
     var selectionDataSource = ParameterBasedFilterInfoSelectionDataSource()
     let filterSelectionTitleProvider = FilterSelectionTitleProvider()
     lazy var verticalSetup: VerticalSetupDemo = {
-        let verticalsCarNorway = [VerticalDemo(id: "car-norway", title: "Biler i Norge", isCurrent: true, isExternal: false, file: "car-norway"), VerticalDemo(id: "car-abroad", title: "Biler i Utlandet", isCurrent: false, isExternal: false, file: "car-abroad")]
-        let verticalsCarAbroad = [VerticalDemo(id: "car-norway", title: "Biler i Norge", isCurrent: false, isExternal: false, file: "car-norway"), VerticalDemo(id: "car-abroad", title: "Biler i Utlandet", isCurrent: true, isExternal: false, file: "car-abroad")]
-
         var marketDemos: [MarketDemos] = [
-            [MarketDemos(market: "car-norway", demos: verticalsCarNorway), MarketDemos(market: "car-abroad", demos: verticalsCarAbroad)],
+            carVerticalDemos(),
             jobVerticalDemos(),
             boatVerticalDemos(),
             mcVerticalDemos(),
@@ -85,6 +82,17 @@ class DemoFilter {
             }
             return MarketDemos(market: market.rawValue, demos: demos)
         }
+    }
+
+    private func carVerticalDemos() -> [MarketDemos] {
+        let markets: [(market: FilterMarketCar, title: String)] = [
+            (market: .norway, title: "Biler i Norge"),
+            (market: .abroad, title: "Biler i utlandet"),
+            (market: .mobileHome, title: "Bobil"),
+            (market: .caravan, title: "Campingvogn"),
+        ]
+
+        return createVerticalDemos(from: markets)
     }
 
     private func boatVerticalDemos() -> [MarketDemos] {

--- a/Sources/FINNFilterImplementation/FilterKey.swift
+++ b/Sources/FINNFilterImplementation/FilterKey.swift
@@ -9,6 +9,8 @@ public enum FilterKey: String, CodingKey {
     case area
     case boatClass = "class"
     case bodyType = "body_type"
+    case caravanDealerSegment = "caravan_dealer_segment"
+    case caravanSegment = "caravan_segment"
     case carEquipment = "car_equipment"
     case category
     case condition
@@ -30,13 +32,17 @@ public enum FilterKey: String, CodingKey {
     case isSold = "is_sold"
     case jobDuration = "job_duration"
     case jobSector = "job_sector"
+    case leasepriceInit = "leaseprice_init"
+    case leasepriceMonth = "leaseprice_month"
     case leisureSituation = "leisure_situation"
+    case length
     case lengthFeet = "length_feet"
     case location
     case make
     case managerRole = "manager_role"
     case markets
     case mileage
+    case mobileHomeSegment = "mobile_home_segment"
     case motorAdLocation = "motor_ad_location"
     case motorIncluded = "motor_included"
     case motorSize = "motor_size"
@@ -66,6 +72,7 @@ public enum FilterKey: String, CodingKey {
     case type
     case viewing
     case warrantyInsurance = "warranty_insurance"
+    case weight
     case width
     case wheelDrive = "wheel_drive"
     case wheelSets = "wheel_sets"

--- a/Sources/FINNFilterImplementation/FilterMarkets/FilterMarketCar.swift
+++ b/Sources/FINNFilterImplementation/FilterMarkets/FilterMarketCar.swift
@@ -21,9 +21,9 @@ extension FilterMarketCar: FilterConfiguration {
     var preferenceFilterKeys: [FilterKey] {
         switch self {
         case .norway, .abroad:
-            return [.condition, .published, .priceChanged, .dealerSegment]
-        default:
-            return [.published]
+            return [.published, .priceChanged, .dealerSegment]
+        case .mobileHome, .caravan:
+            return [.published, .caravanDealerSegment]
         }
     }
 
@@ -47,7 +47,8 @@ extension FilterMarketCar: FilterConfiguration {
                 .carEquipment,
                 .wheelSets,
                 .warrantyInsurance,
-                .registrationClass
+                .condition,
+                .registrationClass,
             ]
         case .abroad:
             return [
@@ -69,7 +70,8 @@ extension FilterMarketCar: FilterConfiguration {
                 .carEquipment,
                 .wheelSets,
                 .warrantyInsurance,
-                .registrationClass
+                .condition,
+                .registrationClass,
             ]
         case .mobileHome:
             return [
@@ -83,11 +85,10 @@ extension FilterMarketCar: FilterConfiguration {
                 .numberOfSeats,
                 .engineEffect,
                 .mobileHomeSegment,
-                .caravanDealerSegment,
                 .transmission,
                 .wheelDrive,
                 .length,
-                .weight
+                .weight,
             ]
         case .caravan:
             return [
@@ -99,10 +100,9 @@ extension FilterMarketCar: FilterConfiguration {
                 .location,
                 .noOfSleepers,
                 .caravanSegment,
-                .caravanDealerSegment,
                 .length,
                 .width,
-                .weight
+                .weight,
             ]
         }
     }

--- a/Sources/FINNFilterImplementation/FilterMarkets/FilterMarketCar.swift
+++ b/Sources/FINNFilterImplementation/FilterMarkets/FilterMarketCar.swift
@@ -20,10 +20,10 @@ extension FilterMarketCar: FilterConfiguration {
 
     var preferenceFilterKeys: [FilterKey] {
         switch self {
-        case .norway:
+        case .norway, .abroad:
             return [.condition, .published, .priceChanged, .dealerSegment]
-        case .abroad:
-            return [.condition, .published, .priceChanged, .dealerSegment]
+        default:
+            return [.published]
         }
     }
 
@@ -45,9 +45,9 @@ extension FilterMarketCar: FilterConfiguration {
                 .wheelDrive,
                 .transmission,
                 .carEquipment,
-                .warrantyInsurance,
                 .wheelSets,
-                .registrationClass,
+                .warrantyInsurance,
+                .registrationClass
             ]
         case .abroad:
             return [
@@ -55,6 +55,8 @@ extension FilterMarketCar: FilterConfiguration {
                 .salesForm,
                 .year,
                 .mileage,
+                .leasepriceInit,
+                .leasepriceMonth,
                 .price,
                 .location,
                 .bodyType,
@@ -65,9 +67,42 @@ extension FilterMarketCar: FilterConfiguration {
                 .wheelDrive,
                 .transmission,
                 .carEquipment,
-                .warrantyInsurance,
                 .wheelSets,
-                .registrationClass,
+                .warrantyInsurance,
+                .registrationClass
+            ]
+        case .mobileHome:
+            return [
+                .make,
+                .salesForm,
+                .year,
+                .mileage,
+                .price,
+                .location,
+                .noOfSleepers,
+                .numberOfSeats,
+                .engineEffect,
+                .mobileHomeSegment,
+                .caravanDealerSegment,
+                .transmission,
+                .wheelDrive,
+                .length,
+                .weight
+            ]
+        case .caravan:
+            return [
+                .make,
+                .salesForm,
+                .year,
+                .mileage,
+                .price,
+                .location,
+                .noOfSleepers,
+                .caravanSegment,
+                .caravanDealerSegment,
+                .length,
+                .width,
+                .weight
             ]
         }
     }

--- a/Sources/FINNFilterImplementation/FilterMarkets/FilterMarketCar.swift
+++ b/Sources/FINNFilterImplementation/FilterMarkets/FilterMarketCar.swift
@@ -7,6 +7,8 @@ import Foundation
 enum FilterMarketCar: String, CaseIterable {
     case norway = "car-norway"
     case abroad = "car-abroad"
+    case mobileHome = "mobile-home"
+    case caravan
 }
 
 // MARK: - FilterConfiguration

--- a/Sources/FINNFilterImplementation/FilterMarkets/FilterMarketCar.swift
+++ b/Sources/FINNFilterImplementation/FilterMarkets/FilterMarketCar.swift
@@ -127,45 +127,135 @@ extension FilterMarketCar: FilterConfiguration {
         }
         switch filterKey {
         case .year:
-            lowValue = 1950
+            switch self {
+            case .norway, .abroad:
+                lowValue = 1950
+            case .mobileHome, .caravan:
+                lowValue = 1990
+            }
             highValue = Calendar.current.component(.year, from: Date())
             unit = "år"
             rangeBoundsOffsets = (hasLowerBoundOffset: true, hasUpperBoundOffset: true)
             increment = 1
             accessibilityValues = (stepIncrement: nil, valueSuffix: nil)
             appearanceProperties = (usesSmallNumberInputFont: false, displaysUnitInNumberInput: false, isCurrencyValueRange: false)
-        case .engineEffect:
-            lowValue = 0
-            highValue = 500
-            unit = "hk"
-            rangeBoundsOffsets = (hasLowerBoundOffset: false, hasUpperBoundOffset: true)
-            increment = 10
-            accessibilityValues = (stepIncrement: nil, valueSuffix: nil)
-            appearanceProperties = (usesSmallNumberInputFont: false, displaysUnitInNumberInput: true, isCurrencyValueRange: false)
         case .mileage:
+            switch self {
+            case .caravan:
+                highValue = 20000
+            default:
+                highValue = 200_000
+            }
             lowValue = 0
-            highValue = 200_000
             unit = "km"
             rangeBoundsOffsets = (hasLowerBoundOffset: false, hasUpperBoundOffset: true)
             increment = 1000
             accessibilityValues = (stepIncrement: nil, valueSuffix: nil)
             appearanceProperties = (usesSmallNumberInputFont: false, displaysUnitInNumberInput: true, isCurrencyValueRange: false)
-        case .numberOfSeats:
-            lowValue = 0
-            highValue = 10
-            unit = "seter"
-            rangeBoundsOffsets = (hasLowerBoundOffset: false, hasUpperBoundOffset: true)
-            increment = 1
-            accessibilityValues = (stepIncrement: nil, valueSuffix: nil)
-            appearanceProperties = (usesSmallNumberInputFont: false, displaysUnitInNumberInput: true, isCurrencyValueRange: false)
         case .price:
+            switch self {
+            case .norway, .abroad, .caravan:
+                highValue = 700_000
+            case .mobileHome:
+                highValue = 1_000_000
+            }
             lowValue = 0
-            highValue = 500_000
+            unit = "kr"
+            rangeBoundsOffsets = (hasLowerBoundOffset: false, hasUpperBoundOffset: true)
+            increment = 10000
+            accessibilityValues = (stepIncrement: nil, valueSuffix: nil)
+            appearanceProperties = (usesSmallNumberInputFont: true, displaysUnitInNumberInput: true, isCurrencyValueRange: true)
+        case .leasepriceInit:
+            lowValue = 0
+            highValue = 150_000
+            unit = "kr"
+            rangeBoundsOffsets = (hasLowerBoundOffset: false, hasUpperBoundOffset: true)
+            increment = 10000
+            accessibilityValues = (stepIncrement: nil, valueSuffix: nil)
+            appearanceProperties = (usesSmallNumberInputFont: false, displaysUnitInNumberInput: true, isCurrencyValueRange: true)
+        case .leasepriceMonth:
+            lowValue = 0
+            highValue = 10000
             unit = "kr"
             rangeBoundsOffsets = (hasLowerBoundOffset: false, hasUpperBoundOffset: true)
             increment = 1000
             accessibilityValues = (stepIncrement: nil, valueSuffix: nil)
             appearanceProperties = (usesSmallNumberInputFont: false, displaysUnitInNumberInput: true, isCurrencyValueRange: true)
+        case .engineEffect:
+            switch self {
+            case .norway, .abroad:
+                lowValue = 0
+                highValue = 500
+            default:
+                lowValue = 0
+                highValue = 300
+            }
+            unit = "hk"
+            rangeBoundsOffsets = (hasLowerBoundOffset: false, hasUpperBoundOffset: true)
+            increment = 10
+            accessibilityValues = (stepIncrement: nil, valueSuffix: nil)
+            appearanceProperties = (usesSmallNumberInputFont: false, displaysUnitInNumberInput: true, isCurrencyValueRange: false)
+        case .numberOfSeats:
+            switch self {
+            case .norway, .abroad:
+                highValue = 10
+            case .mobileHome:
+                highValue = 8
+            default:
+                return nil
+            }
+            lowValue = 0
+            unit = "seter"
+            rangeBoundsOffsets = (hasLowerBoundOffset: false, hasUpperBoundOffset: true)
+            increment = 1
+            accessibilityValues = (stepIncrement: nil, valueSuffix: nil)
+            appearanceProperties = (usesSmallNumberInputFont: false, displaysUnitInNumberInput: true, isCurrencyValueRange: false)
+        case .noOfSleepers:
+            lowValue = 0
+            highValue = 8
+            unit = "stk."
+            rangeBoundsOffsets = (hasLowerBoundOffset: false, hasUpperBoundOffset: true)
+            increment = 1
+            accessibilityValues = (stepIncrement: nil, valueSuffix: nil)
+            appearanceProperties = (usesSmallNumberInputFont: false, displaysUnitInNumberInput: true, isCurrencyValueRange: false)
+        case .length:
+            switch self {
+            case .mobileHome:
+                lowValue = 600
+            case .caravan:
+                lowValue = 500
+            default:
+                return nil
+            }
+            highValue = 950
+            unit = "cm"
+            rangeBoundsOffsets = (hasLowerBoundOffset: true, hasUpperBoundOffset: true)
+            increment = 50
+            accessibilityValues = (stepIncrement: nil, valueSuffix: nil)
+            appearanceProperties = (usesSmallNumberInputFont: false, displaysUnitInNumberInput: true, isCurrencyValueRange: false)
+        case .width:
+            lowValue = 200
+            highValue = 350
+            unit = "cm"
+            rangeBoundsOffsets = (hasLowerBoundOffset: true, hasUpperBoundOffset: true)
+            increment = 10
+            accessibilityValues = (stepIncrement: nil, valueSuffix: nil)
+            appearanceProperties = (usesSmallNumberInputFont: false, displaysUnitInNumberInput: true, isCurrencyValueRange: false)
+        case .weight:
+            switch self {
+            case .mobileHome:
+                lowValue = 3500
+                highValue = 7500
+            case .caravan:
+                lowValue = 1000
+                highValue = 3500
+            default: return nil
+            }
+            unit = "kg"
+            rangeBoundsOffsets = (hasLowerBoundOffset: true, hasUpperBoundOffset: true)
+            increment = 100
+            accessibilityValues = (stepIncrement: nil, valueSuffix: nil)
+            appearanceProperties = (usesSmallNumberInputFont: false, displaysUnitInNumberInput: true, isCurrencyValueRange: false)
         default:
             return nil
         }

--- a/UnitTests/FilterBuilder/FilterInfoBuilderTests.swift
+++ b/UnitTests/FilterBuilder/FilterInfoBuilderTests.swift
@@ -33,10 +33,10 @@ class FilterInfoBuilderTests: XCTestCase, TestDataDecoder {
         XCTAssertNotNil(builder)
         XCTAssertNotNil(buildResult)
         XCTAssertEqual(numberOfSearchQueryFilterInfoElements, 1)
-        XCTAssertEqual(numberOfPreferenceFilterInfoElements, 4)
+        XCTAssertEqual(numberOfPreferenceFilterInfoElements, 3)
         XCTAssertEqual(numberOfRangeFilterInfoElements, 5)
         XCTAssertEqual(numberOfMultiLevelListSelectionFilterInfoElements, 1)
-        XCTAssertEqual(numberOfListSelectionFilterInfoElements, 11)
+        XCTAssertEqual(numberOfListSelectionFilterInfoElements, 12)
     }
 
     func testFilterInfoBuilderBuildsPreferenceFilterInfoWithExpectedValues() {

--- a/UnitTests/FilterBuilder/FilterMarketTests.swift
+++ b/UnitTests/FilterBuilder/FilterMarketTests.swift
@@ -16,7 +16,7 @@ extension FilterMarketTests {
     func verifyAllCasesIsExhaustive(filterMarket: FilterMarket) -> Bool {
         switch filterMarket {
         case .bap(.bap),
-             .car(.norway), .car(.abroad),
+             .car(.norway), .car(.abroad), .car(.mobileHome), .car(.caravan),
              .mc(.mc), .mc(.mopedScooter), .mc(.snowmobile), .mc(.atv),
              .job(.fullTime), .job(.partTime), .job(.management),
              .boat(.boatSale), .boat(.boatUsedWanted), .boat(.boatRent), .boat(.boatMotor), .boat(.boatParts), .boat(.boatPartsMotorWanted), .boat(.boatDock), .boat(.boatDockWanted),


### PR DESCRIPTION
# Why?
The car market was not completely configured, this adds the missing pieces.

No changes to `VerticalDemo` creation this time :) I think we're good for now.

# What?
- Finish implementing all subcategories of `Car`.