### PR TITLE
Filter view controller: disable swipe back gesture for ranges

### DIFF
--- a/Sources/CCFilter/ViewControllers/CCFilterViewController.swift
+++ b/Sources/CCFilter/ViewControllers/CCFilterViewController.swift
@@ -61,7 +61,7 @@ public class CCFilterViewController: UINavigationController {
 
     public override func viewDidLoad() {
         super.viewDidLoad()
-        interactivePopGestureRecognizer?.delegate = self
+        delegate = self
     }
 
     // MARK: - Private
@@ -130,11 +130,12 @@ extension CCFilterViewController: CCRootFilterViewControllerDelegate {
 
 // MARK: - UIGestureRecognizerDelegate
 
-extension CCFilterViewController: UIGestureRecognizerDelegate {
-    public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
-        if let slider = touch.view as? UISlider, slider.isEnabled, !slider.isHidden {
-            return false
+extension CCFilterViewController: UINavigationControllerDelegate {
+    public func navigationController(_ navigationController: UINavigationController, didShow viewController: UIViewController, animated: Bool) {
+        if viewController is CCRangeFilterViewController {
+            interactivePopGestureRecognizer?.isEnabled = false
+        } else {
+            interactivePopGestureRecognizer?.isEnabled = true
         }
-        return true
     }
 }

--- a/Sources/CCFilter/ViewControllers/CCFilterViewController.swift
+++ b/Sources/CCFilter/ViewControllers/CCFilterViewController.swift
@@ -56,7 +56,27 @@ public class CCFilterViewController: UINavigationController {
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+
+    // MARK: - Lifecycle
+
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+        interactivePopGestureRecognizer?.delegate = self
+    }
+
+    // MARK: - Private
+
+    private func updateLoading() {
+        if isLoading {
+            add(loadingViewController)
+            loadingViewController.viewWillAppear(false)
+        } else {
+            loadingViewController.remove()
+        }
+    }
 }
+
+// MARK: - CCRootFilterViewControllerDelegate
 
 extension CCFilterViewController: CCRootFilterViewControllerDelegate {
     func rootFilterViewController(_ viewController: CCRootFilterViewController, didSelectVerticalAt index: Int) {
@@ -108,13 +128,13 @@ extension CCFilterViewController: CCRootFilterViewControllerDelegate {
     }
 }
 
-private extension CCFilterViewController {
-    func updateLoading() {
-        if isLoading {
-            add(loadingViewController)
-            loadingViewController.viewWillAppear(false)
-        } else {
-            loadingViewController.remove()
+// MARK: - UIGestureRecognizerDelegate
+
+extension CCFilterViewController: UIGestureRecognizerDelegate {
+    public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
+        if let slider = touch.view as? UISlider, slider.isEnabled, !slider.isHidden {
+            return false
         }
+        return true
     }
 }


### PR DESCRIPTION
# Why?

Because swipe back gesture is in conflict with gestures from range sliders.

# What?

Disable swipe back gesture, back for ranges only.