### PR TITLE
Seperate filter selection configuration

### DIFF
--- a/Demo/ViewControllers/DemoViewsTableViewController.swift
+++ b/Demo/ViewControllers/DemoViewsTableViewController.swift
@@ -68,7 +68,7 @@ class DemoViewsTableViewController: UITableViewController {
 
             let filter = filterContainer(forMarket: market, using: config)
             let controller = CharcoalViewController()
-            controller.configure(with: filter)
+            controller.filter = filter
             controller.filterDelegate = self
             controller.mapFilterViewManager = MapViewManager()
             controller.searchLocationDataSource = DemoSearchLocationDataSource()
@@ -138,13 +138,17 @@ extension DemoViewsTableViewController: CharcoalViewControllerDelegate {
 
         viewController.isLoading = true
         DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-            viewController.configure(with: filter)
+            viewController.filter = filter
             viewController.isLoading = false
         }
     }
 
     func charcoalViewController(_ viewController: CharcoalViewController, didSelectExternalFilterWithKey key: String, value: String?) {
         UIApplication.shared.openURL(URL(string: "https://finn.no")!)
+    }
+
+    func charcoalViewControllerDidPressShowResults(_ viewController: CharcoalViewController) {
+        print("Did press show results")
     }
 }
 

--- a/Sources/Core/CharcoalViewController.swift
+++ b/Sources/Core/CharcoalViewController.swift
@@ -73,11 +73,8 @@ public class CharcoalViewController: UINavigationController {
     // MARK: - Public
 
     public func set(selection: Set<URLQueryItem>) {
-        selectionStore = FilterSelectionStore(queryItems: selection)
-
-        if let filter = filter {
-            rootFilterViewController?.set(filter: filter.rootFilter, verticals: filter.verticals)
-        }
+        selectionStore.set(selection: selection)
+        rootFilterViewController?.reloadFilters()
     }
 
     // MARK: - Private

--- a/Sources/Core/CharcoalViewController.swift
+++ b/Sources/Core/CharcoalViewController.swift
@@ -14,6 +14,10 @@ public class CharcoalViewController: UINavigationController {
 
     // MARK: - Public properties
 
+    public var filter: FilterContainer? {
+        didSet { configure(with: filter) }
+    }
+
     public weak var filterDelegate: CharcoalViewControllerDelegate?
 
     // MARK: -
@@ -41,8 +45,6 @@ public class CharcoalViewController: UINavigationController {
 
     // MARK: - Private properties
 
-    private var filter: FilterContainer?
-
     private var selectionHasChanged = false
     private var selectionStore = FilterSelectionStore()
 
@@ -67,6 +69,16 @@ public class CharcoalViewController: UINavigationController {
         delegate = self
     }
 
+    // MARK: - Public
+
+    public func set(selection: Set<URLQueryItem>) {
+        selectionStore = FilterSelectionStore(queryItems: selection)
+
+        if let filter = filter {
+            rootFilterViewController?.set(filter: filter.rootFilter, verticals: filter.verticals)
+        }
+    }
+
     // MARK: - Private
 
     private func updateLoading() {
@@ -78,15 +90,8 @@ public class CharcoalViewController: UINavigationController {
         }
     }
 
-    // MARK: - Public
-
-    public func configure(with filter: FilterContainer, queryItems: Set<URLQueryItem>? = nil) {
-        self.filter = filter
-
-        if let queryItems = queryItems {
-            selectionStore = FilterSelectionStore(queryItems: queryItems)
-            selectionStore.delegate = self
-        }
+    private func configure(with filter: FilterContainer?) {
+        guard let filter = filter else { return }
 
         if let rootFilterViewController = rootFilterViewController {
             rootFilterViewController.set(filter: filter.rootFilter, verticals: filter.verticals)

--- a/Sources/Core/CharcoalViewController.swift
+++ b/Sources/Core/CharcoalViewController.swift
@@ -8,6 +8,7 @@ public protocol CharcoalViewControllerDelegate: class {
     func charcoalViewController(_ viewController: CharcoalViewController, didSelect vertical: Vertical)
     func charcoalViewController(_ viewController: CharcoalViewController, didChangeSelection selection: [URLQueryItem])
     func charcoalViewController(_ viewController: CharcoalViewController, didSelectExternalFilterWithKey key: String, value: String?)
+    func charcoalViewControllerDidPressShowResults(_ viewController: CharcoalViewController)
 }
 
 public class CharcoalViewController: UINavigationController {
@@ -120,7 +121,11 @@ extension CharcoalViewController: RootFilterViewControllerDelegate {
 
 extension CharcoalViewController: FilterViewControllerDelegate {
     func filterViewControllerDidPressButtomButton(_ viewController: FilterViewController) {
-        popToRootViewController(animated: true)
+        if viewController === rootFilterViewController {
+            filterDelegate?.charcoalViewControllerDidPressShowResults(self)
+        } else {
+            popToRootViewController(animated: true)
+        }
     }
 
     func filterViewController(_ viewController: FilterViewController, didSelectFilter filter: Filter) {

--- a/Sources/Core/Filters/Root/RootFilterViewController.swift
+++ b/Sources/Core/Filters/Root/RootFilterViewController.swift
@@ -74,6 +74,12 @@ final class RootFilterViewController: FilterViewController {
         tableView.reloadData()
     }
 
+    // MARK: - Public
+
+    func reloadFilters() {
+        tableView.reloadData()
+    }
+
     // MARK: - Setup
 
     func set(filter: Filter, verticals: [Vertical]?) {

--- a/Sources/Core/Selection/FilterSelectionStore.swift
+++ b/Sources/Core/Selection/FilterSelectionStore.swift
@@ -24,6 +24,10 @@ final class FilterSelectionStore {
         self.queryItems = queryItems
     }
 
+    func set(selection: Set<URLQueryItem>) {
+        queryItems = selection
+    }
+
     // MARK: - Values
 
     func value<T: LosslessStringConvertible>(for filter: Filter) -> T? {


### PR DESCRIPTION
# Why?

It was a bit weird to use the same function to set both filter and query items. Separating these makes more sense. And I added delegate method for show result button pressed.

# What?

- Removed query items from `configure(with filter: Filter, queryItems: Set<URLQueryItem>)` function.
- Added method to set a selection.
- Added delegate method for when the show results button is pressed. 

# Show me

No UI