### PR TITLE
Map filters: show filter selection on filter root

### DIFF
--- a/Sources/CCFilter/Models/Selection/CCFilterSelectionStore.swift
+++ b/Sources/CCFilter/Models/Selection/CCFilterSelectionStore.swift
@@ -42,8 +42,15 @@ extension FilterSelectionStore {
     }
 
     func isSelected(node: CCFilterNode) -> Bool {
-        let allChildredSelected = !node.children.isEmpty && node.children.allSatisfy { isSelected(node: $0) }
-        return value(for: node) != nil || allChildredSelected
+        let selected: Bool
+
+        if node is CCMapFilterNode || node is CCRangeFilterNode {
+            selected = node.children.contains(where: { isSelected(node: $0) })
+        } else {
+            selected = !node.children.isEmpty && node.children.allSatisfy { isSelected(node: $0) }
+        }
+
+        return value(for: node) != nil || selected
     }
 }
 
@@ -71,6 +78,8 @@ extension FilterSelectionStore {
             } else {
                 return []
             }
+        } else if let mapNode = node as? CCMapFilterNode, hasSelectedChildren(node: mapNode) {
+            return ["map_filter_title".localized()]
         } else if isSelected(node: node) {
             return [node.title]
         } else {

--- a/Sources/CCFilter/ViewControllers/CCMapFilterViewController.swift
+++ b/Sources/CCFilter/ViewControllers/CCMapFilterViewController.swift
@@ -43,7 +43,7 @@ final class CCMapFilterViewController: CCViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
-    // MARK: - Lifecycle
+    // MARK: - Overrides
 
     public override func viewDidLoad() {
         super.viewDidLoad()
@@ -52,6 +52,13 @@ final class CCMapFilterViewController: CCViewController {
 
         showBottomButton(true, animated: false)
         setup()
+    }
+
+    override func filterBottomButtonView(_ filterBottomButtonView: FilterBottomButtonView, didTapButton button: UIButton) {
+        radius = mapFilterView.currentRadius
+        coordinate = mapFilterView.centerPoint
+        locationName = mapFilterView.locationName
+        super.filterBottomButtonView(filterBottomButtonView, didTapButton: button)
     }
 
     // MARK: - Setup

--- a/Sources/CCFilter/ViewControllers/CCMapFilterViewController.swift
+++ b/Sources/CCFilter/ViewControllers/CCMapFilterViewController.swift
@@ -5,19 +5,17 @@
 import MapKit
 import UIKit
 
-class CCMapFilterViewController: CCViewController {
-
-    // MARK: - Public properties
-
+final class CCMapFilterViewController: CCViewController {
     private let mapFilterViewManager: MapFilterViewManager
     private let searchLocationDataSource: SearchLocationDataSource?
-
-    // MARK: - Private properties
-
     private let mapFilterNode: CCMapFilterNode
 
     private lazy var mapFilterView: MapFilterView = {
-        let mapFilterView = MapFilterView(mapFilterViewManager: mapFilterViewManager)
+        let mapFilterView = MapFilterView(
+            mapFilterViewManager: mapFilterViewManager,
+            radius: radius,
+            centerPoint: coordinate
+        )
         mapFilterView.searchBar = searchLocationViewController.searchBar
         mapFilterView.delegate = self
         mapFilterView.translatesAutoresizingMaskIntoConstraints = false
@@ -31,9 +29,10 @@ class CCMapFilterViewController: CCViewController {
         return searchLocationViewController
     }()
 
-    // MARK: - Setup
+    // MARK: - Init
 
-    init(mapFilterNode: CCMapFilterNode, selectionStore: FilterSelectionStore, mapFilterViewManager: MapFilterViewManager, searchLocationDataSource: SearchLocationDataSource?) {
+    init(mapFilterNode: CCMapFilterNode, selectionStore: FilterSelectionStore,
+         mapFilterViewManager: MapFilterViewManager, searchLocationDataSource: SearchLocationDataSource?) {
         self.mapFilterNode = mapFilterNode
         self.mapFilterViewManager = mapFilterViewManager
         self.searchLocationDataSource = searchLocationDataSource
@@ -44,29 +43,57 @@ class CCMapFilterViewController: CCViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
+    // MARK: - Lifecycle
+
     public override func viewDidLoad() {
         super.viewDidLoad()
         bottomButton.buttonTitle = "apply_button_title".localized()
         view.backgroundColor = .milk
+
         showBottomButton(true, animated: false)
         setup()
     }
+
+    // MARK: - Setup
+
+    private func setup() {
+        view.addSubview(mapFilterView)
+
+        NSLayoutConstraint.activate([
+            mapFilterView.topAnchor.constraint(equalTo: view.topAnchor),
+            mapFilterView.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -bottomButton.height),
+            mapFilterView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            mapFilterView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+        ])
+    }
+
+    private func returnToMapFromLocationSearch() {
+        mapFilterView.searchBar = searchLocationViewController.searchBar
+        mapFilterView.setNeedsLayout()
+
+        searchLocationViewController.willMove(toParent: nil)
+        searchLocationViewController.view.removeFromSuperview()
+        searchLocationViewController.removeFromParent()
+    }
 }
+
+// MARK: - MapFilterViewDelegate
 
 extension CCMapFilterViewController: MapFilterViewDelegate {
     func mapFilterView(_ mapFilterView: MapFilterView, didChangeRadius radius: Int) {
-        let radiusNode = mapFilterNode.radiusNode
-        selectionStore.select(node: radiusNode, value: String(radius))
+        self.radius = radius
     }
 
-    func mapFilterView(_ mapFilterView: MapFilterView, didChangeLocation location: CLLocationCoordinate2D) {
-        let latitudeNode = mapFilterNode.latitudeNode
-        selectionStore.select(node: latitudeNode, value: String(location.latitude))
+    func mapFilterView(_ mapFilterView: MapFilterView, didChangeLocationCoordinate coordinate: CLLocationCoordinate2D?) {
+        self.coordinate = coordinate
+    }
 
-        let longitudeNode = mapFilterNode.longitudeNode
-        selectionStore.select(node: longitudeNode, value: String(location.latitude))
+    func mapFilterView(_ mapFilterView: MapFilterView, didChangeLocationName locationName: String?) {
+        self.locationName = locationName
     }
 }
+
+// MARK: - SearchLocationViewControllerDelegate
 
 extension CCMapFilterViewController: SearchLocationViewControllerDelegate {
     public func searchLocationViewControllerDidSelectCurrentLocation(_ searchLocationViewController: SearchLocationViewController) {
@@ -96,23 +123,42 @@ extension CCMapFilterViewController: SearchLocationViewControllerDelegate {
     }
 }
 
+// MARK: - Store
+
 private extension CCMapFilterViewController {
-    func setup() {
-        view.addSubview(mapFilterView)
-        NSLayoutConstraint.activate([
-            mapFilterView.topAnchor.constraint(equalTo: view.topAnchor),
-            mapFilterView.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -bottomButton.height),
-            mapFilterView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            mapFilterView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-        ])
+    var radius: Int? {
+        get {
+            return Int(selectionStore.value(for: mapFilterNode.radiusNode))
+        }
+        set {
+            selectionStore.select(node: mapFilterNode.radiusNode, value: newValue.map(String.init))
+        }
     }
 
-    func returnToMapFromLocationSearch() {
-        mapFilterView.searchBar = searchLocationViewController.searchBar
-        mapFilterView.setNeedsLayout()
+    var coordinate: CLLocationCoordinate2D? {
+        get {
+            guard let latitude = selectionStore.value(for: mapFilterNode.latitudeNode).flatMap(Double.init) else {
+                return nil
+            }
 
-        searchLocationViewController.willMove(toParent: nil)
-        searchLocationViewController.view.removeFromSuperview()
-        searchLocationViewController.removeFromParent()
+            guard let longitude = selectionStore.value(for: mapFilterNode.longitudeNode).flatMap(Double.init) else {
+                return nil
+            }
+
+            return CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
+        }
+        set {
+            selectionStore.select(node: mapFilterNode.latitudeNode, value: newValue.map({ String($0.latitude) }))
+            selectionStore.select(node: mapFilterNode.longitudeNode, value: newValue.map({ String($0.longitude) }))
+        }
+    }
+
+    var locationName: String? {
+        get {
+            return selectionStore.value(for: mapFilterNode.geoLocationNode)
+        }
+        set {
+            selectionStore.select(node: mapFilterNode.geoLocationNode, value: newValue)
+        }
     }
 }

--- a/Sources/CCFilter/ViewControllers/CCViewController.swift
+++ b/Sources/CCFilter/ViewControllers/CCViewController.swift
@@ -9,7 +9,7 @@ protocol CCViewControllerDelegate: class {
     func viewController(_ viewController: CCViewController, didSelect filterNode: CCFilterNode)
 }
 
-class CCViewController: UIViewController, CCViewControllerDelegate {
+class CCViewController: UIViewController, CCViewControllerDelegate, FilterBottomButtonViewDelegate {
 
     // MARK: - Public properties
 
@@ -70,9 +70,9 @@ class CCViewController: UIViewController, CCViewControllerDelegate {
     func viewController(_ viewController: CCViewController, didSelect filterNode: CCFilterNode) {
         delegate?.viewController(viewController, didSelect: filterNode)
     }
-}
 
-extension CCViewController: FilterBottomButtonViewDelegate {
+    // MARK: - FilterBottomButtonViewDelegate
+
     func filterBottomButtonView(_ filterBottomButtonView: FilterBottomButtonView, didTapButton button: UIButton) {
         delegate?.viewControllerDidPressBottomButton(self)
     }


### PR DESCRIPTION
# Why?

Because it wasn't possible to see filters selected in the map.

# What?

- Show filter selection on filter root
- Select map filters only if there were changes or the user clicked "Bruk"
- Handle edge cases for the range and map filters

# Show me

![simulator screen shot - iphone xs - 2019-02-13 at 17 30 41](https://user-images.githubusercontent.com/10529867/52727281-28b44680-2fb5-11e9-9ba4-75a2b058d00e.png)