### PR TITLE
Make the setup of range filters more generic

### DIFF
--- a/Charcoal.xcodeproj/project.pbxproj
+++ b/Charcoal.xcodeproj/project.pbxproj
@@ -130,6 +130,7 @@
 		CFCB35F022366BE8004E6EB3 /* ContextFilterTestData.json in Resources */ = {isa = PBXBuildFile; fileRef = CFCB35EF22366BE8004E6EB3 /* ContextFilterTestData.json */; };
 		CFCB35F322367C3D004E6EB3 /* Charcoal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 44ECE65F208F7FA20017AC82 /* Charcoal.framework */; };
 		CFCB35F622367CC6004E6EB3 /* Charcoal.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 44ECE65F208F7FA20017AC82 /* Charcoal.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		CFCB35F922368D18004E6EB3 /* RangeFilterConfiguration+FINNSetup.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFCB35F822368D18004E6EB3 /* RangeFilterConfiguration+FINNSetup.swift */; };
 		CFD7BBFB2209BCDF00746823 /* RangeToolbarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFD7BBFA2209BCDF00746823 /* RangeToolbarItem.swift */; };
 		CFEDCD8C223274C7008FCDB1 /* ListFilterImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFEDCD8B223274C7008FCDB1 /* ListFilterImageView.swift */; };
 		CFEDCDFF2232B756008FCDB1 /* FINNSetup.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CFEDCDF82232B756008FCDB1 /* FINNSetup.framework */; };
@@ -380,6 +381,7 @@
 		CFB13DAF21FF2B1800F8D126 /* StepTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StepTests.swift; sourceTree = "<group>"; };
 		CFB13DB121FF2CBB00F8D126 /* ArrayStepTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayStepTests.swift; sourceTree = "<group>"; };
 		CFCB35EF22366BE8004E6EB3 /* ContextFilterTestData.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = ContextFilterTestData.json; sourceTree = "<group>"; };
+		CFCB35F822368D18004E6EB3 /* RangeFilterConfiguration+FINNSetup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RangeFilterConfiguration+FINNSetup.swift"; sourceTree = "<group>"; };
 		CFD7BBFA2209BCDF00746823 /* RangeToolbarItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RangeToolbarItem.swift; sourceTree = "<group>"; };
 		CFEDCD8B223274C7008FCDB1 /* ListFilterImageView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListFilterImageView.swift; sourceTree = "<group>"; };
 		CFEDCDF82232B756008FCDB1 /* FINNSetup.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FINNSetup.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -733,6 +735,7 @@
 				55BDA76E20DBC46800331FFC /* FilterMarket.swift */,
 				CF81E10C221C515800D00423 /* FINNFilterConfiguration.swift */,
 				465F6167219B6ECF00CF568B /* BackendModel */,
+				CFCB35F722368D01004E6EB3 /* Extensions */,
 				08716B2721F73AD2003180D8 /* FilterMarkets */,
 			);
 			path = FINNSetup;
@@ -976,6 +979,14 @@
 				9BE0D54221A4552300F0B63B /* FilterMarketTests.swift */,
 			);
 			path = FilterMarkets;
+			sourceTree = "<group>";
+		};
+		CFCB35F722368D01004E6EB3 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				CFCB35F822368D18004E6EB3 /* RangeFilterConfiguration+FINNSetup.swift */,
+			);
+			path = Extensions;
 			sourceTree = "<group>";
 		};
 		CFEDCD8A223273DC008FCDB1 /* Views */ = {
@@ -1501,6 +1512,7 @@
 				CFEDCE0C2232B7A8008FCDB1 /* FilterMarketCar.swift in Sources */,
 				CFEDCE102232B7A8008FCDB1 /* FilterMarketBoat.swift in Sources */,
 				CFEDCE052232B7A8008FCDB1 /* FilterKey.swift in Sources */,
+				CFCB35F922368D18004E6EB3 /* RangeFilterConfiguration+FINNSetup.swift in Sources */,
 				CFEDCE072232B7A8008FCDB1 /* FINNFilterConfiguration.swift in Sources */,
 				CFEDCE0D2232B7A8008FCDB1 /* FilterMarketJob.swift in Sources */,
 				CFEDCE0B2232B7A8008FCDB1 /* FilterMarketMC.swift in Sources */,

--- a/Charcoal.xcodeproj/project.pbxproj
+++ b/Charcoal.xcodeproj/project.pbxproj
@@ -131,6 +131,7 @@
 		CFCB35F322367C3D004E6EB3 /* Charcoal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 44ECE65F208F7FA20017AC82 /* Charcoal.framework */; };
 		CFCB35F622367CC6004E6EB3 /* Charcoal.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 44ECE65F208F7FA20017AC82 /* Charcoal.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		CFCB35F922368D18004E6EB3 /* RangeFilterConfiguration+FINNSetup.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFCB35F822368D18004E6EB3 /* RangeFilterConfiguration+FINNSetup.swift */; };
+		CFCB35FB2236A299004E6EB3 /* Unit.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFCB35FA2236A299004E6EB3 /* Unit.swift */; };
 		CFD7BBFB2209BCDF00746823 /* RangeToolbarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFD7BBFA2209BCDF00746823 /* RangeToolbarItem.swift */; };
 		CFEDCD8C223274C7008FCDB1 /* ListFilterImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFEDCD8B223274C7008FCDB1 /* ListFilterImageView.swift */; };
 		CFEDCDFF2232B756008FCDB1 /* FINNSetup.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CFEDCDF82232B756008FCDB1 /* FINNSetup.framework */; };
@@ -382,6 +383,7 @@
 		CFB13DB121FF2CBB00F8D126 /* ArrayStepTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayStepTests.swift; sourceTree = "<group>"; };
 		CFCB35EF22366BE8004E6EB3 /* ContextFilterTestData.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = ContextFilterTestData.json; sourceTree = "<group>"; };
 		CFCB35F822368D18004E6EB3 /* RangeFilterConfiguration+FINNSetup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RangeFilterConfiguration+FINNSetup.swift"; sourceTree = "<group>"; };
+		CFCB35FA2236A299004E6EB3 /* Unit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Unit.swift; sourceTree = "<group>"; };
 		CFD7BBFA2209BCDF00746823 /* RangeToolbarItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RangeToolbarItem.swift; sourceTree = "<group>"; };
 		CFEDCD8B223274C7008FCDB1 /* ListFilterImageView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListFilterImageView.swift; sourceTree = "<group>"; };
 		CFEDCDF82232B756008FCDB1 /* FINNSetup.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FINNSetup.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -734,6 +736,7 @@
 				08716B3621F76424003180D8 /* FilterKey.swift */,
 				55BDA76E20DBC46800331FFC /* FilterMarket.swift */,
 				CF81E10C221C515800D00423 /* FINNFilterConfiguration.swift */,
