### PR TITLE
Add support for dynamic price range

### DIFF
--- a/Sources/FINN/FilterMarkets/FilterMarketBap.swift
+++ b/Sources/FINN/FilterMarkets/FilterMarketBap.swift
@@ -81,11 +81,11 @@ extension FilterMarketBap: FINNFilterConfiguration {
                 maximumValue: 30000,
                 valueKind: .intervals(
                     array: [
-                        (range: 0 ..< 500, increment: 50),
-                        (range: 500 ..< 1500, increment: 100),
-                        (range: 1500 ..< 6000, increment: 500),
-                    ],
-                    defaultIncrement: 1000
+                        (from: 0, increment: 50),
+                        (from: 500, increment: 100),
+                        (from: 1500, increment: 500),
+                        (from: 6000, increment: 1000),
+                    ]
                 ),
                 hasLowerBoundOffset: false,
                 hasUpperBoundOffset: true,

--- a/Sources/FINN/FilterMarkets/FilterMarketBap.swift
+++ b/Sources/FINN/FilterMarkets/FilterMarketBap.swift
@@ -79,7 +79,14 @@ extension FilterMarketBap: FINNFilterConfiguration {
             return RangeFilterConfiguration(
                 minimumValue: 0,
                 maximumValue: 30000,
-                valueKind: .incremented(1000),
+                valueKind: .intervals(
+                    array: [
+                        (range: 0 ..< 500, increment: 50),
+                        (range: 500 ..< 1500, increment: 100),
+                        (range: 1500 ..< 6000, increment: 500),
+                        ],
+                    defaultIncrement: 1000
+                ),
                 hasLowerBoundOffset: false,
                 hasUpperBoundOffset: true,
                 unit: "kr",

--- a/Sources/FINN/FilterMarkets/FilterMarketBap.swift
+++ b/Sources/FINN/FilterMarkets/FilterMarketBap.swift
@@ -84,7 +84,7 @@ extension FilterMarketBap: FINNFilterConfiguration {
                         (range: 0 ..< 500, increment: 50),
                         (range: 500 ..< 1500, increment: 100),
                         (range: 1500 ..< 6000, increment: 500),
-                        ],
+                    ],
                     defaultIncrement: 1000
                 ),
                 hasLowerBoundOffset: false,

--- a/UnitTests/Models/RangeFilterConfigurationTests.swift
+++ b/UnitTests/Models/RangeFilterConfigurationTests.swift
@@ -110,11 +110,11 @@ final class RangeFilterConfigurationTests: XCTestCase {
             maximumValue: 4000,
             valueKind: .intervals(
                 array: [
-                    (range: 0 ..< 200, increment: 50),
-                    (range: 200 ..< 500, increment: 100),
-                    (range: 500 ..< 2000, increment: 500),
-                ],
-                defaultIncrement: 1000
+                    (from: 0, increment: 50),
+                    (from: 200, increment: 100),
+                    (from: 500, increment: 500),
+                    (from: 2000, increment: 1000),
+                ]
             ),
             hasLowerBoundOffset: false,
             hasUpperBoundOffset: true,

--- a/UnitTests/Models/RangeFilterConfigurationTests.swift
+++ b/UnitTests/Models/RangeFilterConfigurationTests.swift
@@ -104,6 +104,40 @@ final class RangeFilterConfigurationTests: XCTestCase {
         XCTAssertFalse(config.isCurrencyValueRange)
     }
 
+    func testInitWithIntervals() {
+        let config = RangeFilterConfiguration(
+            minimumValue: 0,
+            maximumValue: 4000,
+            valueKind: .intervals(
+                array: [
+                    (range: 0 ..< 200, increment: 50),
+                    (range: 200 ..< 500, increment: 100),
+                    (range: 500 ..< 2000, increment: 500),
+                ],
+                defaultIncrement: 1000
+            ),
+            hasLowerBoundOffset: false,
+            hasUpperBoundOffset: true,
+            unit: "kr",
+            accessibilityValueSuffix: "test",
+            usesSmallNumberInputFont: false,
+            displaysUnitInNumberInput: true,
+            isCurrencyValueRange: true
+        )
+
+        XCTAssertEqual(config.minimumValue, 0)
+        XCTAssertEqual(config.maximumValue, 4000)
+        XCTAssertFalse(config.hasLowerBoundOffset)
+        XCTAssertTrue(config.hasUpperBoundOffset)
+        XCTAssertEqual(config.values, [0, 50, 100, 150, 200, 300, 400, 500, 1000, 1500, 2000, 3000, 4000])
+        XCTAssertEqual(config.referenceValues, [0, 400, 4000])
+        XCTAssertEqual(config.unit, "kr")
+        XCTAssertEqual(config.accessibilityValueSuffix, "test")
+        XCTAssertFalse(config.usesSmallNumberInputFont)
+        XCTAssertTrue(config.displaysUnitInNumberInput)
+        XCTAssertTrue(config.isCurrencyValueRange)
+    }
+
     func testValueForStepWithoutOffsets() {
         let config = RangeFilterConfiguration(
             minimumValue: 0,


### PR DESCRIPTION
# Why?

Because we want to configure some ranges with dynamic step increment.

# What?

- Add new `ValueKind.intervals(array: [StepInterval], defaultIncrement: Int)`, which can be used like this:

```swift
.intervals(
    array: [
        (range: 0 ..< 500, increment: 50), // 0, 50, 100, 150, ..., 450
        (range: 500 ..< 1500, increment: 100), // 500, 600, 700, 800, ..., 1400
        (range: 1500 ..< 6000, increment: 500), // 1500, 2000, 2500, ..., 5500 
    ],
    defaultIncrement: 1000 // 6000, 7000, 8000
)
```

- Configure dynamic price range for Torget according to requirements 

# Show me

No UI changes.