### PR TITLE
Filter tree structure

### DIFF
--- a/Charcoal.xcodeproj/project.pbxproj
+++ b/Charcoal.xcodeproj/project.pbxproj
@@ -183,6 +183,10 @@
 		CFFD9F9421F21B0900997D14 /* FilterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFFD9F9321F21B0900997D14 /* FilterViewController.swift */; };
 		CFFD9F9621F2257900997D14 /* Array+Step.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFFD9F9521F2257900997D14 /* Array+Step.swift */; };
 		CFFD9F9821F2285400997D14 /* Step.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFFD9F9721F2285400997D14 /* Step.swift */; };
+		DA0DEEFB220DAF26005BB386 /* CCRangeFilterNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA0DEEFA220DAF26005BB386 /* CCRangeFilterNode.swift */; };
+		DA0DEEFD220DAF92005BB386 /* CCMapFilterNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA0DEEFC220DAF92005BB386 /* CCMapFilterNode.swift */; };
+		DA0DEEFF220DB02C005BB386 /* RangeNodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA0DEEFE220DB02C005BB386 /* RangeNodeTests.swift */; };
+		DA0DEF01220DB0E0005BB386 /* MapNodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA0DEF00220DB0E0005BB386 /* MapNodeTests.swift */; };
 		DA3F763D2188812700D21C3A /* StepperFilterInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA3F763C2188812700D21C3A /* StepperFilterInfo.swift */; };
 		DA51040B21BE5F19004048BD /* FinniversKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA51040A21BE5F19004048BD /* FinniversKit.framework */; };
 		DA51040C21BE5F59004048BD /* FinniversKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA51040A21BE5F19004048BD /* FinniversKit.framework */; };
@@ -193,6 +197,10 @@
 		DA51041C21BE6AFE004048BD /* Font.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA51041A21BE6AFE004048BD /* Font.swift */; };
 		DA51041D21BE6CE3004048BD /* FinniversKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA51040A21BE5F19004048BD /* FinniversKit.framework */; };
 		DA7FB7A821B01E33003DBBEB /* SegmentButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7FB7A721B01E33003DBBEB /* SegmentButton.swift */; };
+		DA8D6842220DAB0600D31941 /* CCFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA8D6841220DAB0600D31941 /* CCFilter.swift */; };
+		DA8D6844220DAB3D00D31941 /* CCFilterNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA8D6843220DAB3D00D31941 /* CCFilterNode.swift */; };
+		DA8D6846220DAC0700D31941 /* FilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA8D6845220DAC0700D31941 /* FilterTests.swift */; };
+		DA8D6849220DAC4700D31941 /* FilterNodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA8D6848220DAC4700D31941 /* FilterNodeTests.swift */; };
 		DAE69E282187435B0084F37C /* StepperFilterInfoType.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE69E272187435B0084F37C /* StepperFilterInfoType.swift */; };
 		DAEB179721A6986500D9AAD6 /* SearchQueryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAEB179621A6986500D9AAD6 /* SearchQueryViewController.swift */; };
 		DAF3CA7021830293007235B0 /* StepperFilterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAF3CA6F21830293007235B0 /* StepperFilterViewController.swift */; };
@@ -420,11 +428,19 @@
 		CFFD9F9321F21B0900997D14 /* FilterViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FilterViewController.swift; sourceTree = "<group>"; };
 		CFFD9F9521F2257900997D14 /* Array+Step.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Step.swift"; sourceTree = "<group>"; };
 		CFFD9F9721F2285400997D14 /* Step.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Step.swift; sourceTree = "<group>"; };
+		DA0DEEFA220DAF26005BB386 /* CCRangeFilterNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CCRangeFilterNode.swift; sourceTree = "<group>"; };
+		DA0DEEFC220DAF92005BB386 /* CCMapFilterNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CCMapFilterNode.swift; sourceTree = "<group>"; };
+		DA0DEEFE220DB02C005BB386 /* RangeNodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RangeNodeTests.swift; sourceTree = "<group>"; };
+		DA0DEF00220DB0E0005BB386 /* MapNodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapNodeTests.swift; sourceTree = "<group>"; };
 		DA3F763C2188812700D21C3A /* StepperFilterInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StepperFilterInfo.swift; sourceTree = "<group>"; };
 		DA51040A21BE5F19004048BD /* FinniversKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FinniversKit.framework; path = Carthage/Build/iOS/FinniversKit.framework; sourceTree = "<group>"; };
 		DA51041021BE66A1004048BD /* HockeySDK.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = HockeySDK.framework; path = Carthage/Build/iOS/HockeySDK.framework; sourceTree = "<group>"; };
 		DA51041A21BE6AFE004048BD /* Font.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Font.swift; sourceTree = "<group>"; };
 		DA7FB7A721B01E33003DBBEB /* SegmentButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegmentButton.swift; sourceTree = "<group>"; };
+		DA8D6841220DAB0600D31941 /* CCFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CCFilter.swift; sourceTree = "<group>"; };
+		DA8D6843220DAB3D00D31941 /* CCFilterNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CCFilterNode.swift; sourceTree = "<group>"; };
+		DA8D6845220DAC0700D31941 /* FilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterTests.swift; sourceTree = "<group>"; };
+		DA8D6848220DAC4700D31941 /* FilterNodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterNodeTests.swift; sourceTree = "<group>"; };
 		DAE69E272187435B0084F37C /* StepperFilterInfoType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StepperFilterInfoType.swift; sourceTree = "<group>"; };
 		DAEB179621A6986500D9AAD6 /* SearchQueryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchQueryViewController.swift; sourceTree = "<group>"; };
 		DAF3CA6F21830293007235B0 /* StepperFilterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StepperFilterViewController.swift; sourceTree = "<group>"; };
@@ -619,6 +635,8 @@
 				44ECE6AF208F83BD0017AC82 /* Resources */,
 				9BE0A0402091BE750000632B /* Root */,
 				46905238217F5CB500F8E7FD /* Vertical */,
+				DA0DEEF8220DADD5005BB386 /* CCFilter */,
+				DA0DEEF9220DADDD005BB386 /* CCFilterNode */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -657,6 +675,8 @@
 				44ECE685208F7FDE0017AC82 /* Info.plist */,
 				559C620120DA88330083A574 /* Test Data */,
 				55BDA76520DB7FC000331FFC /* TestDataDecoder.swift */,