+				CFCB35FA2236A299004E6EB3 /* Unit.swift */,
 				465F6167219B6ECF00CF568B /* BackendModel */,
 				CFCB35F722368D01004E6EB3 /* Extensions */,
 				08716B2721F73AD2003180D8 /* FilterMarkets */,
@@ -1509,6 +1512,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CFCB35FB2236A299004E6EB3 /* Unit.swift in Sources */,
 				CFEDCE0C2232B7A8008FCDB1 /* FilterMarketCar.swift in Sources */,
 				CFEDCE102232B7A8008FCDB1 /* FilterMarketBoat.swift in Sources */,
 				CFEDCE052232B7A8008FCDB1 /* FilterKey.swift in Sources */,

--- a/Sources/FINNSetup/Extensions/RangeFilterConfiguration+FINNSetup.swift
+++ b/Sources/FINNSetup/Extensions/RangeFilterConfiguration+FINNSetup.swift
@@ -5,138 +5,43 @@
 import Foundation
 
 extension RangeFilterConfiguration {
-    static func currencyConfiguration(minimumValue: Int, maximumValue: Int, increment: Int) -> RangeFilterConfiguration {
+    static func configuration(minimumValue: Int, maximumValue: Int, increment: Int, unit: Unit) -> RangeFilterConfiguration {
         return RangeFilterConfiguration(
             minimumValue: minimumValue,
             maximumValue: maximumValue,
             valueKind: .incremented(increment),
             hasLowerBoundOffset: minimumValue > 0,
             hasUpperBoundOffset: true,
-            unit: "kr",
+            unit: unit.rawValue,
             accessibilityValueSuffix: nil,
             usesSmallNumberInputFont: maximumValue > 1_000_000,
-            displaysUnitInNumberInput: true,
-            isCurrencyValueRange: true
+            displaysUnitInNumberInput: unit != .year,
+            isCurrencyValueRange: unit == .currency
         )
     }
 
     static func yearConfiguration(minimumValue: Int) -> RangeFilterConfiguration {
-        return RangeFilterConfiguration(
+        return .configuration(
             minimumValue: minimumValue,
             maximumValue: Calendar.current.component(.year, from: Date()),
-            valueKind: .incremented(1),
-            hasLowerBoundOffset: true,
-            hasUpperBoundOffset: true,
-            unit: "år",
-            accessibilityValueSuffix: nil,
-            usesSmallNumberInputFont: false,
-            displaysUnitInNumberInput: false,
-            isCurrencyValueRange: false
+            increment: 1,
+            unit: .year
         )
     }
 
     static func mileageConfiguration(maximumValue: Int) -> RangeFilterConfiguration {
-        return RangeFilterConfiguration(
-            minimumValue: 0,
-            maximumValue: maximumValue,
-            valueKind: .incremented(1000),
-            hasLowerBoundOffset: false,
-            hasUpperBoundOffset: true,
-            unit: "km",
-            accessibilityValueSuffix: nil,
-            usesSmallNumberInputFont: false,
-            displaysUnitInNumberInput: true,
-            isCurrencyValueRange: false
-        )
+        return .configuration(minimumValue: 0, maximumValue: maximumValue, increment: 1000, unit: .kilometers)
     }
 
     static func numberOfSeatsConfiguration(maximumValue: Int) -> RangeFilterConfiguration {
-        return RangeFilterConfiguration(
-            minimumValue: 0,
-            maximumValue: maximumValue,
-            valueKind: .incremented(1),
-            hasLowerBoundOffset: false,
-            hasUpperBoundOffset: true,
-            unit: "seter",
-            accessibilityValueSuffix: nil,
-            usesSmallNumberInputFont: false,
-            displaysUnitInNumberInput: true,
-            isCurrencyValueRange: false
-        )
-    }
-
-    static func weightConfiguration(minimumValue: Int, maximumValue: Int, increment: Int) -> RangeFilterConfiguration {
-        return RangeFilterConfiguration(
-            minimumValue: minimumValue,
-            maximumValue: maximumValue,
-            valueKind: .incremented(10),
-            hasLowerBoundOffset: minimumValue > 0,
-            hasUpperBoundOffset: true,
-            unit: "kg",
-            accessibilityValueSuffix: nil,
-            usesSmallNumberInputFont: false,
-            displaysUnitInNumberInput: true,
-            isCurrencyValueRange: false
-        )
+        return .configuration(minimumValue: 0, maximumValue: maximumValue, increment: 1, unit: .seats)
     }
 
     static func horsePowerConfiguration(minimumValue: Int, maximumValue: Int) -> RangeFilterConfiguration {
-        return RangeFilterConfiguration(
-            minimumValue: minimumValue,
-            maximumValue: maximumValue,
-            valueKind: .incremented(10),
-            hasLowerBoundOffset: minimumValue > 0,
-            hasUpperBoundOffset: true,
-            unit: "hk",
-            accessibilityValueSuffix: nil,
-            usesSmallNumberInputFont: false,
-            displaysUnitInNumberInput: true,
-            isCurrencyValueRange: false
-        )
-    }
-
-    static func sizeConfiguration(minimumValue: Int, maximumValue: Int, increment: Int, unit: String = "cm") -> RangeFilterConfiguration {
-        return RangeFilterConfiguration(
-            minimumValue: minimumValue,
-            maximumValue: maximumValue,
-            valueKind: .incremented(increment),
-            hasLowerBoundOffset: minimumValue > 0,
-            hasUpperBoundOffset: true,
-            unit: unit,
-            accessibilityValueSuffix: nil,
-            usesSmallNumberInputFont: false,
-            displaysUnitInNumberInput: true,
-            isCurrencyValueRange: false
-        )
-    }
-
-    static func areaConfiguration(minimumValue: Int, maximumValue: Int, increment: Int) -> RangeFilterConfiguration {
-        return RangeFilterConfiguration(
-            minimumValue: minimumValue,
-            maximumValue: maximumValue,
-            valueKind: .incremented(increment),
-            hasLowerBoundOffset: true,
-            hasUpperBoundOffset: true,
-            unit: "m\u{00B2}",
-            accessibilityValueSuffix: nil,
-            usesSmallNumberInputFont: false,
-            displaysUnitInNumberInput: true,
-            isCurrencyValueRange: false
-        )
+        return .configuration(minimumValue: minimumValue, maximumValue: maximumValue, increment: 10, unit: .horsePower)
     }
 
     static func numberOfItemsConfiguration(minimumValue: Int, maximumValue: Int) -> RangeFilterConfiguration {
-        return RangeFilterConfiguration(
-            minimumValue: minimumValue,
-            maximumValue: maximumValue,
-            valueKind: .incremented(1),
-            hasLowerBoundOffset: false,
-            hasUpperBoundOffset: true,
-            unit: "stk.",
-            accessibilityValueSuffix: nil,
-            usesSmallNumberInputFont: false,
-            displaysUnitInNumberInput: true,
-            isCurrencyValueRange: false
-        )
+        return .configuration(minimumValue: minimumValue, maximumValue: maximumValue, increment: 1, unit: .items)
     }
 }

--- a/Sources/FINNSetup/Extensions/RangeFilterConfiguration+FINNSetup.swift
+++ b/Sources/FINNSetup/Extensions/RangeFilterConfiguration+FINNSetup.swift
@@ -1,0 +1,142 @@
+//
+//  Copyright © FINN.no AS, Inc. All rights reserved.
+//
+
+import Foundation
+
+extension RangeFilterConfiguration {
+    static func currencyConfiguration(minimumValue: Int, maximumValue: Int, increment: Int) -> RangeFilterConfiguration {
+        return RangeFilterConfiguration(
+            minimumValue: minimumValue,
+            maximumValue: maximumValue,
+            valueKind: .incremented(increment),
+            hasLowerBoundOffset: minimumValue > 0,
+            hasUpperBoundOffset: true,
+            unit: "kr",
+            accessibilityValueSuffix: nil,
+            usesSmallNumberInputFont: maximumValue > 1_000_000,
+            displaysUnitInNumberInput: true,
+            isCurrencyValueRange: true
+        )
+    }
+
+    static func yearConfiguration(minimumValue: Int) -> RangeFilterConfiguration {
+        return RangeFilterConfiguration(
+            minimumValue: minimumValue,
+            maximumValue: Calendar.current.component(.year, from: Date()),
+            valueKind: .incremented(1),
+            hasLowerBoundOffset: true,
+            hasUpperBoundOffset: true,
+            unit: "år",
+            accessibilityValueSuffix: nil,
+            usesSmallNumberInputFont: false,
+            displaysUnitInNumberInput: false,
+            isCurrencyValueRange: false
+        )
+    }
+
+    static func mileageConfiguration(maximumValue: Int) -> RangeFilterConfiguration {
+        return RangeFilterConfiguration(
+            minimumValue: 0,
+            maximumValue: maximumValue,
+            valueKind: .incremented(1000),
+            hasLowerBoundOffset: false,
+            hasUpperBoundOffset: true,
+            unit: "km",
+            accessibilityValueSuffix: nil,
+            usesSmallNumberInputFont: false,
+            displaysUnitInNumberInput: true,
+            isCurrencyValueRange: false
+        )
+    }
+
+    static func numberOfSeatsConfiguration(maximumValue: Int) -> RangeFilterConfiguration {
+        return RangeFilterConfiguration(
+            minimumValue: 0,
+            maximumValue: maximumValue,
+            valueKind: .incremented(1),
+            hasLowerBoundOffset: false,
+            hasUpperBoundOffset: true,
+            unit: "seter",
+            accessibilityValueSuffix: nil,
+            usesSmallNumberInputFont: false,
+            displaysUnitInNumberInput: true,
+            isCurrencyValueRange: false
+        )
+    }
+
+    static func weightConfiguration(minimumValue: Int, maximumValue: Int, increment: Int) -> RangeFilterConfiguration {
+        return RangeFilterConfiguration(
+            minimumValue: minimumValue,
+            maximumValue: maximumValue,
+            valueKind: .incremented(10),
+            hasLowerBoundOffset: minimumValue > 0,
+            hasUpperBoundOffset: true,
+            unit: "kg",
+            accessibilityValueSuffix: nil,
+            usesSmallNumberInputFont: false,
+            displaysUnitInNumberInput: true,
+            isCurrencyValueRange: false
+        )
+    }
+
+    static func horsePowerConfiguration(minimumValue: Int, maximumValue: Int) -> RangeFilterConfiguration {
+        return RangeFilterConfiguration(
+            minimumValue: minimumValue,
+            maximumValue: maximumValue,
+            valueKind: .incremented(10),
+            hasLowerBoundOffset: minimumValue > 0,
+            hasUpperBoundOffset: true,
+            unit: "hk",
+            accessibilityValueSuffix: nil,
+            usesSmallNumberInputFont: false,
+            displaysUnitInNumberInput: true,
+            isCurrencyValueRange: false
+        )
+    }
+
+    static func sizeConfiguration(minimumValue: Int, maximumValue: Int, increment: Int, unit: String = "cm") -> RangeFilterConfiguration {
+        return RangeFilterConfiguration(
+            minimumValue: minimumValue,
+            maximumValue: maximumValue,
+            valueKind: .incremented(increment),
+            hasLowerBoundOffset: minimumValue > 0,
+            hasUpperBoundOffset: true,
+            unit: unit,
+            accessibilityValueSuffix: nil,
+            usesSmallNumberInputFont: false,
+            displaysUnitInNumberInput: true,
+            isCurrencyValueRange: false
+        )
+    }
+
+    static func areaConfiguration(minimumValue: Int, maximumValue: Int, increment: Int) -> RangeFilterConfiguration {
+        return RangeFilterConfiguration(
+            minimumValue: minimumValue,
+            maximumValue: maximumValue,
+            valueKind: .incremented(increment),
+            hasLowerBoundOffset: true,
+            hasUpperBoundOffset: true,
+            unit: "m\u{00B2}",
+            accessibilityValueSuffix: nil,
+            usesSmallNumberInputFont: false,
+            displaysUnitInNumberInput: true,
+            isCurrencyValueRange: false
+        )
+    }
+
+    static func numberOfItemsConfiguration(minimumValue: Int, maximumValue: Int) -> RangeFilterConfiguration {
+        return RangeFilterConfiguration(
+            minimumValue: minimumValue,
+            maximumValue: maximumValue,
+            valueKind: .incremented(1),
+            hasLowerBoundOffset: false,
+            hasUpperBoundOffset: true,
+            unit: "stk.",
+            accessibilityValueSuffix: nil,
+            usesSmallNumberInputFont: false,
+            displaysUnitInNumberInput: true,
+            isCurrencyValueRange: false
+        )
+    }
+}

--- a/Sources/FINNSetup/FilterMarkets/FilterMarketB2B.swift
+++ b/Sources/FINNSetup/FilterMarkets/FilterMarketB2B.swift
@@ -145,40 +145,14 @@ extension FilterMarketB2B: FINNFilterConfiguration {
                 maximumValue = 1_000_000
             }
 
-            return RangeFilterConfiguration(
-                minimumValue: minimumValue,
-                maximumValue: maximumValue,
-                valueKind: .incremented(10000),
-                hasLowerBoundOffset: minimumValue > 0,
-                hasUpperBoundOffset: true,
-                unit: "kr",
-                accessibilityValueSuffix: nil,
-                usesSmallNumberInputFont: false,
-                displaysUnitInNumberInput: true,
-                isCurrencyValueRange: true
-            )
+            return .currencyConfiguration(minimumValue: minimumValue, maximumValue: maximumValue, increment: 10000)
         case .year:
-            let minimumValue: Int
-
             switch self {
             case .bus, .vanNorway, .vanAbroad:
-                minimumValue = 1990
+                return .yearConfiguration(minimumValue: 1990)
             default:
-                minimumValue = 1985
+                return .yearConfiguration(minimumValue: 1985)
             }
-
-            return RangeFilterConfiguration(
-                minimumValue: minimumValue,
-                maximumValue: Calendar.current.component(.year, from: Date()),
-                valueKind: .incremented(1),
-                hasLowerBoundOffset: true,
-                hasUpperBoundOffset: true,
-                unit: "år",
-                accessibilityValueSuffix: nil,
-                usesSmallNumberInputFont: false,
-                displaysUnitInNumberInput: false,
-                isCurrencyValueRange: false
-            )
         case .engineEffect:
             let minimumValue: Int
             let maximumValue: Int
@@ -198,57 +172,13 @@ extension FilterMarketB2B: FINNFilterConfiguration {
                 maximumValue = 600
             }
 
-            return RangeFilterConfiguration(
-                minimumValue: minimumValue,
-                maximumValue: maximumValue,
-                valueKind: .incremented(10),
-                hasLowerBoundOffset: minimumValue > 0,
-                hasUpperBoundOffset: true,
-                unit: "hk",
-                accessibilityValueSuffix: nil,
-                usesSmallNumberInputFont: false,
-                displaysUnitInNumberInput: true,
-                isCurrencyValueRange: false
-            )
+            return .horsePowerConfiguration(minimumValue: minimumValue, maximumValue: maximumValue)
         case .weight:
-            return RangeFilterConfiguration(
-                minimumValue: 1000,
-                maximumValue: 40000,
-                valueKind: .incremented(50),
-                hasLowerBoundOffset: true,
-                hasUpperBoundOffset: true,
-                unit: "kg",
-                accessibilityValueSuffix: nil,
-                usesSmallNumberInputFont: false,
-                displaysUnitInNumberInput: true,
-                isCurrencyValueRange: false
-            )
+            return .weightConfiguration(minimumValue: 1000, maximumValue: 40000, increment: 50)
         case .mileage:
-            return RangeFilterConfiguration(
-                minimumValue: 0,
-                maximumValue: 200_000,
-                valueKind: .incremented(1000),
-                hasLowerBoundOffset: false,
-                hasUpperBoundOffset: true,
-                unit: "km",
-                accessibilityValueSuffix: nil,
-                usesSmallNumberInputFont: false,
-                displaysUnitInNumberInput: true,
-                isCurrencyValueRange: false
-            )
+            return .mileageConfiguration(maximumValue: 200_000)
         case .numberOfSeats:
-            return RangeFilterConfiguration(
-                minimumValue: 0,
-                maximumValue: 10,
-                valueKind: .incremented(1),
-                hasLowerBoundOffset: false,
-                hasUpperBoundOffset: true,
-                unit: "seter",
-                accessibilityValueSuffix: nil,
-                usesSmallNumberInputFont: false,
-                displaysUnitInNumberInput: true,
-                isCurrencyValueRange: false
-            )
+            return .numberOfSeatsConfiguration(maximumValue: 10)
         default:
             return nil
         }

--- a/Sources/FINNSetup/FilterMarkets/FilterMarketB2B.swift
+++ b/Sources/FINNSetup/FilterMarkets/FilterMarketB2B.swift
@@ -145,7 +145,12 @@ extension FilterMarketB2B: FINNFilterConfiguration {
                 maximumValue = 1_000_000
             }
 
-            return .currencyConfiguration(minimumValue: minimumValue, maximumValue: maximumValue, increment: 10000)
+            return .configuration(
+                minimumValue: minimumValue,
+                maximumValue: maximumValue,
+                increment: 10000,
+                unit: .currency
+            )
         case .year:
             switch self {
             case .bus, .vanNorway, .vanAbroad:
@@ -174,7 +179,7 @@ extension FilterMarketB2B: FINNFilterConfiguration {
 
             return .horsePowerConfiguration(minimumValue: minimumValue, maximumValue: maximumValue)
         case .weight:
-            return .weightConfiguration(minimumValue: 1000, maximumValue: 40000, increment: 50)
+            return .configuration(minimumValue: 1000, maximumValue: 40000, increment: 50, unit: .kilograms)
         case .mileage:
             return .mileageConfiguration(maximumValue: 200_000)
         case .numberOfSeats:

--- a/Sources/FINNSetup/FilterMarkets/FilterMarketBap.swift
+++ b/Sources/FINNSetup/FilterMarkets/FilterMarketBap.swift
@@ -76,9 +76,9 @@ extension FilterMarketBap: FINNFilterConfiguration {
 
         switch filterKey {
         case .horseHeight:
-            return .sizeConfiguration(minimumValue: 120, maximumValue: 200, increment: 10)
+            return .configuration(minimumValue: 120, maximumValue: 200, increment: 10, unit: .centimeters)
         case .lengthCm:
-            return .sizeConfiguration(minimumValue: 50, maximumValue: 220, increment: 10)
+            return .configuration(minimumValue: 50, maximumValue: 220, increment: 10, unit: .centimeters)
         case .price:
             return RangeFilterConfiguration(
                 minimumValue: 0,
@@ -93,7 +93,7 @@ extension FilterMarketBap: FINNFilterConfiguration {
                 ),
                 hasLowerBoundOffset: false,
                 hasUpperBoundOffset: true,
-                unit: "kr",
+                unit: Unit.currency.rawValue,
                 accessibilityValueSuffix: nil,
                 usesSmallNumberInputFont: false,
                 displaysUnitInNumberInput: true,

--- a/Sources/FINNSetup/FilterMarkets/FilterMarketBap.swift
+++ b/Sources/FINNSetup/FilterMarkets/FilterMarketBap.swift
@@ -76,31 +76,9 @@ extension FilterMarketBap: FINNFilterConfiguration {
 
         switch filterKey {
         case .horseHeight:
-            return RangeFilterConfiguration(
-                minimumValue: 120,
-                maximumValue: 200,
-                valueKind: .incremented(10),
-                hasLowerBoundOffset: true,
-                hasUpperBoundOffset: true,
-                unit: "cm",
-                accessibilityValueSuffix: nil,
-                usesSmallNumberInputFont: false,
-                displaysUnitInNumberInput: true,
-                isCurrencyValueRange: false
-            )
+            return .sizeConfiguration(minimumValue: 120, maximumValue: 200, increment: 10)
         case .lengthCm:
-            return RangeFilterConfiguration(
-                minimumValue: 50,
-                maximumValue: 220,
-                valueKind: .incremented(10),
-                hasLowerBoundOffset: true,
-                hasUpperBoundOffset: true,
-                unit: "cm",
-                accessibilityValueSuffix: nil,
-                usesSmallNumberInputFont: false,
-                displaysUnitInNumberInput: true,
-                isCurrencyValueRange: false
-            )
+            return .sizeConfiguration(minimumValue: 50, maximumValue: 220, increment: 10)
         case .price:
             return RangeFilterConfiguration(
                 minimumValue: 0,

--- a/Sources/FINNSetup/FilterMarkets/FilterMarketBoat.swift
+++ b/Sources/FINNSetup/FilterMarkets/FilterMarketBoat.swift
@@ -153,18 +153,7 @@ extension FilterMarketBoat: FINNFilterConfiguration {
                 increment = 1000
             }
 
-            return RangeFilterConfiguration(
-                minimumValue: 0,
-                maximumValue: maximumValue,
-                valueKind: .incremented(increment),
-                hasLowerBoundOffset: false,
-                hasUpperBoundOffset: true,
-                unit: "kr",
-                accessibilityValueSuffix: nil,
-                usesSmallNumberInputFont: false,
-                displaysUnitInNumberInput: true,
-                isCurrencyValueRange: true
-            )
+            return .currencyConfiguration(minimumValue: 0, maximumValue: maximumValue, increment: increment)
         case .lengthFeet:
             return RangeFilterConfiguration(
                 minimumValue: 0,
@@ -179,70 +168,15 @@ extension FilterMarketBoat: FINNFilterConfiguration {
                 isCurrencyValueRange: false
             )
         case .year:
-            return RangeFilterConfiguration(
-                minimumValue: 1985,
-                maximumValue: Calendar.current.component(.year, from: Date()),
-                valueKind: .incremented(1),
-                hasLowerBoundOffset: true,
-                hasUpperBoundOffset: true,
-                unit: "år",
-                accessibilityValueSuffix: nil,
-                usesSmallNumberInputFont: false,
-                displaysUnitInNumberInput: false,
-                isCurrencyValueRange: false
-            )
+            return .yearConfiguration(minimumValue: 1985)
         case .motorSize:
-            return RangeFilterConfiguration(
-                minimumValue: 0,
-                maximumValue: 500,
-                valueKind: .incremented(10),
-                hasLowerBoundOffset: false,
-                hasUpperBoundOffset: true,
-                unit: "hk",
-                accessibilityValueSuffix: nil,
-                usesSmallNumberInputFont: false,
-                displaysUnitInNumberInput: true,
-                isCurrencyValueRange: false
-            )
+            return .horsePowerConfiguration(minimumValue: 0, maximumValue: 500)
         case .noOfSeats:
-            return RangeFilterConfiguration(
-                minimumValue: 0,
-                maximumValue: 20,
-                valueKind: .incremented(1),
-                hasLowerBoundOffset: false,
-                hasUpperBoundOffset: true,
-                unit: "stk.",
-                accessibilityValueSuffix: nil,
-                usesSmallNumberInputFont: false,
-                displaysUnitInNumberInput: true,
-                isCurrencyValueRange: false
-            )
+            return .numberOfItemsConfiguration(minimumValue: 0, maximumValue: 20)
         case .noOfSleepers:
-            return RangeFilterConfiguration(
-                minimumValue: 0,
-                maximumValue: 10,
-                valueKind: .incremented(1),
-                hasLowerBoundOffset: false,
-                hasUpperBoundOffset: true,
-                unit: "stk.",
-                accessibilityValueSuffix: nil,
-                usesSmallNumberInputFont: false,
-                displaysUnitInNumberInput: true,
-                isCurrencyValueRange: false
-            )
+            return .numberOfItemsConfiguration(minimumValue: 0, maximumValue: 10)
         case .width:
-            return RangeFilterConfiguration(
-                minimumValue: 250,
-                maximumValue: 500,
-                valueKind: .incremented(10),
-                hasLowerBoundOffset: true,
-                hasUpperBoundOffset: true,
-                unit: "cm",
-                accessibilityValueSuffix: nil,
-                usesSmallNumberInputFont: false,
-                displaysUnitInNumberInput: true,
-                isCurrencyValueRange: false
-            )
+            return .sizeConfiguration(minimumValue: 250, maximumValue: 500, increment: 10)
         default:
             return nil
         }

--- a/Sources/FINNSetup/FilterMarkets/FilterMarketBoat.swift
+++ b/Sources/FINNSetup/FilterMarkets/FilterMarketBoat.swift
@@ -153,20 +153,9 @@ extension FilterMarketBoat: FINNFilterConfiguration {
                 increment = 1000
             }
 
-            return .currencyConfiguration(minimumValue: 0, maximumValue: maximumValue, increment: increment)
+            return .configuration(minimumValue: 0, maximumValue: maximumValue, increment: increment, unit: .currency)
         case .lengthFeet:
-            return RangeFilterConfiguration(
-                minimumValue: 0,
-                maximumValue: 60,
-                valueKind: .incremented(1),
-                hasLowerBoundOffset: false,
-                hasUpperBoundOffset: true,
-                unit: "fot",
-                accessibilityValueSuffix: nil,
-                usesSmallNumberInputFont: false,
-                displaysUnitInNumberInput: true,
-                isCurrencyValueRange: false
-            )
+            return .configuration(minimumValue: 0, maximumValue: 60, increment: 1, unit: .feet)
         case .year:
             return .yearConfiguration(minimumValue: 1985)
         case .motorSize:
@@ -176,7 +165,7 @@ extension FilterMarketBoat: FINNFilterConfiguration {
         case .noOfSleepers:
             return .numberOfItemsConfiguration(minimumValue: 0, maximumValue: 10)
         case .width:
-            return .sizeConfiguration(minimumValue: 250, maximumValue: 500, increment: 10)
+            return .configuration(minimumValue: 250, maximumValue: 500, increment: 10, unit: .centimeters)
         default:
             return nil
         }

--- a/Sources/FINNSetup/FilterMarkets/FilterMarketCar.swift
+++ b/Sources/FINNSetup/FilterMarkets/FilterMarketCar.swift
@@ -155,14 +155,14 @@ extension FilterMarketCar: FINNFilterConfiguration {
         case .price:
             switch self {
             case .norway, .abroad, .caravan:
-                return .currencyConfiguration(minimumValue: 0, maximumValue: 700_000, increment: 10000)
+                return .configuration(minimumValue: 0, maximumValue: 700_000, increment: 10000, unit: .currency)
             case .mobileHome:
-                return .currencyConfiguration(minimumValue: 0, maximumValue: 1_000_000, increment: 10000)
+                return .configuration(minimumValue: 0, maximumValue: 1_000_000, increment: 10000, unit: .currency)
             }
         case .leasepriceInit:
-            return .currencyConfiguration(minimumValue: 0, maximumValue: 150_000, increment: 10000)
+            return .configuration(minimumValue: 0, maximumValue: 150_000, increment: 10000, unit: .currency)
         case .leasepriceMonth:
-            return .currencyConfiguration(minimumValue: 0, maximumValue: 10000, increment: 1000)
+            return .configuration(minimumValue: 0, maximumValue: 10000, increment: 1000, unit: .currency)
         case .engineEffect:
             switch self {
             case .norway, .abroad:
@@ -184,20 +184,20 @@ extension FilterMarketCar: FINNFilterConfiguration {
         case .length:
             switch self {
             case .mobileHome:
-                return .sizeConfiguration(minimumValue: 600, maximumValue: 950, increment: 50)
+                return .configuration(minimumValue: 600, maximumValue: 950, increment: 50, unit: .centimeters)
             case .caravan:
-                return .sizeConfiguration(minimumValue: 500, maximumValue: 950, increment: 50)
+                return .configuration(minimumValue: 500, maximumValue: 950, increment: 50, unit: .centimeters)
             default:
                 return nil
             }
         case .width:
-            return .sizeConfiguration(minimumValue: 200, maximumValue: 350, increment: 10)
+            return .configuration(minimumValue: 200, maximumValue: 350, increment: 10, unit: .centimeters)
         case .weight:
             switch self {
             case .mobileHome:
-                return .weightConfiguration(minimumValue: 3500, maximumValue: 7500, increment: 100)
+                return .configuration(minimumValue: 3500, maximumValue: 7500, increment: 100, unit: .kilograms)
             case .caravan:
-                return .weightConfiguration(minimumValue: 1000, maximumValue: 3500, increment: 100)
+                return .configuration(minimumValue: 1000, maximumValue: 3500, increment: 100, unit: .kilograms)
             default:
                 return nil
             }

--- a/Sources/FINNSetup/FilterMarkets/FilterMarketCar.swift
+++ b/Sources/FINNSetup/FilterMarkets/FilterMarketCar.swift
@@ -139,223 +139,68 @@ extension FilterMarketCar: FINNFilterConfiguration {
 
         switch filterKey {
         case .year:
-            let minimumValue: Int
-
             switch self {
             case .norway, .abroad:
-                minimumValue = 1950
+                return .yearConfiguration(minimumValue: 1950)
             case .mobileHome, .caravan:
-                minimumValue = 1990
+                return .yearConfiguration(minimumValue: 1990)
             }
-
-            return RangeFilterConfiguration(
-                minimumValue: minimumValue,
-                maximumValue: Calendar.current.component(.year, from: Date()),
-                valueKind: .incremented(1),
-                hasLowerBoundOffset: true,
-                hasUpperBoundOffset: true,
-                unit: "år",
-                accessibilityValueSuffix: nil,
-                usesSmallNumberInputFont: false,
-                displaysUnitInNumberInput: false,
-                isCurrencyValueRange: false
-            )
         case .mileage:
-            let maximumValue: Int
-
             switch self {
             case .caravan:
-                maximumValue = 20000
+                return .mileageConfiguration(maximumValue: 20000)
             default:
-                maximumValue = 200_000
+                return .mileageConfiguration(maximumValue: 200_000)
             }
-
-            return RangeFilterConfiguration(
-                minimumValue: 0,
-                maximumValue: maximumValue,
-                valueKind: .incremented(1000),
-                hasLowerBoundOffset: false,
-                hasUpperBoundOffset: true,
-                unit: "km",
-                accessibilityValueSuffix: nil,
-                usesSmallNumberInputFont: false,
-                displaysUnitInNumberInput: true,
-                isCurrencyValueRange: false
-            )
         case .price:
-            let maximumValue: Int
-
             switch self {
             case .norway, .abroad, .caravan:
-                maximumValue = 700_000
+                return .currencyConfiguration(minimumValue: 0, maximumValue: 700_000, increment: 10000)
             case .mobileHome:
-                maximumValue = 1_000_000
+                return .currencyConfiguration(minimumValue: 0, maximumValue: 1_000_000, increment: 10000)
             }
-
-            return RangeFilterConfiguration(
-                minimumValue: 0,
-                maximumValue: maximumValue,
-                valueKind: .incremented(10000),
-                hasLowerBoundOffset: false,
-                hasUpperBoundOffset: true,
-                unit: "kr",
-                accessibilityValueSuffix: nil,
-                usesSmallNumberInputFont: true,
-                displaysUnitInNumberInput: true,
-                isCurrencyValueRange: true
-            )
         case .leasepriceInit:
-            return RangeFilterConfiguration(
-                minimumValue: 0,
-                maximumValue: 150_000,
-                valueKind: .incremented(10000),
-                hasLowerBoundOffset: false,
-                hasUpperBoundOffset: true,
-                unit: "kr",
-                accessibilityValueSuffix: nil,
-                usesSmallNumberInputFont: false,
-                displaysUnitInNumberInput: true,
-                isCurrencyValueRange: true
-            )
+            return .currencyConfiguration(minimumValue: 0, maximumValue: 150_000, increment: 10000)
         case .leasepriceMonth:
-            return RangeFilterConfiguration(
-                minimumValue: 0,
-                maximumValue: 10000,
-                valueKind: .incremented(1000),
-                hasLowerBoundOffset: false,
-                hasUpperBoundOffset: true,
-                unit: "kr",
-                accessibilityValueSuffix: nil,
-                usesSmallNumberInputFont: false,
-                displaysUnitInNumberInput: true,
-                isCurrencyValueRange: true
-            )
+            return .currencyConfiguration(minimumValue: 0, maximumValue: 10000, increment: 1000)
         case .engineEffect:
-            let minimumValue: Int
-            let maximumValue: Int
-
             switch self {
             case .norway, .abroad:
-                minimumValue = 0
-                maximumValue = 500
+                return .horsePowerConfiguration(minimumValue: 0, maximumValue: 500)
             default:
-                minimumValue = 0
-                maximumValue = 300
+                return .horsePowerConfiguration(minimumValue: 0, maximumValue: 300)
             }
-
-            return RangeFilterConfiguration(
-                minimumValue: minimumValue,
-                maximumValue: maximumValue,
-                valueKind: .incremented(10),
-                hasLowerBoundOffset: false,
-                hasUpperBoundOffset: true,
-                unit: "hk",
-                accessibilityValueSuffix: nil,
-                usesSmallNumberInputFont: false,
-                displaysUnitInNumberInput: true,
-                isCurrencyValueRange: false
-            )
         case .numberOfSeats:
-            let maximumValue: Int
-
             switch self {
             case .norway, .abroad:
-                maximumValue = 10
+                return .numberOfSeatsConfiguration(maximumValue: 10)
             case .mobileHome:
-                maximumValue = 8
+                return .numberOfSeatsConfiguration(maximumValue: 8)
             default:
                 return nil
             }
-
-            return RangeFilterConfiguration(
-                minimumValue: 0,
-                maximumValue: maximumValue,
-                valueKind: .incremented(1),
-                hasLowerBoundOffset: false,
-                hasUpperBoundOffset: true,
-                unit: "seter",
-                accessibilityValueSuffix: nil,
-                usesSmallNumberInputFont: false,
-                displaysUnitInNumberInput: true,
-                isCurrencyValueRange: false
-            )
         case .noOfSleepers:
-            return RangeFilterConfiguration(
-                minimumValue: 0,
-                maximumValue: 8,
-                valueKind: .incremented(1),
-                hasLowerBoundOffset: false,
-                hasUpperBoundOffset: true,
-                unit: "stk.",
-                accessibilityValueSuffix: nil,
-                usesSmallNumberInputFont: false,
-                displaysUnitInNumberInput: true,
-                isCurrencyValueRange: false
-            )
+            return .numberOfItemsConfiguration(minimumValue: 0, maximumValue: 8)
         case .length:
-            let minimumValue: Int
-
             switch self {
             case .mobileHome:
-                minimumValue = 600
+                return .sizeConfiguration(minimumValue: 600, maximumValue: 950, increment: 50)
             case .caravan:
-                minimumValue = 500
+                return .sizeConfiguration(minimumValue: 500, maximumValue: 950, increment: 50)
             default:
                 return nil
             }
-
-            return RangeFilterConfiguration(
-                minimumValue: minimumValue,
-                maximumValue: 950,
-                valueKind: .incremented(50),
-                hasLowerBoundOffset: true,
-                hasUpperBoundOffset: true,
-                unit: "cm",
-                accessibilityValueSuffix: nil,
-                usesSmallNumberInputFont: false,
-                displaysUnitInNumberInput: true,
-                isCurrencyValueRange: false
-            )
         case .width:
-            return RangeFilterConfiguration(
-                minimumValue: 200,
-                maximumValue: 350,
-                valueKind: .incremented(10),
-                hasLowerBoundOffset: true,
-                hasUpperBoundOffset: true,
-                unit: "cm",
-                accessibilityValueSuffix: nil,
-                usesSmallNumberInputFont: false,
-                displaysUnitInNumberInput: true,
-                isCurrencyValueRange: false
-            )
+            return .sizeConfiguration(minimumValue: 200, maximumValue: 350, increment: 10)
         case .weight:
-            let minimumValue: Int
-            let maximumValue: Int
-
             switch self {
             case .mobileHome:
-                minimumValue = 3500
-                maximumValue = 7500
+                return .weightConfiguration(minimumValue: 3500, maximumValue: 7500, increment: 100)
             case .caravan:
-                minimumValue = 1000
-                maximumValue = 3500
+                return .weightConfiguration(minimumValue: 1000, maximumValue: 3500, increment: 100)
             default:
                 return nil
             }
-
-            return RangeFilterConfiguration(
-                minimumValue: minimumValue,
-                maximumValue: maximumValue,
-                valueKind: .incremented(100),
-                hasLowerBoundOffset: true,
-                hasUpperBoundOffset: true,
-                unit: "kg",
-                accessibilityValueSuffix: nil,
-                usesSmallNumberInputFont: false,
-                displaysUnitInNumberInput: true,
-                isCurrencyValueRange: false
-            )
         default:
             return nil
         }

--- a/Sources/FINNSetup/FilterMarkets/FilterMarketMC.swift
+++ b/Sources/FINNSetup/FilterMarkets/FilterMarketMC.swift
@@ -94,9 +94,9 @@ extension FilterMarketMC: FINNFilterConfiguration {
         case .mileage:
             return .mileageConfiguration(maximumValue: 200_000)
         case .price:
-            return .currencyConfiguration(minimumValue: 0, maximumValue: 250_000, increment: 1000)
+            return .configuration(minimumValue: 0, maximumValue: 250_000, increment: 1000, unit: .currency)
         case .engineVolume:
-            return .sizeConfiguration(minimumValue: 50, maximumValue: 1000, increment: 25, unit: "ccm")
+            return .configuration(minimumValue: 50, maximumValue: 1000, increment: 25, unit: .cubicCentimeters)
         default:
             return nil
         }

--- a/Sources/FINNSetup/FilterMarkets/FilterMarketMC.swift
+++ b/Sources/FINNSetup/FilterMarkets/FilterMarketMC.swift
@@ -88,70 +88,15 @@ extension FilterMarketMC: FINNFilterConfiguration {
 
         switch filterKey {
         case .year:
-            return RangeFilterConfiguration(
-                minimumValue: 1950,
-                maximumValue: Calendar.current.component(.year, from: Date()),
-                valueKind: .incremented(1),
-                hasLowerBoundOffset: true,
-                hasUpperBoundOffset: true,
-                unit: "år",
-                accessibilityValueSuffix: nil,
-                usesSmallNumberInputFont: false,
-                displaysUnitInNumberInput: false,
-                isCurrencyValueRange: false
-            )
+            return .yearConfiguration(minimumValue: 1950)
         case .engineEffect:
-            return RangeFilterConfiguration(
-                minimumValue: 0,
-                maximumValue: 200,
-                valueKind: .incremented(10),
-                hasLowerBoundOffset: false,
-                hasUpperBoundOffset: true,
-                unit: "hk",
-                accessibilityValueSuffix: nil,
-                usesSmallNumberInputFont: false,
-                displaysUnitInNumberInput: true,
-                isCurrencyValueRange: false
-            )
+            return .horsePowerConfiguration(minimumValue: 0, maximumValue: 200)
         case .mileage:
-            return RangeFilterConfiguration(
-                minimumValue: 0,
-                maximumValue: 200_000,
-                valueKind: .incremented(1000),
-                hasLowerBoundOffset: false,
-                hasUpperBoundOffset: true,
-                unit: "km",
-                accessibilityValueSuffix: nil,
-                usesSmallNumberInputFont: false,
-                displaysUnitInNumberInput: true,
-                isCurrencyValueRange: false
-            )
+            return .mileageConfiguration(maximumValue: 200_000)
         case .price:
-            return RangeFilterConfiguration(
-                minimumValue: 0,
-                maximumValue: 250_000,
-                valueKind: .incremented(1000),
-                hasLowerBoundOffset: false,
-                hasUpperBoundOffset: true,
-                unit: "kr",
-                accessibilityValueSuffix: nil,
-                usesSmallNumberInputFont: false,
-                displaysUnitInNumberInput: true,
-                isCurrencyValueRange: true
-            )
+            return .currencyConfiguration(minimumValue: 0, maximumValue: 250_000, increment: 1000)
         case .engineVolume:
-            return RangeFilterConfiguration(
-                minimumValue: 50,
-                maximumValue: 1000,
-                valueKind: .incremented(25),
-                hasLowerBoundOffset: false,
-                hasUpperBoundOffset: true,
-                unit: "ccm",
-                accessibilityValueSuffix: nil,
-                usesSmallNumberInputFont: false,
-                displaysUnitInNumberInput: true,
-                isCurrencyValueRange: false
-            )
+            return .sizeConfiguration(minimumValue: 50, maximumValue: 1000, increment: 25, unit: "ccm")
         default:
             return nil
         }

--- a/Sources/FINNSetup/FilterMarkets/FilterMarketRealestate.swift
+++ b/Sources/FINNSetup/FilterMarkets/FilterMarketRealestate.swift
@@ -229,31 +229,9 @@ extension FilterMarketRealestate: FINNFilterConfiguration {
                 increment = 50000
             }
 
-            return RangeFilterConfiguration(
-                minimumValue: minimumValue,
-                maximumValue: maximumValue,
-                valueKind: .incremented(increment),
-                hasLowerBoundOffset: true,
-                hasUpperBoundOffset: true,
-                unit: "kr",
-                accessibilityValueSuffix: nil,
-                usesSmallNumberInputFont: true,
-                displaysUnitInNumberInput: true,
-                isCurrencyValueRange: true
-            )
+            return .currencyConfiguration(minimumValue: minimumValue, maximumValue: maximumValue, increment: increment)
         case .rent:
-            return RangeFilterConfiguration(
-                minimumValue: 500,
-                maximumValue: 20000,
-                valueKind: .incremented(500),
-                hasLowerBoundOffset: true,
-                hasUpperBoundOffset: true,
-                unit: "kr",
-                accessibilityValueSuffix: nil,
-                usesSmallNumberInputFont: false,
-                displaysUnitInNumberInput: true,
-                isCurrencyValueRange: true
-            )
+            return .currencyConfiguration(minimumValue: 500, maximumValue: 20000, increment: 500)
         case .area:
             let minimumValue: Int
             let maximumValue: Int
@@ -270,44 +248,11 @@ extension FilterMarketRealestate: FINNFilterConfiguration {
                 maximumValue = 400
             }
 
-            return RangeFilterConfiguration(
-                minimumValue: minimumValue,
-                maximumValue: maximumValue,
-                valueKind: .incremented(5),
-                hasLowerBoundOffset: true,
-                hasUpperBoundOffset: true,
-                unit: "m\u{00B2}",
-                accessibilityValueSuffix: nil,
-                usesSmallNumberInputFont: true,
-                displaysUnitInNumberInput: true,
-                isCurrencyValueRange: false
-            )
+            return .areaConfiguration(minimumValue: minimumValue, maximumValue: maximumValue, increment: 5)
         case .plotArea:
-            return RangeFilterConfiguration(
-                minimumValue: 300,
-                maximumValue: 6000,
-                valueKind: .incremented(50),
-                hasLowerBoundOffset: true,
-                hasUpperBoundOffset: true,
-                unit: "m\u{00B2}",
-                accessibilityValueSuffix: nil,
-                usesSmallNumberInputFont: false,
-                displaysUnitInNumberInput: true,
-                isCurrencyValueRange: false
-            )
+            return .areaConfiguration(minimumValue: 300, maximumValue: 6000, increment: 50)
         case .constructionYear:
-            return RangeFilterConfiguration(
-                minimumValue: 1900,
-                maximumValue: Calendar.current.component(.year, from: Date()),
-                valueKind: .incremented(1),
-                hasLowerBoundOffset: true,
-                hasUpperBoundOffset: true,
-                unit: "år",
-                accessibilityValueSuffix: nil,
-                usesSmallNumberInputFont: false,
-                displaysUnitInNumberInput: false,
-                isCurrencyValueRange: false
-            )
+            return .yearConfiguration(minimumValue: 1900)
         default:
             return nil
         }

--- a/Sources/FINNSetup/FilterMarkets/FilterMarketRealestate.swift
+++ b/Sources/FINNSetup/FilterMarkets/FilterMarketRealestate.swift
@@ -229,9 +229,14 @@ extension FilterMarketRealestate: FINNFilterConfiguration {
                 increment = 50000
             }
 
-            return .currencyConfiguration(minimumValue: minimumValue, maximumValue: maximumValue, increment: increment)
+            return .configuration(
+                minimumValue: minimumValue,
+                maximumValue: maximumValue,
+                increment: increment,
+                unit: .currency
+            )
         case .rent:
-            return .currencyConfiguration(minimumValue: 500, maximumValue: 20000, increment: 500)
+            return .configuration(minimumValue: 500, maximumValue: 20000, increment: 500, unit: .currency)
         case .area:
             let minimumValue: Int
             let maximumValue: Int
@@ -248,9 +253,9 @@ extension FilterMarketRealestate: FINNFilterConfiguration {
                 maximumValue = 400
             }
 
-            return .areaConfiguration(minimumValue: minimumValue, maximumValue: maximumValue, increment: 5)
+            return .configuration(minimumValue: minimumValue, maximumValue: maximumValue, increment: 5, unit: .squareMeters)
         case .plotArea:
-            return .areaConfiguration(minimumValue: 300, maximumValue: 6000, increment: 50)
+            return .configuration(minimumValue: 300, maximumValue: 6000, increment: 50, unit: .squareMeters)
         case .constructionYear:
             return .yearConfiguration(minimumValue: 1900)
         default:

--- a/Sources/FINNSetup/Unit.swift
+++ b/Sources/FINNSetup/Unit.swift
@@ -1,0 +1,19 @@
+//
+//  Copyright © FINN.no AS, Inc. All rights reserved.
+//
+
+import Foundation
+
+enum Unit: String {
+    case centimeters = "cm"
+    case cubicCentimeters = "ccm"
+    case currency = "kr"
+    case feet = "fot"
+    case horsePower = "hk"
+    case items = "stk."
+    case kilograms = "kg"
+    case kilometers = "km"
+    case seats = "seter"
+    case squareMeters = "m\u{00B2}"
+    case year = "år"
+}


### PR DESCRIPTION
# Why?

To remove code duplication and make it easier to make changes to similar range filters.

# What?

- Make an extension of `RangeFilterConfiguration` with factory methods to create different kinds of configuration using new `Unit` enum
- Refactor market setup using new configuration helpers

# Show me

No UI changes.