### PR TITLE
FilterViewController: remove conformance to FilterViewControllerDelegate

### DIFF
--- a/Sources/Core/CharcoalViewController.swift
+++ b/Sources/Core/CharcoalViewController.swift
@@ -131,7 +131,7 @@ extension CharcoalViewController: FilterViewControllerDelegate {
             nextViewController.showBottomButton(showBottomButton, animated: false)
         }
 
-        nextViewController.delegate = viewController
+        nextViewController.delegate = self
         pushViewController(nextViewController, animated: true)
     }
 }

--- a/Sources/Core/Filters/FilterViewController.swift
+++ b/Sources/Core/Filters/FilterViewController.swift
@@ -9,27 +9,27 @@ protocol FilterViewControllerDelegate: class {
     func filterViewController(_ viewController: FilterViewController, didSelectFilter filter: Filter)
 }
 
-class FilterViewController: UIViewController, FilterViewControllerDelegate, FilterBottomButtonViewDelegate {
+class FilterViewController: UIViewController, FilterBottomButtonViewDelegate {
 
     // MARK: - Public properties
 
+    weak var delegate: FilterViewControllerDelegate?
     var filter: Filter
     let selectionStore: FilterSelectionStore
-    var isShowingBottomButton = false
-    weak var delegate: FilterViewControllerDelegate?
+    private(set) var isShowingBottomButton = false
 
     // MARK: - Private properties
 
     lazy var bottomButtonBottomConstraint = bottomButton.bottomAnchor.constraint(equalTo: view.bottomAnchor)
 
-    lazy var bottomButton: FilterBottomButtonView = {
+    private(set) lazy var bottomButton: FilterBottomButtonView = {
         let view = FilterBottomButtonView()
         view.delegate = self
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()
 
-    // MARK: - Setup
+    // MARK: - Init
 
     init(filter: Filter, selectionStore: FilterSelectionStore) {
         self.filter = filter
@@ -40,6 +40,8 @@ class FilterViewController: UIViewController, FilterViewControllerDelegate, Filt
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+
+    // MARK: - Lifecycle
 
     public override func viewDidLoad() {
         super.viewDidLoad()
@@ -53,39 +55,34 @@ class FilterViewController: UIViewController, FilterViewControllerDelegate, Filt
         view.bringSubviewToFront(bottomButton)
     }
 
-    func showBottomButton(_ show: Bool, animated: Bool) {
-        view.layoutIfNeeded()
-        isShowingBottomButton = show
-        bottomButtonBottomConstraint.isActive = show
-        let duration = animated ? 0.3 : 0
-        UIView.animate(withDuration: duration, delay: 0, options: .curveEaseOut, animations: {
-            self.view.layoutIfNeeded()
-        })
-    }
+    // MARK: - Setup
 
-    func filterViewControllerDidSelectApply(_ viewController: FilterViewController) {
-        delegate?.filterViewControllerDidSelectApply(viewController)
-    }
-
-    func filterViewController(_ viewController: FilterViewController, didSelectFilter filter: Filter) {
-        delegate?.filterViewController(viewController, didSelectFilter: filter)
-    }
-
-    // MARK: - FilterBottomButtonViewDelegate
-
-    func filterBottomButtonView(_ filterBottomButtonView: FilterBottomButtonView, didTapButton button: UIButton) {
-        delegate?.filterViewControllerDidSelectApply(self)
-    }
-}
-
-private extension FilterViewController {
-    func setup() {
+    private func setup() {
         view.addSubview(bottomButton)
+
         NSLayoutConstraint.activate([
             bottomButton.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             bottomButton.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             bottomButton.topAnchor.constraint(lessThanOrEqualTo: view.bottomAnchor),
             bottomButton.heightAnchor.constraint(equalToConstant: bottomButton.height),
         ])
+    }
+
+    func showBottomButton(_ show: Bool, animated: Bool) {
+        view.layoutIfNeeded()
+        isShowingBottomButton = show
+        bottomButtonBottomConstraint.isActive = show
+
+        let duration = animated ? 0.3 : 0
+
+        UIView.animate(withDuration: duration, delay: 0, options: .curveEaseOut, animations: {
+            self.view.layoutIfNeeded()
+        })
+    }
+
+    // MARK: - FilterBottomButtonViewDelegate
+
+    func filterBottomButtonView(_ filterBottomButtonView: FilterBottomButtonView, didTapButton button: UIButton) {
+        delegate?.filterViewControllerDidSelectApply(self)
     }
 }

--- a/Sources/Core/Filters/List/ListFilterViewController.swift
+++ b/Sources/Core/Filters/List/ListFilterViewController.swift
@@ -33,22 +33,22 @@ final class ListFilterViewController: FilterViewController {
         setup()
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        tableView.reloadData()
+    }
+
     override func showBottomButton(_ show: Bool, animated: Bool) {
         super.showBottomButton(show, animated: animated)
         let bottomInset = show ? bottomButton.height : 0
         tableView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: bottomInset, right: 0)
     }
 
-    override func filterViewController(_ viewController: FilterViewController, didSelectFilter filter: Filter) {
-        super.filterViewController(viewController, didSelectFilter: filter)
-        showBottomButton(true, animated: false)
-        tableView.reloadData()
-    }
-
     // MARK: - Setup
 
     func setup() {
         view.addSubview(tableView)
+
         NSLayoutConstraint.activate([
             tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             tableView.topAnchor.constraint(equalTo: view.topAnchor),

--- a/Sources/Core/Filters/Root/RootFilterViewController.swift
+++ b/Sources/Core/Filters/Root/RootFilterViewController.swift
@@ -55,7 +55,7 @@ final class RootFilterViewController: FilterViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
-    // MARK: - Setup
+    // MARK: - Lifecycle
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -65,10 +65,12 @@ final class RootFilterViewController: FilterViewController {
         setup()
     }
 
-    override func filterViewController(_ viewController: FilterViewController, didSelectFilter filter: Filter) {
-        super.filterViewController(viewController, didSelectFilter: filter)
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
         tableView.reloadData()
     }
+
+    // MARK: - Setup
 
     func set(filter: Filter, verticals: [Vertical]?) {
         self.filter = filter


### PR DESCRIPTION
# Why?

It was a bit confusing that `FilterViewController` conformed to `FilterViewControllerDelegate` and delegated back to other filter view controllers.

# What?

- Remove conformance to `FilterViewControllerDelegate` and method overrides in subclasses
- Now `CharcoalViewController` is the only delegate of `FilterViewController`. It pushes new view controllers into navigation stack or pops to the root view controller
- In subclasses of `FilterViewController` it's usually enough to reload data in `viewWillAppear` to be up-to-date with `FilterSelectionStore`

# Show me

No UI changes.