### PR TITLE
List filter cell: set selection style to .none

### DIFF
--- a/Sources/CCFilter/Views/TableViewCells/CCListFilterCell.swift
+++ b/Sources/CCFilter/Views/TableViewCells/CCListFilterCell.swift
@@ -55,13 +55,14 @@ extension CCListFilterCell {
         } else {
             detailLabelTrailingConstraint.constant = 0
         }
-
-        separatorInset = UIEdgeInsets(top: 0, left: 24 + .largeSpacing, bottom: 0, right: 0)
     }
 }
 
 private extension CCListFilterCell {
     func setup() {
+        separatorInset = UIEdgeInsets(top: 0, left: 24 + .largeSpacing, bottom: 0, right: 0)
+        selectionStyle = .none
+
         contentView.addSubview(iconView)
         contentView.addSubview(titleLabel)
         contentView.addSubview(detailLabel)


### PR DESCRIPTION
# Why?

Because it was like that before.

# What?

List filter cell: set selection style to `.none`