### PR TITLE
Filter selection tags: make the close button to clear the value

### DIFF
--- a/Charcoal.xcodeproj/project.pbxproj
+++ b/Charcoal.xcodeproj/project.pbxproj
@@ -177,6 +177,7 @@
 		CF88577D21F61D7E0056CC81 /* FeedbackGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF88577C21F61D7E0056CC81 /* FeedbackGenerator.swift */; };
 		CFB13DB021FF2B1800F8D126 /* StepTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFB13DAF21FF2B1800F8D126 /* StepTests.swift */; };
 		CFB13DB221FF2CBB00F8D126 /* ArrayStepTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFB13DB121FF2CBB00F8D126 /* ArrayStepTests.swift */; };
+		CFB8AC53220C8CDC00512252 /* FilterTagView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFB8AC52220C8CDC00512252 /* FilterTagView.swift */; };
 		CFD7BBFB2209BCDF00746823 /* RangeToolbarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFD7BBFA2209BCDF00746823 /* RangeToolbarItem.swift */; };
 		CFFD9F8D21F09F7500997D14 /* StepSliderInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFFD9F8C21F09F7500997D14 /* StepSliderInfoTests.swift */; };
 		CFFD9F9421F21B0900997D14 /* FilterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFFD9F9321F21B0900997D14 /* FilterViewController.swift */; };
@@ -413,6 +414,7 @@
 		CF88577C21F61D7E0056CC81 /* FeedbackGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackGenerator.swift; sourceTree = "<group>"; };
 		CFB13DAF21FF2B1800F8D126 /* StepTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StepTests.swift; sourceTree = "<group>"; };
 		CFB13DB121FF2CBB00F8D126 /* ArrayStepTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayStepTests.swift; sourceTree = "<group>"; };
+		CFB8AC52220C8CDC00512252 /* FilterTagView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterTagView.swift; sourceTree = "<group>"; };
 		CFD7BBFA2209BCDF00746823 /* RangeToolbarItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RangeToolbarItem.swift; sourceTree = "<group>"; };
 		CFFD9F8C21F09F7500997D14 /* StepSliderInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StepSliderInfoTests.swift; sourceTree = "<group>"; };
 		CFFD9F9321F21B0900997D14 /* FilterViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FilterViewController.swift; sourceTree = "<group>"; };
@@ -1026,6 +1028,7 @@
 				9B5E877021998B3500793A1A /* CurrentSelectionValuesContainerView.swift */,
 				9BE9A061219ADC4F00059C19 /* ExpandedSelectionValuesView.swift */,
 				46F642532199C83B00C1D864 /* SelectionWithTitle.swift */,
+				CFB8AC52220C8CDC00512252 /* FilterTagView.swift */,
 			);
 			path = CurrentSelection;
 			sourceTree = "<group>";
@@ -1397,6 +1400,7 @@
 				559C61F420DA4C8D0083A574 /* (null) in Sources */,
 				559C6CB620B6D771009B734D /* RangeNumberInputView.swift in Sources */,
 				9BB827A6216C9CD40014028C /* RangeFilterInfo.swift in Sources */,
+				CFB8AC53220C8CDC00512252 /* FilterTagView.swift in Sources */,
 				55858A1320AAC26400B100EA /* FilterInfoType.swift in Sources */,
 				9BE0A04F2091C2E90000632B /* ArrayExtensions.swift in Sources */,
 				46774F3B21BFF57F00ECFED8 /* MapDistanceValueFormatter.swift in Sources */,

--- a/Sources/Root/CurrentSelection/ExpandedSelectionValuesView.swift
+++ b/Sources/Root/CurrentSelection/ExpandedSelectionValuesView.swift
@@ -55,6 +55,8 @@ class ExpandedSelectionValuesView: UIView, CurrentSelectionValuesContainer {
     }
 }
 
