### PR TITLE
updates protocols

### DIFF
--- a/Demo/ViewControllers/DemoViewsTableViewController.swift
+++ b/Demo/ViewControllers/DemoViewsTableViewController.swift
@@ -118,7 +118,9 @@ extension DemoViewsTableViewController {
 // MARK: - CharcoalViewControllerDelegate
 
 extension DemoViewsTableViewController: CharcoalViewControllerDelegate {
-    func charcoalViewControllerDidChangeSelection(_ filterViewController: CharcoalViewController) {}
+    func charcoalViewController(_ filterViewController: CharcoalViewController, didChangeSelection selection: [URLQueryItem]) {
+        print("Selection did change")
+    }
 
     func charcoalViewController(_ viewController: CharcoalViewController, didSelect vertical: Vertical) {
         guard let vertical = vertical as? VerticalDemo, let config = FilterMarket(market: vertical.id) else { return }

--- a/Sources/Core/CharcoalViewController.swift
+++ b/Sources/Core/CharcoalViewController.swift
@@ -84,10 +84,6 @@ public class CharcoalViewController: UINavigationController {
 // MARK: - RootFilterViewControllerDelegate
 
 extension CharcoalViewController: RootFilterViewControllerDelegate {
-    func rootFilterViewControllerDidChangeSelection(_ viewController: RootFilterViewController) {
-        filterDelegate?.charcoalViewController(self, didChangeSelection: selectionStore.queryItems(for: filter.rootFilter))
-    }
-
     func rootFilterViewController(_ viewController: RootFilterViewController, didSelectVerticalAt index: Int) {
         guard let vertical = filter.verticals?[safe: index] else { return }
         filterDelegate?.charcoalViewController(self, didSelect: vertical)
@@ -143,7 +139,13 @@ extension CharcoalViewController: FilterViewControllerDelegate {
 
 extension CharcoalViewController: FilterSelectionStoreDelegate {
     func filterSelectionStoreDidChange(_ selectionStore: FilterSelectionStore) {
-        selectionHasChanged = true
+        if topViewController === rootFilterViewController {
+            // Changes in inline filters or removes selected filters
+            filterDelegate?.charcoalViewController(self, didChangeSelection: selectionStore.queryItems(for: filter.rootFilter))
+            selectionHasChanged = false
+        } else {
+            selectionHasChanged = true
+        }
     }
 }
 
@@ -152,7 +154,7 @@ extension CharcoalViewController: FilterSelectionStoreDelegate {
 extension CharcoalViewController: UINavigationControllerDelegate {
     public func navigationController(_ navigationController: UINavigationController, willShow viewController: UIViewController, animated: Bool) {
         guard viewController === rootFilterViewController else { return }
-
+        // Will return to root filters
         if selectionHasChanged {
             filterDelegate?.charcoalViewController(self, didChangeSelection: selectionStore.queryItems(for: filter.rootFilter))
             selectionHasChanged = false

--- a/Sources/Core/CharcoalViewController.swift
+++ b/Sources/Core/CharcoalViewController.swift
@@ -34,6 +34,7 @@ public class CharcoalViewController: UINavigationController {
 
     // MARK: - Private properties
 
+    private var selectionHasChanged = false
     private let selectionStore: FilterSelectionStore
     private var rootFilterViewController: RootFilterViewController
 
@@ -53,6 +54,7 @@ public class CharcoalViewController: UINavigationController {
         rootFilterViewController.verticals = filter.verticals
         super.init(nibName: nil, bundle: nil)
         rootFilterViewController.rootDelegate = self
+        selectionStore.delegate = self
         setViewControllers([rootFilterViewController], animated: false)
     }
 
@@ -95,6 +97,10 @@ extension CharcoalViewController: RootFilterViewControllerDelegate {
 // MARK: - FilterViewControllerDelegate
 
 extension CharcoalViewController: FilterViewControllerDelegate {
+    func filterViewControllerDidPressButtomButton(_ viewController: FilterViewController) {
+        popToRootViewController(animated: true)
+    }
+
     func filterViewController(_ viewController: FilterViewController, didSelectFilter filter: Filter) {
         guard !filter.subfilters.isEmpty else { return }
         let nextViewController: FilterViewController
@@ -135,15 +141,21 @@ extension CharcoalViewController: FilterViewControllerDelegate {
     }
 }
 
+extension CharcoalViewController: FilterSelectionStoreDelegate {
+    func filterSelectionStoreDidChange(_ selectionStore: FilterSelectionStore) {
+        selectionHasChanged = true
+    }
+}
+
 // MARK: - UIGestureRecognizerDelegate
 
 extension CharcoalViewController: UINavigationControllerDelegate {
     public func navigationController(_ navigationController: UINavigationController, willShow viewController: UIViewController, animated: Bool) {
         guard viewController === rootFilterViewController else { return }
 
-        if selectionStore.hasChanges {
+        if selectionHasChanged {
             filterDelegate?.charcoalViewController(self, didChangeSelection: selectionStore.queryItems(for: filter.rootFilter))
-            selectionStore.hasChanges = false
+            selectionHasChanged = false
         }
     }
 

--- a/Sources/Core/Filters/FilterViewController.swift
+++ b/Sources/Core/Filters/FilterViewController.swift
@@ -6,6 +6,7 @@ import UIKit
 
 protocol FilterViewControllerDelegate: class {
     func filterViewController(_ viewController: FilterViewController, didSelectFilter filter: Filter)
+    func filterViewControllerDidPressButtomButton(_ viewController: FilterViewController)
 }
 
 class FilterViewController: UIViewController, FilterBottomButtonViewDelegate {
@@ -82,6 +83,6 @@ class FilterViewController: UIViewController, FilterBottomButtonViewDelegate {
     // MARK: - FilterBottomButtonViewDelegate
 
     func filterBottomButtonView(_ filterBottomButtonView: FilterBottomButtonView, didTapButton button: UIButton) {
-        navigationController?.popToRootViewController(animated: true)
+        delegate?.filterViewControllerDidPressButtomButton(self)
     }
 }

--- a/Sources/Core/Filters/FilterViewController.swift
+++ b/Sources/Core/Filters/FilterViewController.swift
@@ -5,7 +5,6 @@
 import UIKit
 
 protocol FilterViewControllerDelegate: class {
-    func filterViewControllerDidSelectApply(_ viewController: FilterViewController)
     func filterViewController(_ viewController: FilterViewController, didSelectFilter filter: Filter)
 }
 
@@ -83,6 +82,6 @@ class FilterViewController: UIViewController, FilterBottomButtonViewDelegate {
     // MARK: - FilterBottomButtonViewDelegate
 
     func filterBottomButtonView(_ filterBottomButtonView: FilterBottomButtonView, didTapButton button: UIButton) {
-        delegate?.filterViewControllerDidSelectApply(self)
+        navigationController?.popToRootViewController(animated: true)
     }
 }

--- a/Sources/Core/Filters/Root/RootFilterViewController.swift
+++ b/Sources/Core/Filters/Root/RootFilterViewController.swift
@@ -6,7 +6,6 @@ import UIKit
 
 protocol RootFilterViewControllerDelegate: class {
     func rootFilterViewController(_ viewController: RootFilterViewController, didSelectVerticalAt index: Int)
-    func rootFilterViewControllerDidChangeSelection(_ viewController: RootFilterViewController)
 }
 
 final class RootFilterViewController: FilterViewController {
@@ -142,7 +141,6 @@ extension RootFilterViewController: RootFilterCellDelegate {
         let selectedSubfilters = selectionStore.selectedSubfilters(for: currentFilter)
 
         selectionStore.removeValues(for: selectedSubfilters[index])
-        rootDelegate?.rootFilterViewControllerDidChangeSelection(self)
         tableView.reloadRows(at: [indexPath], with: .fade)
 
         let exclusiveFilters = config.mutuallyExclusiveFilters(for: currentFilter.key)
@@ -165,8 +163,6 @@ extension RootFilterViewController: CCInlineFilterViewDelegate {
                 selectionStore.setValue(from: subfilter)
             }
         }
-
-        rootDelegate?.rootFilterViewControllerDidChangeSelection(self)
     }
 
     func inlineFilterView(_ inlineFilterview: CCInlineFilterView, didTapExpandableSegment segment: Segment) {

--- a/Sources/Core/Filters/Root/RootFilterViewController.swift
+++ b/Sources/Core/Filters/Root/RootFilterViewController.swift
@@ -6,6 +6,7 @@ import UIKit
 
 protocol RootFilterViewControllerDelegate: class {
     func rootFilterViewController(_ viewController: RootFilterViewController, didSelectVerticalAt index: Int)
+    func rootFilterViewControllerDidChangeSelection(_ viewController: RootFilterViewController)
 }
 
 final class RootFilterViewController: FilterViewController {
@@ -141,6 +142,7 @@ extension RootFilterViewController: RootFilterCellDelegate {
         let selectedSubfilters = selectionStore.selectedSubfilters(for: currentFilter)
 
         selectionStore.removeValues(for: selectedSubfilters[index])
+        rootDelegate?.rootFilterViewControllerDidChangeSelection(self)
         tableView.reloadRows(at: [indexPath], with: .fade)
 
         let exclusiveFilters = config.mutuallyExclusiveFilters(for: currentFilter.key)
@@ -163,6 +165,8 @@ extension RootFilterViewController: CCInlineFilterViewDelegate {
                 selectionStore.setValue(from: subfilter)
             }
         }
+
+        rootDelegate?.rootFilterViewControllerDidChangeSelection(self)
     }
 
     func inlineFilterView(_ inlineFilterview: CCInlineFilterView, didTapExpandableSegment segment: Segment) {

--- a/Sources/Core/Selection/FilterSelectionStore.swift
+++ b/Sources/Core/Selection/FilterSelectionStore.swift
@@ -49,38 +49,25 @@ final class FilterSelectionStore {
 
 extension FilterSelectionStore {
     func setValue(from filter: Filter) {
-        setValue(filter.value, for: filter)
+        _setValue(filter.value, for: filter)
         delegate?.filterSelectionStoreDidChange(self)
     }
 
     func setValue<T: LosslessStringConvertible>(_ value: T?, for filter: Filter) {
-        removeValues(for: filter)
-
-        if let value = value {
-            let queryItem = URLQueryItem(name: filter.key, value: String(value))
-            queryItems.insert(queryItem)
-        }
-
+        _setValue(value, for: filter)
         delegate?.filterSelectionStoreDidChange(self)
     }
 
     func removeValues(for filter: Filter) {
-        if let queryItem = queryItem(for: filter) {
-            queryItems.remove(queryItem)
-        }
-
-        filter.subfilters.forEach {
-            removeValues(for: $0)
-        }
-
+        _removeValues(for: filter)
         delegate?.filterSelectionStoreDidChange(self)
     }
 
     func toggleValue(for filter: Filter) {
         if isSelected(filter) {
-            removeValues(for: filter)
+            _removeValues(for: filter)
         } else {
-            setValue(filter.value, for: filter)
+            _setValue(filter.value, for: filter)
         }
 
         delegate?.filterSelectionStoreDidChange(self)
@@ -96,6 +83,27 @@ extension FilterSelectionStore {
         }
 
         return queryItem(for: filter) != nil || selected
+    }
+}
+
+private extension FilterSelectionStore {
+    func _setValue<T: LosslessStringConvertible>(_ value: T?, for filter: Filter) {
+        removeValues(for: filter)
+
+        if let value = value {
+            let queryItem = URLQueryItem(name: filter.key, value: String(value))
+            queryItems.insert(queryItem)
+        }
+    }
+
+    func _removeValues(for filter: Filter) {
+        if let queryItem = queryItem(for: filter) {
+            queryItems.remove(queryItem)
+        }
+
+        filter.subfilters.forEach {
+            removeValues(for: $0)
+        }
     }
 }
 

--- a/Sources/Core/Selection/FilterSelectionStore.swift
+++ b/Sources/Core/Selection/FilterSelectionStore.swift
@@ -5,6 +5,13 @@
 import Foundation
 
 final class FilterSelectionStore {
+
+    // MARK: - Internal properties
+
+    internal var hasChanges = false
+
+    // MARK: - Private properties
+
     private var queryItems: Set<URLQueryItem>
 
     // MARK: - Init
@@ -39,6 +46,7 @@ final class FilterSelectionStore {
 extension FilterSelectionStore {
     func setValue(from filter: Filter) {
         setValue(filter.value, for: filter)
+        hasChanges = true
     }
 
     func setValue<T: LosslessStringConvertible>(_ value: T?, for filter: Filter) {
@@ -48,6 +56,8 @@ extension FilterSelectionStore {
             let queryItem = URLQueryItem(name: filter.key, value: String(value))
             queryItems.insert(queryItem)
         }
+
+        hasChanges = true
     }
 
     func removeValues(for filter: Filter) {
@@ -58,6 +68,8 @@ extension FilterSelectionStore {
         filter.subfilters.forEach {
             removeValues(for: $0)
         }
+
+        hasChanges = true
     }
 
     func toggleValue(for filter: Filter) {
@@ -66,6 +78,8 @@ extension FilterSelectionStore {
         } else {
             setValue(filter.value, for: filter)
         }
+
+        hasChanges = true
     }
 
     func isSelected(_ filter: Filter) -> Bool {

--- a/Sources/Core/Selection/FilterSelectionStore.swift
+++ b/Sources/Core/Selection/FilterSelectionStore.swift
@@ -4,11 +4,15 @@
 
 import Foundation
 
+protocol FilterSelectionStoreDelegate: class {
+    func filterSelectionStoreDidChange(_ selectionStore: FilterSelectionStore)
+}
+
 final class FilterSelectionStore {
 
     // MARK: - Internal properties
 
-    internal var hasChanges = false
+    weak var delegate: FilterSelectionStoreDelegate?
 
     // MARK: - Private properties
 
@@ -46,7 +50,7 @@ final class FilterSelectionStore {
 extension FilterSelectionStore {
     func setValue(from filter: Filter) {
         setValue(filter.value, for: filter)
-        hasChanges = true
+        delegate?.filterSelectionStoreDidChange(self)
     }
 
     func setValue<T: LosslessStringConvertible>(_ value: T?, for filter: Filter) {
@@ -57,7 +61,7 @@ extension FilterSelectionStore {
             queryItems.insert(queryItem)
         }
 
-        hasChanges = true
+        delegate?.filterSelectionStoreDidChange(self)
     }
 
     func removeValues(for filter: Filter) {
@@ -69,7 +73,7 @@ extension FilterSelectionStore {
             removeValues(for: $0)
         }
 
-        hasChanges = true
+        delegate?.filterSelectionStoreDidChange(self)
     }
 
     func toggleValue(for filter: Filter) {
@@ -79,7 +83,7 @@ extension FilterSelectionStore {
             setValue(filter.value, for: filter)
         }
 
-        hasChanges = true
+        delegate?.filterSelectionStoreDidChange(self)
     }
 
     func isSelected(_ filter: Filter) -> Bool {

--- a/Sources/Core/Selection/FilterSelectionStore.swift
+++ b/Sources/Core/Selection/FilterSelectionStore.swift
@@ -88,7 +88,7 @@ extension FilterSelectionStore {
 
 private extension FilterSelectionStore {
     func _setValue<T: LosslessStringConvertible>(_ value: T?, for filter: Filter) {
-        removeValues(for: filter)
+        _removeValues(for: filter)
 
         if let value = value {
             let queryItem = URLQueryItem(name: filter.key, value: String(value))
@@ -102,7 +102,7 @@ private extension FilterSelectionStore {
         }
 
         filter.subfilters.forEach {
-            removeValues(for: $0)
+            _removeValues(for: $0)
         }
     }
 }


### PR DESCRIPTION
# Why?

We had some protocol methods that wasn't needed and there were no way to get the query items from the selection store and it seems fit to send these as arguments with the delegate call.

# What?

- Removed `didSelectApply` protocol method. View controllers pop directly to root when the button is pressed. `CharcoalViewController` tells the delegate if the selection store has changed when root filters will be displayed.
- Added query items to `CharcoalViewControllerDelegate` method.
- Added `hasChanges` flag to `FilterSelectionStore`.

# Show me

No UI
