### PR TITLE
Selection store: create with query items

### DIFF
--- a/Sources/CCFilter/Models/FilterNodes/CCFilterNode.swift
+++ b/Sources/CCFilter/Models/FilterNodes/CCFilterNode.swift
@@ -12,11 +12,6 @@ class CCFilterNode {
     private(set) var children: [CCFilterNode] = []
     private(set) weak var parent: CCFilterNode?
 
-    var id: String {
-        let value = self.value.map({ ".\($0)" }) ?? ""
-        return "\(title.lowercased()).\(name)\(value)"
-    }
-
     var isLeafNode: Bool {
         return children.isEmpty
     }

--- a/Sources/CCFilter/Models/Selection/CCFilterSelectionStore.swift
+++ b/Sources/CCFilter/Models/Selection/CCFilterSelectionStore.swift
@@ -5,7 +5,15 @@
 import Foundation
 
 final class FilterSelectionStore {
-    var queryItems = Set<URLQueryItem>()
+    private var queryItems: Set<URLQueryItem>
+
+    // MARK: - Init
+
+    init(queryItems: Set<URLQueryItem> = []) {
+        self.queryItems = queryItems
+    }
+
+    // MARK: - Values
 
     func value<T: LosslessStringConvertible>(for node: CCFilterNode) -> T? {
         return queryItem(for: node)?.value.flatMap({ T($0) })

--- a/Sources/CCFilter/Models/Selection/CCFilterSelectionStore.swift
+++ b/Sources/CCFilter/Models/Selection/CCFilterSelectionStore.swift
@@ -42,11 +42,11 @@ extension FilterSelectionStore {
     }
 
     func setValue<T: LosslessStringConvertible>(_ value: T?, for node: CCFilterNode) {
+        removeValues(for: node)
+
         if let value = value {
             let queryItem = URLQueryItem(name: node.name, value: String(value))
             queryItems.insert(queryItem)
-        } else {
-            removeValues(for: node)
         }
     }
 

--- a/Sources/CCFilter/ViewControllers/CCFilterViewController.swift
+++ b/Sources/CCFilter/ViewControllers/CCFilterViewController.swift
@@ -42,10 +42,10 @@ public class CCFilterViewController: UINavigationController {
 
     // MARK: - Init
 
-    public init(filter: CCFilter, config: FilterConfiguration) {
+    public init(filter: CCFilter, config: FilterConfiguration, queryItems: Set<URLQueryItem> = []) {
         self.filter = filter
         self.config = config
-        selectionStore = FilterSelectionStore()
+        selectionStore = FilterSelectionStore(queryItems: queryItems)
         rootFilterViewController = CCRootFilterViewController(filterNode: filter.root, selectionStore: selectionStore)
         rootFilterViewController.verticals = filter.verticals
         super.init(nibName: nil, bundle: nil)

--- a/Sources/CCFilter/ViewControllers/CCRangeFilterViewController.swift
+++ b/Sources/CCFilter/ViewControllers/CCRangeFilterViewController.swift
@@ -55,11 +55,11 @@ private extension CCRangeFilterViewController {
     func setup() {
         bottomButton.buttonTitle = "apply_button_title".localized()
 
-        let lowValue = selectionStore.value(for: rangeFilterNode.lowValueNode)
-        rangeFilterView.setLowValue(Int(lowValue), animated: false)
+        let lowValue: Int? = selectionStore.value(for: rangeFilterNode.lowValueNode)
+        rangeFilterView.setLowValue(lowValue, animated: false)
 
-        let highValue = selectionStore.value(for: rangeFilterNode.highValueNode)
-        rangeFilterView.setHighValue(Int(highValue), animated: false)
+        let highValue: Int? = selectionStore.value(for: rangeFilterNode.highValueNode)
+        rangeFilterView.setHighValue(highValue, animated: false)
 
         view.addSubview(rangeFilterView)
 

--- a/UnitTests/Filter/FilterTests.swift
+++ b/UnitTests/Filter/FilterTests.swift
@@ -39,7 +39,7 @@ final class FilterSelectionStoreTests: XCTestCase {
     }
 
     func testSetValueForNode() {
-        let node = CCFilterNode(title: "Test", name: "test", value: "valueA")
+        let node = CCFilterNode(title: "Test", name: "test")
 
         store.setValue("valueB", for: node)
         XCTAssertEqual(store.value(for: node), "valueB")
@@ -56,6 +56,24 @@ final class FilterSelectionStoreTests: XCTestCase {
 
         store.removeValues(for: node)
         XCTAssertFalse(store.isSelected(node))
+    }
+
+    func testRemoveValuesForNodeWithChildren() {
+        let parent = CCFilterNode(title: "Test", name: "parent", value: "value")
+        let childA = CCFilterNode(title: "Child A", name: "childA", value: "valueB")
+        let childB = CCFilterNode(title: "Child B", name: "childB", value: "valueB")
+
+        parent.add(child: childA)
+        parent.add(child: childB)
+
+        store.setValue(from: parent)
+        store.setValue(from: childA)
+        store.setValue(from: childB)
+
+        store.removeValues(for: parent)
+        XCTAssertFalse(store.isSelected(parent))
+        XCTAssertFalse(store.isSelected(childA))
+        XCTAssertFalse(store.isSelected(childB))
     }
 
     func testToggleValueForNode() {

--- a/UnitTests/FilterNode/FilterNodeTests.swift
+++ b/UnitTests/FilterNode/FilterNodeTests.swift
@@ -6,14 +6,6 @@
 import XCTest
 
 final class FilterNodeTests: XCTestCase {
-    func testId() {
-        let nodeA = CCFilterNode(title: "Test", name: "name", value: "value")
-        XCTAssertEqual(nodeA.id, "test.name.value")
-
-        let nodeB = CCFilterNode(title: "Test", name: "name", value: nil)
-        XCTAssertEqual(nodeB.id, "test.name")
-    }
-
     func testIsLeafNode() {
         let filterNode = CCFilterNode(title: "Test", name: "test")
         XCTAssertTrue(filterNode.isLeafNode)


### PR DESCRIPTION
# Why?

Because it should be possible to create new filter view controller with preselected filters.

# What?

- Refactor `FilterSelectionStore` using set of query items
- Remove `id` from `CCFilterNode`
- Add optional set of query items as a parameter in `init` method of `CCFilterViewController`

# Show me

No UI changes.