### PR TITLE
Setup range context filters for Torget

### DIFF
--- a/Sources/FINN/FilterMarkets/FilterMarketBap.swift
+++ b/Sources/FINN/FilterMarkets/FilterMarketBap.swift
@@ -75,6 +75,32 @@ extension FilterMarketBap: FINNFilterConfiguration {
         }
 
         switch filterKey {
+        case .horseHeight:
+            return RangeFilterConfiguration(
+                minimumValue: 120,
+                maximumValue: 200,
+                valueKind: .incremented(10),
+                hasLowerBoundOffset: true,
+                hasUpperBoundOffset: true,
+                unit: "cm",
+                accessibilityValueSuffix: nil,
+                usesSmallNumberInputFont: false,
+                displaysUnitInNumberInput: true,
+                isCurrencyValueRange: false
+            )
+        case .lengthCm:
+            return RangeFilterConfiguration(
+                minimumValue: 50,
+                maximumValue: 220,
+                valueKind: .incremented(10),
+                hasLowerBoundOffset: true,
+                hasUpperBoundOffset: true,
+                unit: "cm",
+                accessibilityValueSuffix: nil,
+                usesSmallNumberInputFont: false,
+                displaysUnitInNumberInput: true,
+                isCurrencyValueRange: false
+            )
         case .price:
             return RangeFilterConfiguration(
                 minimumValue: 0,


### PR DESCRIPTION
# Why?

Because some of the context filters did not have range configuration.

# What?

Setup range context filters for Torget.

# Show me

No UI changes.