### PR TITLE
Move category above location for BAP

### DIFF
--- a/Sources/FINNFilterImplementation/FilterMarkets/FilterMarketBap.swift
+++ b/Sources/FINNFilterImplementation/FilterMarkets/FilterMarketBap.swift
@@ -21,8 +21,8 @@ extension FilterMarketBap: FilterConfiguration {
 
     var supportedFiltersKeys: [FilterKey] {
         return [
-            .location,
             .category,
+            .location,
             .price,
         ]
     }


### PR DESCRIPTION
# Why?
_Ref. [this Trello task](https://trello.com/c/azq474Jj/325-filter-kategori-should-be-above-omr%C3%A5de-in-torget-root-view)._

Category should be placed above location for BAP market.

# What?
- Reordered the filters.