+// MARK: - FilterTagViewDelegate
+
 extension ExpandedSelectionValuesView: FilterTagViewDelegate {
     func filterTagViewDidSelectRemove(_ view: FilterTagView) {
         guard let tappedIndex = buttonContainerView.arrangedSubviews.index(of: view) else {

--- a/Sources/Root/CurrentSelection/ExpandedSelectionValuesView.swift
+++ b/Sources/Root/CurrentSelection/ExpandedSelectionValuesView.swift
@@ -37,16 +37,6 @@ class ExpandedSelectionValuesView: UIView, CurrentSelectionValuesContainer {
         buttonContainerView.fillInSuperview()
     }
 
-    @objc private func didTapRemoveButton(_ sender: UIButton) {
-        guard let tappedIndex = buttonContainerView.arrangedSubviews.index(of: sender) else {
-            return
-        }
-        guard let selection = selectedValues?[safe: tappedIndex] else {
-            return
-        }
-        delegate?.currentSelectionValuesContainerView(self, didTapRemoveSelection: selection)
-    }
-
     func configure(with selectedValues: [SelectionWithTitle]?) {
         buttonContainerView.arrangedSubviews.forEach { $0.removeFromSuperview() }
         self.selectedValues = selectedValues
@@ -56,58 +46,23 @@ class ExpandedSelectionValuesView: UIView, CurrentSelectionValuesContainer {
         }
 
         selectedValues.forEach { selectedValue in
-            let button = FilterValueView(title: selectedValue.title)
-            button.translatesAutoresizingMaskIntoConstraints = false
-            button.backgroundColor = selectedValue.selectionInfo.isValid ? .primaryBlue : .cherry
-            buttonContainerView.addArrangedSubview(button)
-            // button.addTarget(self, action: #selector(didTapRemoveButton(_:)), for: .touchUpInside)
+            let view = FilterTagView(title: selectedValue.title)
+            view.translatesAutoresizingMaskIntoConstraints = false
+            view.backgroundColor = selectedValue.selectionInfo.isValid ? .primaryBlue : .cherry
+            view.delegate = self
+            buttonContainerView.addArrangedSubview(view)
         }
     }
 }
 
-private class FilterValueView: UIView {
-    private lazy var titleLabel: UILabel = {
-        let label = UILabel(withAutoLayout: true)
-        label.font = .title5
-        label.textColor = .milk
-        return label
-    }()
-
-    private lazy var button: UIButton = {
-        let button = UIButton(withAutoLayout: true)
-        button.imageEdgeInsets = UIEdgeInsets(leading: .smallSpacing)
-        button.setImage(UIImage(named: .removeFilterValue), for: .normal)
-        // button.addTarget(self, action: #selector(didTapRemoveButton(_:)), for: .touchUpInside)
-        return button
-    }()
-
-    init(title: String) {
-        super.init(frame: .zero)
-        setup(title: title)
-    }
-
-    required init?(coder aDecoder: NSCoder) {
-        super.init(coder: aDecoder)
-        setup(title: "")
-    }
-
-    private func setup(title: String) {
-        addSubview(titleLabel)
-        addSubview(button)
-
-        titleLabel.text = title
-
-        layer.cornerRadius = 4
-        backgroundColor = .primaryBlue
-
-        NSLayoutConstraint.activate([
-            titleLabel.topAnchor.constraint(equalTo: topAnchor, constant: .mediumSpacing),
-            titleLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -.mediumSpacing),
-            titleLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: .mediumSpacing),
-
-            button.leadingAnchor.constraint(equalTo: titleLabel.trailingAnchor),
-            button.trailingAnchor.constraint(equalTo: trailingAnchor),
-            button.centerYAnchor.constraint(equalTo: titleLabel.centerYAnchor),
-        ])
+extension ExpandedSelectionValuesView: FilterTagViewDelegate {
+    func filterTagViewDidSelectRemove(_ view: FilterTagView) {
+        guard let tappedIndex = buttonContainerView.arrangedSubviews.index(of: view) else {
+            return
+        }
+        guard let selection = selectedValues?[safe: tappedIndex] else {
+            return
+        }
+        delegate?.currentSelectionValuesContainerView(self, didTapRemoveSelection: selection)
     }
 }

--- a/Sources/Root/CurrentSelection/ExpandedSelectionValuesView.swift
+++ b/Sources/Root/CurrentSelection/ExpandedSelectionValuesView.swift
@@ -56,16 +56,31 @@ class ExpandedSelectionValuesView: UIView, CurrentSelectionValuesContainer {
         }
 
         selectedValues.forEach { selectedValue in
-            let button = RemoveFilterValueButton(title: selectedValue.title)
+            let button = FilterValueView(title: selectedValue.title)
             button.translatesAutoresizingMaskIntoConstraints = false
             button.backgroundColor = selectedValue.selectionInfo.isValid ? .primaryBlue : .cherry
             buttonContainerView.addArrangedSubview(button)
-            button.addTarget(self, action: #selector(didTapRemoveButton(_:)), for: .touchUpInside)
+            // button.addTarget(self, action: #selector(didTapRemoveButton(_:)), for: .touchUpInside)
         }
     }
 }
 
-private class RemoveFilterValueButton: UIButton {
+private class FilterValueView: UIView {
+    private lazy var titleLabel: UILabel = {
+        let label = UILabel(withAutoLayout: true)
+        label.font = .title5
+        label.textColor = .milk
+        return label
+    }()
+
+    private lazy var button: UIButton = {
+        let button = UIButton(withAutoLayout: true)
+        button.imageEdgeInsets = UIEdgeInsets(leading: .smallSpacing)
+        button.setImage(UIImage(named: .removeFilterValue), for: .normal)
+        // button.addTarget(self, action: #selector(didTapRemoveButton(_:)), for: .touchUpInside)
+        return button
+    }()
+
     init(title: String) {
         super.init(frame: .zero)
         setup(title: title)
@@ -77,25 +92,22 @@ private class RemoveFilterValueButton: UIButton {
     }
 
     private func setup(title: String) {
+        addSubview(titleLabel)
+        addSubview(button)
+
+        titleLabel.text = title
+
         layer.cornerRadius = 4
         backgroundColor = .primaryBlue
-        titleLabel?.font = .title5
-        setTitleColor(.milk, for: .normal)
-        contentEdgeInsets = UIEdgeInsets(leading: .mediumSpacing, trailing: .mediumSpacing)
-        imageEdgeInsets = UIEdgeInsets(leading: .smallSpacing)
-        setImage(UIImage(named: .removeFilterValue), for: .normal)
-        setTitle(title, for: .normal)
-    }
 
-    override func imageRect(forContentRect contentRect: CGRect) -> CGRect {
-        var imageRect = super.imageRect(forContentRect: contentRect)
-        imageRect.origin.x = contentRect.maxX - imageRect.width - imageEdgeInsets.right + imageEdgeInsets.left
-        return imageRect
-    }
+        NSLayoutConstraint.activate([
+            titleLabel.topAnchor.constraint(equalTo: topAnchor, constant: .mediumSpacing),
+            titleLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -.mediumSpacing),
+            titleLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: .mediumSpacing),
 
-    override func titleRect(forContentRect contentRect: CGRect) -> CGRect {
-        var titleRect = super.titleRect(forContentRect: contentRect)
-        titleRect.origin.x = titleRect.minX - imageRect(forContentRect: contentRect).width
-        return titleRect
+            button.leadingAnchor.constraint(equalTo: titleLabel.trailingAnchor),
+            button.trailingAnchor.constraint(equalTo: trailingAnchor),
+            button.centerYAnchor.constraint(equalTo: titleLabel.centerYAnchor),
+        ])
     }
 }

--- a/Sources/Root/CurrentSelection/FilterTagView.swift
+++ b/Sources/Root/CurrentSelection/FilterTagView.swift
@@ -21,7 +21,8 @@ final class FilterTagView: UIView {
     }()
 
     private lazy var removeButton: UIButton = {
-        let button = UIButton(withAutoLayout: true)
+        let button = RemoveButton(withAutoLayout: true)
+        button.adjustsImageWhenHighlighted = false
         button.imageEdgeInsets = UIEdgeInsets(leading: .smallSpacing, trailing: .smallSpacing)
         button.setImage(removeButtonImage, for: .normal)
         button.addTarget(self, action: #selector(handleRemoveButtonTap), for: .touchUpInside)
@@ -72,5 +73,23 @@ final class FilterTagView: UIView {
 
     @objc private func handleRemoveButtonTap() {
         delegate?.filterTagViewDidSelectRemove(self)
+    }
+}
+
+private final class RemoveButton: UIButton {
+    override var isHighlighted: Bool {
+        didSet {
+            updateAlpha(opaque: !isHighlighted)
+        }
+    }
+
+    override var isSelected: Bool {
+        didSet {
+            updateAlpha(opaque: !isSelected)
+        }
+    }
+
+    private func updateAlpha(opaque: Bool) {
+        alpha = opaque ? 1 : 0.7
     }
 }

--- a/Sources/Root/CurrentSelection/FilterTagView.swift
+++ b/Sources/Root/CurrentSelection/FilterTagView.swift
@@ -11,6 +11,8 @@ protocol FilterTagViewDelegate: AnyObject {
 final class FilterTagView: UIView {
     weak var delegate: FilterTagViewDelegate?
 
+    // MARK: - Private vars
+
     private lazy var titleLabel: UILabel = {
         let label = UILabel(withAutoLayout: true)
         label.font = .title5
@@ -18,7 +20,7 @@ final class FilterTagView: UIView {
         return label
     }()
 
-    private lazy var button: UIButton = {
+    private lazy var removeButton: UIButton = {
         let button = UIButton(withAutoLayout: true)
         button.imageEdgeInsets = UIEdgeInsets(leading: .smallSpacing, trailing: .smallSpacing)
         button.setImage(removeButtonImage, for: .normal)
@@ -44,24 +46,25 @@ final class FilterTagView: UIView {
 
     private func setup(title: String) {
         addSubview(titleLabel)
-        addSubview(button)
+        addSubview(removeButton)
 
         layer.cornerRadius = 4
         backgroundColor = .primaryBlue
         titleLabel.text = title
 
-        let buttonWidth = removeButtonImage.size.width + button.imageEdgeInsets.leading + button.imageEdgeInsets.trailing
+        let buttonInsets = removeButton.imageEdgeInsets.leading + removeButton.imageEdgeInsets.trailing
+        let buttonWidth = removeButtonImage.size.width + buttonInsets
 
         NSLayoutConstraint.activate([
             titleLabel.topAnchor.constraint(equalTo: topAnchor, constant: .mediumSpacing),
             titleLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -.mediumSpacing),
             titleLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: .mediumSpacing),
-            titleLabel.trailingAnchor.constraint(equalTo: button.leadingAnchor),
+            titleLabel.trailingAnchor.constraint(equalTo: removeButton.leadingAnchor),
 
-            button.trailingAnchor.constraint(equalTo: trailingAnchor),
-            button.topAnchor.constraint(equalTo: topAnchor),
-            button.bottomAnchor.constraint(equalTo: bottomAnchor),
-            button.widthAnchor.constraint(equalToConstant: buttonWidth), // 22)
+            removeButton.trailingAnchor.constraint(equalTo: trailingAnchor),
+            removeButton.topAnchor.constraint(equalTo: topAnchor),
+            removeButton.bottomAnchor.constraint(equalTo: bottomAnchor),
+            removeButton.widthAnchor.constraint(equalToConstant: buttonWidth),
         ])
     }
 

--- a/Sources/Root/CurrentSelection/FilterTagView.swift
+++ b/Sources/Root/CurrentSelection/FilterTagView.swift
@@ -1,0 +1,73 @@
+//
+//  Copyright © FINN.no AS, Inc. All rights reserved.
+//
+
+import UIKit
+
+protocol FilterTagViewDelegate: AnyObject {
+    func filterTagViewDidSelectRemove(_ view: FilterTagView)
+}
+
+final class FilterTagView: UIView {
+    weak var delegate: FilterTagViewDelegate?
+
+    private lazy var titleLabel: UILabel = {
+        let label = UILabel(withAutoLayout: true)
+        label.font = .title5
+        label.textColor = .milk
+        return label
+    }()
+
+    private lazy var button: UIButton = {
+        let button = UIButton(withAutoLayout: true)
+        button.imageEdgeInsets = UIEdgeInsets(leading: .smallSpacing, trailing: .smallSpacing)
+        button.setImage(removeButtonImage, for: .normal)
+        button.addTarget(self, action: #selector(handleRemoveButtonTap), for: .touchUpInside)
+        return button
+    }()
+
+    private lazy var removeButtonImage = UIImage(named: .removeFilterValue)
+
+    // MARK: - Init
+
+    init(title: String) {
+        super.init(frame: .zero)
+        setup(title: title)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        setup(title: "")
+    }
+
+    // MARK: - Setup
+
+    private func setup(title: String) {
+        addSubview(titleLabel)
+        addSubview(button)
+
+        layer.cornerRadius = 4
+        backgroundColor = .primaryBlue
+        titleLabel.text = title
+
+        let buttonWidth = removeButtonImage.size.width + button.imageEdgeInsets.leading + button.imageEdgeInsets.trailing
+
+        NSLayoutConstraint.activate([
+            titleLabel.topAnchor.constraint(equalTo: topAnchor, constant: .mediumSpacing),
+            titleLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -.mediumSpacing),
+            titleLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: .mediumSpacing),
+            titleLabel.trailingAnchor.constraint(equalTo: button.leadingAnchor),
+
+            button.trailingAnchor.constraint(equalTo: trailingAnchor),
+            button.topAnchor.constraint(equalTo: topAnchor),
+            button.bottomAnchor.constraint(equalTo: bottomAnchor),
+            button.widthAnchor.constraint(equalToConstant: buttonWidth), // 22)
+        ])
+    }
+
+    // MARK: - Actions
+
+    @objc private func handleRemoveButtonTap() {
+        delegate?.filterTagViewDidSelectRemove(self)
+    }
+}


### PR DESCRIPTION
# Why?

We decided to do so, I think mainly because it was easy to remove filter tags by accident.

# What?

Make the close button to clear the value while the tag selection view itself is not interactive.

# Show me

### Before

![filter_before](https://user-images.githubusercontent.com/10529867/52476768-0038e080-2ba0-11e9-92b4-3e1cc24fc979.gif)


### After

![filter](https://user-images.githubusercontent.com/10529867/52476775-0464fe00-2ba0-11e9-8c75-90730a526f08.gif)
