### PR TITLE
Don't show selection count for collapsedSelection when 1 item

### DIFF
--- a/Sources/Root/CurrentSelection/CollapsedSelectionValuesView.swift
+++ b/Sources/Root/CurrentSelection/CollapsedSelectionValuesView.swift
@@ -30,8 +30,13 @@ class CollapsedSelectionValuesView: UIView, CurrentSelectionValuesContainer {
             collapsedLabel.text = nil
             return
         }
-        let titles = selectedValues.compactMap({ $0.title })
-        collapsedLabel.text = "(\(selectedValues.count)) " + titles.joined(separator: ", ")
+        let titlesJoined = selectedValues.compactMap({ $0.title }).joined(separator: ", ")
+
+        if selectedValues.count > 1 {
+            collapsedLabel.text = "(\(selectedValues.count)) " + titlesJoined
+        } else {
+            collapsedLabel.text = titlesJoined
+        }
     }
 
     private func setup() {


### PR DESCRIPTION
# Why?
When a single item has been selected, which has a long textual value, the text was collapsed and prefixed with `(1) `.

# What?
- Remove count prefix if the collection of collapsed items has a count of 1.

# Show me
### Before & after
<img align="left" width="320" alt="screen shot 2019-02-01 at 09 41 33" src="https://user-images.githubusercontent.com/1901556/52112164-0100ce00-2606-11e9-976c-a52ab3ff5711.png">
<img width="320" alt="screen shot 2019-02-01 at 09 41 53" src="https://user-images.githubusercontent.com/1901556/52112167-02ca9180-2606-11e9-8c50-ae7ec955c3fa.png">
