### PR TITLE
Prevent panGesture in rangeFilters view

### DIFF
--- a/Sources/RangeFilter/RangeFilterViewController.swift
+++ b/Sources/RangeFilter/RangeFilterViewController.swift
@@ -5,8 +5,16 @@
 import Foundation
 
 public final class RangeFilterViewController: FilterViewController {
+
+    // MARK: - Private attributes
+
     private let filterInfo: RangeFilterInfoType
     private var currentRangeValue: RangeValue?
+    private lazy var swallowPanGesture: UIPanGestureRecognizer = {
+        let gestureRecognizer = UIPanGestureRecognizer()
+        gestureRecognizer.cancelsTouchesInView = true
+        return gestureRecognizer
+    }()
 
     lazy var rangeFilterView: RangeFilterView = {
         let view = RangeFilterView(filterInfo: filterInfo)
@@ -44,6 +52,7 @@ public final class RangeFilterViewController: FilterViewController {
 
 private extension RangeFilterViewController {
     func setup() {
+        view.addGestureRecognizer(swallowPanGesture)
         view.backgroundColor = .milk
         title = filterInfo.title
 


### PR DESCRIPTION
# Why?
It was possible to make the bottomSheet expand/collapse by swiping within the view of a rangeFilter. The bottomSheet should only do this when sliding the top section.

# What?
- Swallow panGestures and prevent them from propagating upwards in the view hierarchy.

# Show me
### Before & After
I made the backgroundColor `lightGray` just to make it visible where I'm swiping in the view.

<img align="left" width="320" alt="range_filter_pan_before" src="https://user-images.githubusercontent.com/1901556/52109425-b5e2bd00-25fd-11e9-9ebf-b51febf3fdbb.gif">
<img width="320" alt="range_filter_pan_after" src="https://user-images.githubusercontent.com/1901556/52109426-b7ac8080-25fd-11e9-8d34-70e5f510a28f.gif">