+				DA0DEEF6220DACA9005BB386 /* FilterNodes */,
+				DA8D6847220DAC3A00D31941 /* Filter */,
 			);
 			path = UnitTests;
 			sourceTree = "<group>";
@@ -1081,6 +1101,42 @@
 			path = StepSlider;
 			sourceTree = "<group>";
 		};
+		DA0DEEF6220DACA9005BB386 /* FilterNodes */ = {
+			isa = PBXGroup;
+			children = (
+				DA8D6848220DAC4700D31941 /* FilterNodeTests.swift */,
+				DA0DEEFE220DB02C005BB386 /* RangeNodeTests.swift */,
+				DA0DEF00220DB0E0005BB386 /* MapNodeTests.swift */,
+			);
+			path = FilterNodes;
+			sourceTree = "<group>";
+		};
+		DA0DEEF8220DADD5005BB386 /* CCFilter */ = {
+			isa = PBXGroup;
+			children = (
+				DA8D6841220DAB0600D31941 /* CCFilter.swift */,
+			);
+			path = CCFilter;
+			sourceTree = "<group>";
+		};
+		DA0DEEF9220DADDD005BB386 /* CCFilterNode */ = {
+			isa = PBXGroup;
+			children = (
+				DA8D6843220DAB3D00D31941 /* CCFilterNode.swift */,
+				DA0DEEFA220DAF26005BB386 /* CCRangeFilterNode.swift */,
+				DA0DEEFC220DAF92005BB386 /* CCMapFilterNode.swift */,
+			);
+			path = CCFilterNode;
+			sourceTree = "<group>";
+		};
+		DA8D6847220DAC3A00D31941 /* Filter */ = {
+			isa = PBXGroup;
+			children = (
+				DA8D6845220DAC0700D31941 /* FilterTests.swift */,
+			);
+			path = Filter;
+			sourceTree = "<group>";
+		};
 		DAF3CA6E218301B3007235B0 /* StepperFilter */ = {
 			isa = PBXGroup;
 			children = (
@@ -1380,6 +1436,7 @@
 				55C9CC292099C2A700F0C9C8 /* CustomPopoverPresentationTransitioningDelegate.swift in Sources */,
 				9B923324212A9F4200B02723 /* UIDeviceExtensions.swift in Sources */,
 				9BFC089421341FFA00AB8A11 /* FilterSelectionDataSource.swift in Sources */,
+				DA0DEEFB220DAF26005BB386 /* CCRangeFilterNode.swift in Sources */,
 				9B741D1C21B6B1CB00D18097 /* StepSlider.swift in Sources */,
 				08716B3721F76424003180D8 /* FilterKey.swift in Sources */,
 				55F97D1720B4432C002BABC9 /* RangeSliderView.swift in Sources */,
@@ -1400,6 +1457,7 @@
 				559C61F420DA4C8D0083A574 /* (null) in Sources */,
 				559C6CB620B6D771009B734D /* RangeNumberInputView.swift in Sources */,
 				9BB827A6216C9CD40014028C /* RangeFilterInfo.swift in Sources */,
+				DA8D6842220DAB0600D31941 /* CCFilter.swift in Sources */,
 				CFB8AC53220C8CDC00512252 /* FilterTagView.swift in Sources */,
 				55858A1320AAC26400B100EA /* FilterInfoType.swift in Sources */,
 				9BE0A04F2091C2E90000632B /* ArrayExtensions.swift in Sources */,
@@ -1417,6 +1475,7 @@
 				9B5A66F821A2E26C005C9118 /* FilterRootStateController.swift in Sources */,
 				9BE0A05A2091E7E90000632B /* SearchQueryCell.swift in Sources */,
 				9BB827B1216CD0860014028C /* RangeFilterInfoType.swift in Sources */,
+				DA8D6844220DAB3D00D31941 /* CCFilterNode.swift in Sources */,
 				9BE0D54521A5696100F0B63B /* ErrorViewController.swift in Sources */,
 				55858A1720AAC2EB00B100EA /* FilterDataSource.swift in Sources */,
 				CFFD9F9821F2285400997D14 /* Step.swift in Sources */,
@@ -1466,6 +1525,7 @@
 				4690523A217F5CD000F8E7FD /* Vertical.swift in Sources */,
 				9BE0A061209200410000632B /* FilterCell.swift in Sources */,
 				55BDA77320DBD99600331FFC /* ParameterBasedFilterInfo.swift in Sources */,
+				DA0DEEFD220DAF92005BB386 /* CCMapFilterNode.swift in Sources */,
 				9B5A66F621A2E122005C9118 /* LoadingViewController.swift in Sources */,
 				55E869E220E39373008B921E /* FilterNavigator.swift in Sources */,
 				4670268F2170DD3900B9C952 /* SliderReferenceValueView.swift in Sources */,
@@ -1514,7 +1574,11 @@
 				55BDA76620DB7FC000331FFC /* TestDataDecoder.swift in Sources */,
 				CFB13DB221FF2CBB00F8D126 /* ArrayStepTests.swift in Sources */,
 				9BE5EC9021EE0BB1009C5E1A /* FilterSelectionDataTests.swift in Sources */,
+				DA0DEEFF220DB02C005BB386 /* RangeNodeTests.swift in Sources */,
+				DA8D6846220DAC0700D31941 /* FilterTests.swift in Sources */,
 				559C61FC20DA87330083A574 /* FilterDecodingTests.swift in Sources */,
+				DA0DEF01220DB0E0005BB386 /* MapNodeTests.swift in Sources */,
+				DA8D6849220DAC4700D31941 /* FilterNodeTests.swift in Sources */,
 				9BE0D54321A4552300F0B63B /* FilterMarketTests.swift in Sources */,
 				55BDA76120DB7E8C00331FFC /* FilterInfoBuilderTests.swift in Sources */,
 				9BB827B4216DF2E20014028C /* ParameterBasedFilterInfoSelectionDataSourceTests.swift in Sources */,

--- a/Sources/CCFilter/CCFilter.swift
+++ b/Sources/CCFilter/CCFilter.swift
@@ -5,7 +5,12 @@
 import Foundation
 
 public class CCFilter {
+
+    // MARK: - Private properties
+
     private var root: CCFilterNode
+
+    // MARK: - Setup
 
     public init(root: CCFilterNode) {
         self.root = root
@@ -13,8 +18,8 @@ public class CCFilter {
 }
 
 public extension CCFilter {
-    var urlEncoded: String {
-        return root.urlItems.joined(separator: "&")
+    var queryItems: [URLQueryItem] {
+        return root.queryItems
     }
 
     func reset() {

--- a/Sources/CCFilter/CCFilter.swift
+++ b/Sources/CCFilter/CCFilter.swift
@@ -1,0 +1,23 @@
+//
+//  Copyright © FINN.no AS, Inc. All rights reserved.
+//
+
+import Foundation
+
+public class CCFilter {
+    private var root: CCFilterNode
+
+    public init(root: CCFilterNode) {
+        self.root = root
+    }
+}
+
+public extension CCFilter {
+    var urlEncoded: String {
+        return root.urlItems.joined(separator: "&")
+    }
+
+    func reset() {
+        root.reset()
+    }
+}

--- a/Sources/CCFilterNode/CCFilterNode.swift
+++ b/Sources/CCFilterNode/CCFilterNode.swift
@@ -1,0 +1,72 @@
+//
+//  Copyright © FINN.no AS, Inc. All rights reserved.
+//
+
+import Foundation
+
+private protocol CCFilterNodeDelegate: class {
+    func childNodeDidChangeSelection(_ childNode: CCFilterNode)
+}
+
+public class CCFilterNode {
+
+    // MARK: - Public properties
+
+    public let title: String
+    public let name: String
+    public var value: String?
+    public var numberOfResults: Int
+
+    public var isSelected: Bool {
+        didSet { delegate?.childNodeDidChangeSelection(self) }
+    }
+
+    // MARK: - Private properties
+
+    private(set) var children: [CCFilterNode] = []
+    private weak var delegate: CCFilterNodeDelegate?
+
+    // MARK: - Setup
+
+    public init(title: String, name: String, value: String? = nil, isSelected: Bool = false, numberOfResults: Int = 0) {
+        self.title = title
+        self.name = name
+        self.value = value
+        self.isSelected = isSelected
+        self.numberOfResults = numberOfResults
+    }
+
+    // MARK: - Public methods
+
+    func add(child: CCFilterNode, at index: Int? = nil) {
+        if let index = index { children.insert(child, at: index) }
+        else { children.append(child) }
+        child.delegate = self
+    }
+
+    func child(at index: Int) -> CCFilterNode {
+        return children[index]
+    }
+
+    func reset() {
+        isSelected = false
+        children.forEach { $0.reset() }
+    }
+
+    var isLeafNode: Bool {
+        return children.count == 0
+    }
+
+    var urlItems: [String] {
+        if isSelected, let value = value {
+            return ["\(name)=\(value)"]
+        }
+        return children.reduce([]) { $0 + $1.urlItems }
+    }
+}
+
+extension CCFilterNode: CCFilterNodeDelegate {
+    func childNodeDidChangeSelection(_ childNode: CCFilterNode) {
+        isSelected = children.reduce(true) { $0 && $1.isSelected }
+    }
+}

--- a/Sources/CCFilterNode/CCFilterNode.swift
+++ b/Sources/CCFilterNode/CCFilterNode.swift
@@ -15,7 +15,7 @@ public class CCFilterNode {
     public let title: String
     public let name: String
     public var value: String?
-    public var numberOfResults: Int
+    public let numberOfResults: Int
 
     public var isSelected: Bool {
         didSet { delegate?.childNodeDidChangeSelection(self) }
@@ -39,12 +39,16 @@ public class CCFilterNode {
     // MARK: - Public methods
 
     func add(child: CCFilterNode, at index: Int? = nil) {
-        if let index = index { children.insert(child, at: index) }
-        else { children.append(child) }
+        if let index = index {
+            children.insert(child, at: index)
+        } else {
+            children.append(child)
+        }
         child.delegate = self
     }
 
-    func child(at index: Int) -> CCFilterNode {
+    func child(at index: Int) -> CCFilterNode? {
+        guard index < children.count else { return nil }
         return children[index]
     }
 
@@ -54,19 +58,19 @@ public class CCFilterNode {
     }
 
     var isLeafNode: Bool {
-        return children.count == 0
+        return children.isEmpty
     }
 
-    var urlItems: [String] {
+    var queryItems: [URLQueryItem] {
         if isSelected, let value = value {
-            return ["\(name)=\(value)"]
+            return [URLQueryItem(name: name, value: value)]
         }
-        return children.reduce([]) { $0 + $1.urlItems }
+        return children.reduce([]) { $0 + $1.queryItems }
     }
 }
 
 extension CCFilterNode: CCFilterNodeDelegate {
     func childNodeDidChangeSelection(_ childNode: CCFilterNode) {
-        isSelected = children.reduce(true) { $0 && $1.isSelected }
+        isSelected = children.allSatisfy { $0.isSelected }
     }
 }

--- a/Sources/CCFilterNode/CCMapFilterNode.swift
+++ b/Sources/CCFilterNode/CCMapFilterNode.swift
@@ -4,29 +4,36 @@
 
 import Foundation
 
-extension CCMapFilterNode {
-    enum Key: String, CaseIterable {
-        case lat, lon, radius, geoLocationName
-    }
+public class CCMapFilterNode: CCFilterNode {
 
-    enum Index: Int, CaseIterable {
-        case lat, lon, radius, geoLocationName
-    }
-}
+    // MARK: - Public properies
 
-class CCMapFilterNode: CCFilterNode {
-    static let filterKey = "map"
+    public static let filterKey = "map"
 
-    init(title: String, name: String) {
+    // MARK: - Internal properties
+
+    let latitudeNode: CCFilterNode
+    let longitudeNode: CCFilterNode
+    let radiusNode: CCFilterNode
+    let geoLocationNode: CCFilterNode
+
+    // MARK: - Setup
+
+    public init(title: String, name: String) {
+        latitudeNode = CCFilterNode(title: "", name: "lat")
+        longitudeNode = CCFilterNode(title: "", name: "lon")
+        radiusNode = CCFilterNode(title: "", name: "radius")
+        geoLocationNode = CCFilterNode(title: "", name: "geoLocationName")
         super.init(title: title, name: name, value: nil, isSelected: false, numberOfResults: 0)
         setup()
     }
 }
 
-extension CCMapFilterNode {
+private extension CCMapFilterNode {
     func setup() {
-        Index.allCases.forEach {
-            add(child: CCFilterNode(title: "", name: Key.allCases[$0.rawValue].rawValue))
-        }
+        add(child: latitudeNode)
+        add(child: longitudeNode)
+        add(child: radiusNode)
+        add(child: geoLocationNode)
     }
 }

--- a/Sources/CCFilterNode/CCMapFilterNode.swift
+++ b/Sources/CCFilterNode/CCMapFilterNode.swift
@@ -1,0 +1,32 @@
+//
+//  Copyright © FINN.no AS, Inc. All rights reserved.
+//
+
+import Foundation
+
+extension CCMapFilterNode {
+    enum Key: String, CaseIterable {
+        case lat, lon, radius, geoLocationName
+    }
+
+    enum Index: Int, CaseIterable {
+        case lat, lon, radius, geoLocationName
+    }
+}
+
+class CCMapFilterNode: CCFilterNode {
+    static let filterKey = "map"
+
+    init(title: String, name: String) {
+        super.init(title: title, name: name, value: nil, isSelected: false, numberOfResults: 0)
+        setup()
+    }
+}
+
+extension CCMapFilterNode {
+    func setup() {
+        Index.allCases.forEach {
+            add(child: CCFilterNode(title: "", name: Key.allCases[$0.rawValue].rawValue))
+        }
+    }
+}

--- a/Sources/CCFilterNode/CCRangeFilterNode.swift
+++ b/Sources/CCFilterNode/CCRangeFilterNode.swift
@@ -4,40 +4,35 @@
 
 import Foundation
 
-extension CCRangeFilterNode {
-    enum Key: String, CaseIterable {
-        case from = "_from", to = "_to"
-    }
-
-    enum Index: Int, CaseIterable {
-        case from, to
-    }
-}
-
 public class CCRangeFilterNode: CCFilterNode {
+
+    // MARK: - Internal properties
+
+    let lowNode: CCFilterNode
+    let highNode: CCFilterNode
+
     public init(title: String, name: String) {
+        lowNode = CCFilterNode(title: "", name: name + "_from")
+        highNode = CCFilterNode(title: "", name: name + "_to")
         super.init(title: title, name: name)
         setup()
     }
 
-    override var urlItems: [String] {
-        let fromNode = child(at: Index.from.rawValue)
-        let toNode = child(at: Index.to.rawValue)
-
+    override var queryItems: [URLQueryItem] {
         if isSelected {
-            guard let fromValue = fromNode.value, let toValue = toNode.value else { return [] }
-            let fromItem = "\(fromNode.name)=\(fromValue)"
-            let toItem = "\(toNode.name)=\(toValue)"
+            guard let lowValue = lowNode.value, let highValue = highNode.value else { return [] }
+            let fromItem = URLQueryItem(name: lowNode.name, value: lowValue)
+            let toItem = URLQueryItem(name: highNode.name, value: highValue)
             return [fromItem, toItem]
         } else {
-            return fromNode.urlItems + toNode.urlItems
+            return lowNode.queryItems + highNode.queryItems
         }
     }
 
     override func reset() {
         isSelected = false
-        reset(child(at: Index.from.rawValue))
-        reset(child(at: Index.to.rawValue))
+        reset(lowNode)
+        reset(highNode)
     }
 
     private func reset(_ child: CCFilterNode) {
@@ -48,8 +43,7 @@ public class CCRangeFilterNode: CCFilterNode {
 
 extension CCRangeFilterNode {
     func setup() {
-        Index.allCases.forEach {
-            add(child: CCFilterNode(title: "", name: name + Key.allCases[$0.rawValue].rawValue))
-        }
+        add(child: lowNode)
+        add(child: highNode)
     }
 }

--- a/Sources/CCFilterNode/CCRangeFilterNode.swift
+++ b/Sources/CCFilterNode/CCRangeFilterNode.swift
@@ -1,0 +1,55 @@
+//
+//  Copyright © FINN.no AS, Inc. All rights reserved.
+//
+
+import Foundation
+
+extension CCRangeFilterNode {
+    enum Key: String, CaseIterable {
+        case from = "_from", to = "_to"
+    }
+
+    enum Index: Int, CaseIterable {
+        case from, to
+    }
+}
+
+public class CCRangeFilterNode: CCFilterNode {
+    public init(title: String, name: String) {
+        super.init(title: title, name: name)
+        setup()
+    }
+
+    override var urlItems: [String] {
+        let fromNode = child(at: Index.from.rawValue)
+        let toNode = child(at: Index.to.rawValue)
+
+        if isSelected {
+            guard let fromValue = fromNode.value, let toValue = toNode.value else { return [] }
+            let fromItem = "\(fromNode.name)=\(fromValue)"
+            let toItem = "\(toNode.name)=\(toValue)"
+            return [fromItem, toItem]
+        } else {
+            return fromNode.urlItems + toNode.urlItems
+        }
+    }
+
+    override func reset() {
+        isSelected = false
+        reset(child(at: Index.from.rawValue))
+        reset(child(at: Index.to.rawValue))
+    }
+
+    private func reset(_ child: CCFilterNode) {
+        child.value = nil
+        child.isSelected = false
+    }
+}
+
+extension CCRangeFilterNode {
+    func setup() {
+        Index.allCases.forEach {
+            add(child: CCFilterNode(title: "", name: name + Key.allCases[$0.rawValue].rawValue))
+        }
+    }
+}

--- a/Sources/CCFilterNode/CCRangeFilterNode.swift
+++ b/Sources/CCFilterNode/CCRangeFilterNode.swift
@@ -8,31 +8,31 @@ public class CCRangeFilterNode: CCFilterNode {
 
     // MARK: - Internal properties
 
-    let lowNode: CCFilterNode
-    let highNode: CCFilterNode
+    let lowValueNode: CCFilterNode
+    let highValueNode: CCFilterNode
 
     public init(title: String, name: String) {
-        lowNode = CCFilterNode(title: "", name: name + "_from")
-        highNode = CCFilterNode(title: "", name: name + "_to")
+        lowValueNode = CCFilterNode(title: "", name: name + "_from")
+        highValueNode = CCFilterNode(title: "", name: name + "_to")
         super.init(title: title, name: name)
         setup()
     }
 
     override var queryItems: [URLQueryItem] {
         if isSelected {
-            guard let lowValue = lowNode.value, let highValue = highNode.value else { return [] }
-            let fromItem = URLQueryItem(name: lowNode.name, value: lowValue)
-            let toItem = URLQueryItem(name: highNode.name, value: highValue)
+            guard let lowValue = lowValueNode.value, let highValue = highValueNode.value else { return [] }
+            let fromItem = URLQueryItem(name: lowValueNode.name, value: lowValue)
+            let toItem = URLQueryItem(name: highValueNode.name, value: highValue)
             return [fromItem, toItem]
         } else {
-            return lowNode.queryItems + highNode.queryItems
+            return lowValueNode.queryItems + highValueNode.queryItems
         }
     }
 
     override func reset() {
         isSelected = false
-        reset(lowNode)
-        reset(highNode)
+        reset(lowValueNode)
+        reset(highValueNode)
     }
 
     private func reset(_ child: CCFilterNode) {
@@ -43,7 +43,7 @@ public class CCRangeFilterNode: CCFilterNode {
 
 extension CCRangeFilterNode {
     func setup() {
-        add(child: lowNode)
-        add(child: highNode)
+        add(child: lowValueNode)
+        add(child: highValueNode)
     }
 }

--- a/Sources/FINNFilterImplementation/BackendModel/FilterData.swift
+++ b/Sources/FINNFilterImplementation/BackendModel/FilterData.swift
@@ -27,6 +27,20 @@ struct FilterData: Decodable {
         queries = try container.decodeIfPresent([FilterDataQuery].self, forKey: CodingKeys.queries) ?? []
     }
 
+    public func filterNode() -> CCFilterNode {
+        if let isRange = isRange, isRange {
+            let rangeNode = CCRangeFilterNode(title: title, name: parameterName)
+            return rangeNode
+        }
+
+        let filterNode = CCFilterNode(title: title, name: parameterName)
+        queries.forEach { query in
+            filterNode.add(child: query.filterNode(name: parameterName))
+        }
+
+        return filterNode
+    }
+
     static func decode(from dict: [AnyHashable: Any]?) -> FilterData? {
         guard let dict = dict else {
             return nil

--- a/Sources/FINNFilterImplementation/BackendModel/FilterData.swift
+++ b/Sources/FINNFilterImplementation/BackendModel/FilterData.swift
@@ -28,9 +28,8 @@ struct FilterData: Decodable {
     }
 
     public func filterNode() -> CCFilterNode {
-        if let isRange = isRange, isRange {
-            let rangeNode = CCRangeFilterNode(title: title, name: parameterName)
-            return rangeNode
+        if isRange == true {
+            return CCRangeFilterNode(title: title, name: parameterName)
         }
 
         let filterNode = CCFilterNode(title: title, name: parameterName)

--- a/Sources/FINNFilterImplementation/BackendModel/FilterDataQuery.swift
+++ b/Sources/FINNFilterImplementation/BackendModel/FilterDataQuery.swift
@@ -28,6 +28,16 @@ struct FilterDataQuery: Decodable {
         return FilterDataQuery(title: title, value: value, totalResults: totalResults ?? 0, filter: filter)
     }
 
+    public func filterNode(name: String) -> CCFilterNode {
+        let filterNode = CCFilterNode(title: title, name: name, value: value, numberOfResults: totalResults)
+        if let filterData = filter {
+            filterData.queries.forEach({ query in
+                filterNode.add(child: query.filterNode(name: filterData.parameterName))
+            })
+        }
+        return filterNode
+    }
+
     static func decode(from array: [[AnyHashable: Any]]?) -> [FilterDataQuery]? {
         guard let array = array else {
             return nil

--- a/Sources/FINNFilterImplementation/BackendModel/FilterSetup.swift
+++ b/Sources/FINNFilterImplementation/BackendModel/FilterSetup.swift
@@ -47,6 +47,31 @@ public struct FilterSetup: Decodable {
         }
     }
 
+    public func asCCFilter() -> CCFilter? {
+        guard let filterMarket = FilterMarket(market: market) else {
+            return nil
+        }
+
+        let searchQueryNode = CCFilterNode(title: "Ord i annonsen", name: "q")
+
+        let preferenceFilters = filterMarket.preferenceFilterKeys.compactMap { self.filterData(forKey: $0) }
+        let preferenceNode = CCFilterNode(title: "Preferences", name: "preferences")
+        preferenceFilters.forEach { preferenceNode.add(child: $0.filterNode()) }
+
+        let filters = filterMarket.supportedFiltersKeys.compactMap { self.filterData(forKey: $0) }
+        let filterNodes = filters.map { $0.filterNode() }
+
+        if let locationNode = filterNodes.first(where: { $0.name == FilterKey.location.rawValue }) {
+            let mapNode = CCMapFilterNode(title: "Område i kart", name: CCMapFilterNode.filterKey)
+            locationNode.add(child: mapNode, at: 0)
+        }
+
+        let root = CCFilterNode(title: filterTitle, name: market, numberOfResults: hits)
+        ([searchQueryNode, preferenceNode] + filterNodes).forEach { root.add(child: $0) }
+
+        return CCFilter(root: root)
+    }
+
     public static func decode(from dict: [AnyHashable: Any]?) -> FilterSetup? {
         guard let dict = dict else {
             return nil

--- a/Sources/FINNFilterImplementation/BackendModel/FilterSetup.swift
+++ b/Sources/FINNFilterImplementation/BackendModel/FilterSetup.swift
@@ -52,17 +52,17 @@ public struct FilterSetup: Decodable {
             return nil
         }
 
-        let searchQueryNode = CCFilterNode(title: "Ord i annonsen", name: "q")
+        let searchQueryNode = CCFilterNode(title: "search_placeholder".localized(), name: "q")
 
-        let preferenceFilters = filterMarket.preferenceFilterKeys.compactMap { self.filterData(forKey: $0) }
-        let preferenceNode = CCFilterNode(title: "Preferences", name: "preferences")
+        let preferenceFilters = filterMarket.preferenceFilterKeys.compactMap { filterData(forKey: $0) }
+        let preferenceNode = CCFilterNode(title: "", name: "preferences")
         preferenceFilters.forEach { preferenceNode.add(child: $0.filterNode()) }
 
-        let filters = filterMarket.supportedFiltersKeys.compactMap { self.filterData(forKey: $0) }
+        let filters = filterMarket.supportedFiltersKeys.compactMap { filterData(forKey: $0) }
         let filterNodes = filters.map { $0.filterNode() }
 
         if let locationNode = filterNodes.first(where: { $0.name == FilterKey.location.rawValue }) {
-            let mapNode = CCMapFilterNode(title: "Område i kart", name: CCMapFilterNode.filterKey)
+            let mapNode = CCMapFilterNode(title: "map_filter_title".localized(), name: CCMapFilterNode.filterKey)
             locationNode.add(child: mapNode, at: 0)
         }
 

--- a/Sources/Resources/en.lproj/Localizable.strings
+++ b/Sources/Resources/en.lproj/Localizable.strings
@@ -23,6 +23,7 @@
 "cancel" = "Avbryt";
 "done" = "Ferdig";
 "value_slider_control_value_slider_accessibility_label" = "Slider for verdi";
+"search_placeholder" = "Ord i annonsen";
 "map_filter_title" = "Område i kart";
 "my_home_address" = "Min hjemmeadresse";
 "my_current_location" = "Min nåværende posisjon";

--- a/UnitTests/Filter/FilterTests.swift
+++ b/UnitTests/Filter/FilterTests.swift
@@ -1,0 +1,16 @@
+//
+//  Copyright © FINN.no AS, Inc. All rights reserved.
+//
+
+@testable import Charcoal
+import XCTest
+
+final class FilterTests: XCTestCase {
+    func testUrlEncoded() {
+        let rootNode = CCFilterNode(title: "Root", name: "root")
+        rootNode.add(child: CCFilterNode(title: "Child 1", name: "name1", value: "value1", isSelected: true, numberOfResults: 0))
+        rootNode.add(child: CCFilterNode(title: "Child 2", name: "name2", value: "value2", isSelected: true, numberOfResults: 0))
+        let filter = CCFilter(root: rootNode)
+        XCTAssertEqual(filter.urlEncoded, "name1=value1&name2=value2")
+    }
+}

--- a/UnitTests/Filter/FilterTests.swift
+++ b/UnitTests/Filter/FilterTests.swift
@@ -11,6 +11,6 @@ final class FilterTests: XCTestCase {
         rootNode.add(child: CCFilterNode(title: "Child 1", name: "name1", value: "value1", isSelected: true, numberOfResults: 0))
         rootNode.add(child: CCFilterNode(title: "Child 2", name: "name2", value: "value2", isSelected: true, numberOfResults: 0))
         let filter = CCFilter(root: rootNode)
-        XCTAssertEqual(filter.urlEncoded, "name1=value1&name2=value2")
+        XCTAssertEqual(filter.queryItems.count, 2)
     }
 }

--- a/UnitTests/FilterNodes/FilterNodeTests.swift
+++ b/UnitTests/FilterNodes/FilterNodeTests.swift
@@ -1,0 +1,78 @@
+//
+//  Copyright © FINN.no AS, Inc. All rights reserved.
+//
+
+@testable import Charcoal
+import XCTest
+
+final class FilterNodeTests: XCTestCase {
+    func testAddChild() {
+        let filterNode = CCFilterNode(title: "Test", name: "test")
+        filterNode.add(child: CCFilterNode(title: "Child 1", name: "child-1"))
+        filterNode.add(child: CCFilterNode(title: "Child 2", name: "child-2"))
+        XCTAssertEqual(filterNode.children.count, 2)
+    }
+
+    func testAddChildAtIndex() {
+        let filterNode = CCFilterNode(title: "Test", name: "test")
+        filterNode.add(child: CCFilterNode(title: "Child 1", name: "index-0"))
+        filterNode.add(child: CCFilterNode(title: "Child 2", name: "index-2"))
+        filterNode.add(child: CCFilterNode(title: "Child 3", name: "index-1"), at: 1)
+        XCTAssertEqual(filterNode.child(at: 1).name, "index-1")
+    }
+
+    func testUrlItem() {
+        let filterNode = CCFilterNode(title: "Title", name: "name", value: "value", isSelected: true, numberOfResults: 0)
+        let urlItems = filterNode.urlItems
+        XCTAssertEqual(urlItems.count, 1)
+        XCTAssertEqual(urlItems.first, "name=value")
+    }
+
+    func testUrlItemValueNil() {
+        let filterNode = CCFilterNode(title: "Title", name: "name", value: nil, isSelected: true, numberOfResults: 0)
+        let urlItems = filterNode.urlItems
+        XCTAssertEqual(urlItems.count, 0)
+    }
+
+    func testMultipleUrlItemsRootNotSelected() {
+        let filterNode = CCFilterNode(title: "Title", name: "name")
+        filterNode.add(child: CCFilterNode(title: "Title1", name: "name1", value: "value1", isSelected: true))
+        filterNode.add(child: CCFilterNode(title: "Title2", name: "name2", value: "value2", isSelected: true))
+        let urlItems = filterNode.urlItems
+        XCTAssertEqual(urlItems.count, 2)
+        XCTAssertEqual(urlItems.first, "name1=value1")
+        XCTAssertEqual(urlItems.last, "name2=value2")
+    }
+
+    func testMultipleUrlItemsRootIsSelected() {
+        let filterNode = CCFilterNode(title: "Title", name: "name", value: "value", isSelected: true)
+        filterNode.add(child: CCFilterNode(title: "Title1", name: "name1", value: "value1", isSelected: true))
+        filterNode.add(child: CCFilterNode(title: "Title2", name: "name2", value: "value2", isSelected: true))
+        let urlItems = filterNode.urlItems
+        XCTAssertEqual(urlItems.count, 1)
+    }
+
+    func testDelegateSelection() {
+        let filterNode = CCFilterNode(title: "Title", name: "name", value: "value", isSelected: true)
+        let child1 = CCFilterNode(title: "Title1", name: "name1", value: "value1")
+        let child2 = CCFilterNode(title: "Title2", name: "name2", value: "value2")
+        filterNode.add(child: child1)
+        filterNode.add(child: child2)
+
+        child1.isSelected = true
+        XCTAssertFalse(filterNode.isSelected)
+        child2.isSelected = true
+        XCTAssertTrue(filterNode.isSelected)
+    }
+
+    func testReset() {
+        let filterNode = CCFilterNode(title: "Title", name: "name", value: "value", isSelected: true)
+        let child1 = CCFilterNode(title: "Title1", name: "name1", value: "value1", isSelected: true)
+        let child2 = CCFilterNode(title: "Title2", name: "name2", value: "value2", isSelected: true)
+        filterNode.add(child: child1)
+        filterNode.add(child: child2)
+
+        filterNode.reset()
+        XCTAssertFalse(filterNode.isSelected || child1.isSelected || child2.isSelected)
+    }
+}

--- a/UnitTests/FilterNodes/FilterNodeTests.swift
+++ b/UnitTests/FilterNodes/FilterNodeTests.swift
@@ -18,19 +18,18 @@ final class FilterNodeTests: XCTestCase {
         filterNode.add(child: CCFilterNode(title: "Child 1", name: "index-0"))
         filterNode.add(child: CCFilterNode(title: "Child 2", name: "index-2"))
         filterNode.add(child: CCFilterNode(title: "Child 3", name: "index-1"), at: 1)
-        XCTAssertEqual(filterNode.child(at: 1).name, "index-1")
+        XCTAssertEqual(filterNode.child(at: 1)?.name, "index-1")
     }
 
     func testUrlItem() {
         let filterNode = CCFilterNode(title: "Title", name: "name", value: "value", isSelected: true, numberOfResults: 0)
-        let urlItems = filterNode.urlItems
+        let urlItems = filterNode.queryItems
         XCTAssertEqual(urlItems.count, 1)
-        XCTAssertEqual(urlItems.first, "name=value")
     }
 
     func testUrlItemValueNil() {
         let filterNode = CCFilterNode(title: "Title", name: "name", value: nil, isSelected: true, numberOfResults: 0)
-        let urlItems = filterNode.urlItems
+        let urlItems = filterNode.queryItems
         XCTAssertEqual(urlItems.count, 0)
     }
 
@@ -38,17 +37,15 @@ final class FilterNodeTests: XCTestCase {
         let filterNode = CCFilterNode(title: "Title", name: "name")
         filterNode.add(child: CCFilterNode(title: "Title1", name: "name1", value: "value1", isSelected: true))
         filterNode.add(child: CCFilterNode(title: "Title2", name: "name2", value: "value2", isSelected: true))
-        let urlItems = filterNode.urlItems
+        let urlItems = filterNode.queryItems
         XCTAssertEqual(urlItems.count, 2)
-        XCTAssertEqual(urlItems.first, "name1=value1")
-        XCTAssertEqual(urlItems.last, "name2=value2")
     }
 
     func testMultipleUrlItemsRootIsSelected() {
         let filterNode = CCFilterNode(title: "Title", name: "name", value: "value", isSelected: true)
         filterNode.add(child: CCFilterNode(title: "Title1", name: "name1", value: "value1", isSelected: true))
         filterNode.add(child: CCFilterNode(title: "Title2", name: "name2", value: "value2", isSelected: true))
-        let urlItems = filterNode.urlItems
+        let urlItems = filterNode.queryItems
         XCTAssertEqual(urlItems.count, 1)
     }
 

--- a/UnitTests/FilterNodes/MapNodeTests.swift
+++ b/UnitTests/FilterNodes/MapNodeTests.swift
@@ -1,0 +1,24 @@
+//
+//  Copyright © FINN.no AS, Inc. All rights reserved.
+//
+
+@testable import Charcoal
+import XCTest
+
+final class MapNodeTests: XCTestCase {
+    func testSetup() {
+        let rangeNode = CCMapFilterNode(title: "Map", name: "map")
+
+        XCTAssertEqual(rangeNode.children.count, 4)
+
+        let latitudeNode = rangeNode.child(at: CCMapFilterNode.Index.lat.rawValue)
+        let longitudeNode = rangeNode.child(at: CCMapFilterNode.Index.lon.rawValue)
+        let radiusNode = rangeNode.child(at: CCMapFilterNode.Index.radius.rawValue)
+        let locationNode = rangeNode.child(at: CCMapFilterNode.Index.geoLocationName.rawValue)
+
+        XCTAssertEqual(latitudeNode.name, "lat")
+        XCTAssertEqual(longitudeNode.name, "lon")
+        XCTAssertEqual(radiusNode.name, "radius")
+        XCTAssertEqual(locationNode.name, "geoLocationName")
+    }
+}

--- a/UnitTests/FilterNodes/MapNodeTests.swift
+++ b/UnitTests/FilterNodes/MapNodeTests.swift
@@ -8,17 +8,10 @@ import XCTest
 final class MapNodeTests: XCTestCase {
     func testSetup() {
         let rangeNode = CCMapFilterNode(title: "Map", name: "map")
-
         XCTAssertEqual(rangeNode.children.count, 4)
-
-        let latitudeNode = rangeNode.child(at: CCMapFilterNode.Index.lat.rawValue)
-        let longitudeNode = rangeNode.child(at: CCMapFilterNode.Index.lon.rawValue)
-        let radiusNode = rangeNode.child(at: CCMapFilterNode.Index.radius.rawValue)
-        let locationNode = rangeNode.child(at: CCMapFilterNode.Index.geoLocationName.rawValue)
-
-        XCTAssertEqual(latitudeNode.name, "lat")
-        XCTAssertEqual(longitudeNode.name, "lon")
-        XCTAssertEqual(radiusNode.name, "radius")
-        XCTAssertEqual(locationNode.name, "geoLocationName")
+        XCTAssertEqual(rangeNode.latitudeNode.name, "lat")
+        XCTAssertEqual(rangeNode.longitudeNode.name, "lon")
+        XCTAssertEqual(rangeNode.radiusNode.name, "radius")
+        XCTAssertEqual(rangeNode.geoLocationNode.name, "geoLocationName")
     }
 }

--- a/UnitTests/FilterNodes/RangeNodeTests.swift
+++ b/UnitTests/FilterNodes/RangeNodeTests.swift
@@ -17,4 +17,26 @@ final class RangeNodeTests: XCTestCase {
         XCTAssertEqual(fromNode.name, "range_from")
         XCTAssertEqual(toNode.name, "range_to")
     }
+
+    func testUrlItems() {
+        let rangeNode = CCRangeFilterNode(title: "Range", name: "range")
+
+        let fromNode = rangeNode.child(at: CCRangeFilterNode.Index.from.rawValue)
+        fromNode.value = "value1"
+        fromNode.isSelected = true
+
+        let toNode = rangeNode.child(at: CCRangeFilterNode.Index.to.rawValue)
+        toNode.value = "value2"
+        toNode.isSelected = true
+
+        let urlItems = rangeNode.urlItems
+        XCTAssertEqual(urlItems.count, 2)
+        XCTAssertEqual(urlItems.first, "range_from=value1")
+        XCTAssertEqual(urlItems.last, "range_to=value2")
+
+        fromNode.isSelected = false
+        let urlItems2 = rangeNode.urlItems
+        XCTAssertEqual(urlItems2.count, 1)
+        XCTAssertEqual(urlItems2.first, "range_to=value2")
+    }
 }

--- a/UnitTests/FilterNodes/RangeNodeTests.swift
+++ b/UnitTests/FilterNodes/RangeNodeTests.swift
@@ -1,0 +1,20 @@
+//
+//  Copyright © FINN.no AS, Inc. All rights reserved.
+//
+
+@testable import Charcoal
+import XCTest
+
+final class RangeNodeTests: XCTestCase {
+    func testSetup() {
+        let rangeNode = CCRangeFilterNode(title: "Range", name: "range")
+
+        XCTAssertEqual(rangeNode.children.count, 2)
+
+        let fromNode = rangeNode.child(at: CCRangeFilterNode.Index.from.rawValue)
+        let toNode = rangeNode.child(at: CCRangeFilterNode.Index.to.rawValue)
+
+        XCTAssertEqual(fromNode.name, "range_from")
+        XCTAssertEqual(toNode.name, "range_to")
+    }
+}

--- a/UnitTests/FilterNodes/RangeNodeTests.swift
+++ b/UnitTests/FilterNodes/RangeNodeTests.swift
@@ -11,23 +11,23 @@ final class RangeNodeTests: XCTestCase {
 
         XCTAssertEqual(rangeNode.children.count, 2)
 
-        XCTAssertEqual(rangeNode.lowNode.name, "range_from")
-        XCTAssertEqual(rangeNode.highNode.name, "range_to")
+        XCTAssertEqual(rangeNode.lowValueNode.name, "range_from")
+        XCTAssertEqual(rangeNode.highValueNode.name, "range_to")
     }
 
     func testUrlItems() {
         let rangeNode = CCRangeFilterNode(title: "Range", name: "range")
 
-        rangeNode.lowNode.value = "value1"
-        rangeNode.lowNode.isSelected = true
+        rangeNode.lowValueNode.value = "value1"
+        rangeNode.lowValueNode.isSelected = true
 
-        rangeNode.highNode.value = "value2"
-        rangeNode.highNode.isSelected = true
+        rangeNode.highValueNode.value = "value2"
+        rangeNode.highValueNode.isSelected = true
 
         let urlItems = rangeNode.queryItems
         XCTAssertEqual(urlItems.count, 2)
 
-        rangeNode.lowNode.isSelected = false
+        rangeNode.lowValueNode.isSelected = false
         let urlItems2 = rangeNode.queryItems
         XCTAssertEqual(urlItems2.count, 1)
     }

--- a/UnitTests/FilterNodes/RangeNodeTests.swift
+++ b/UnitTests/FilterNodes/RangeNodeTests.swift
@@ -11,32 +11,24 @@ final class RangeNodeTests: XCTestCase {
 
         XCTAssertEqual(rangeNode.children.count, 2)
 
-        let fromNode = rangeNode.child(at: CCRangeFilterNode.Index.from.rawValue)
-        let toNode = rangeNode.child(at: CCRangeFilterNode.Index.to.rawValue)
-
-        XCTAssertEqual(fromNode.name, "range_from")
-        XCTAssertEqual(toNode.name, "range_to")
+        XCTAssertEqual(rangeNode.lowNode.name, "range_from")
+        XCTAssertEqual(rangeNode.highNode.name, "range_to")
     }
 
     func testUrlItems() {
         let rangeNode = CCRangeFilterNode(title: "Range", name: "range")
 
-        let fromNode = rangeNode.child(at: CCRangeFilterNode.Index.from.rawValue)
-        fromNode.value = "value1"
-        fromNode.isSelected = true
+        rangeNode.lowNode.value = "value1"
+        rangeNode.lowNode.isSelected = true
 
-        let toNode = rangeNode.child(at: CCRangeFilterNode.Index.to.rawValue)
-        toNode.value = "value2"
-        toNode.isSelected = true
+        rangeNode.highNode.value = "value2"
+        rangeNode.highNode.isSelected = true
 
-        let urlItems = rangeNode.urlItems
+        let urlItems = rangeNode.queryItems
         XCTAssertEqual(urlItems.count, 2)
-        XCTAssertEqual(urlItems.first, "range_from=value1")
-        XCTAssertEqual(urlItems.last, "range_to=value2")
 
-        fromNode.isSelected = false
-        let urlItems2 = rangeNode.urlItems
+        rangeNode.lowNode.isSelected = false
+        let urlItems2 = rangeNode.queryItems
         XCTAssertEqual(urlItems2.count, 1)
-        XCTAssertEqual(urlItems2.first, "range_to=value2")
     }
 }


### PR DESCRIPTION
# Why?

This PR aims to simplify the logic behind the filter selection process. Instead of having two different objects handling UI state and filter selection, I have made a structure that will handle both. The goal
was to make the filter state more connected to the UI.

The previous selection process
```swift
selectionDataSource.addValue(value, for: filterInfo)
// and
selectionDataSource.clearValue(value, for: filterInfo)
```
is replaced with
``` swift
filterNode.isSelected = true // or false
```
where each filter node represents a single url query item.

Each view controller will receive a filter node during initialisation and it will be responsible for handling the child nodes of that filter node. F.eks:

```swift
func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
    return filterNode.children.count
}

func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
    let cell = tableView.dequeue(CCListFilterCell.self, for: indexPath)
    cell.configure(for: filterNode.child(at: indexPath.row))
    return cell
}
```

When the user have applied changes to the filter selection, the updated selection can easily be retrieved like so:
```swift
let queryString = filter.urlEncoded
```

I believe that this tree structure will help improve the navigation and flow of data.


# What?

- Added a Filter structure which is composed of multiple FilterNodes. Every filter node can act as a key-value pair and represent a single url query item or it can have child nodes and represent a group of key-value pairs.
- Added RangeFilterNode and MapFilterNode which are special cases where the child nodes are hard coded for convenience.
- Added implementation to demonstrate how you can build the filter tree using the FilterSetup object.
- Added tests for filter and filter nodes.

# Show me

No UI
