### PR TITLE
Fix inline filter bugs

### DIFF
--- a/Sources/Charcoal/Filters/Inline/InlineFilterView.swift
+++ b/Sources/Charcoal/Filters/Inline/InlineFilterView.swift
@@ -27,7 +27,6 @@ final class InlineFilterView: UIView {
     private lazy var collectionView: UICollectionView = {
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .horizontal
-        layout.estimatedItemSize = CGSize(width: 300, height: InlineSegmentCell.cellHeight)
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
         collectionView.backgroundColor = .milk
         collectionView.showsHorizontalScrollIndicator = false
@@ -51,6 +50,7 @@ final class InlineFilterView: UIView {
     // MARK: - Public
 
     func configure(withTitles titles: [[String]], verticalTitle: String? = nil, selectedItems: [[Int]]) {
+        vertical = nil
         segments = []
 
         if let verticalTitle = verticalTitle {
@@ -104,6 +104,21 @@ extension InlineFilterView: UICollectionViewDataSource {
 }
 
 extension InlineFilterView: UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        guard let section = Section(rawValue: indexPath.section) else { return .zero }
+
+        let segmentSize: CGSize
+
+        switch section {
+        case .vertical:
+            segmentSize = vertical?.intrinsicContentSize ?? .zero
+        case .filters:
+            segmentSize = segments[indexPath.item].intrinsicContentSize
+        }
+
+        return CGSize(width: segmentSize.width, height: InlineSegmentCell.cellHeight)
+    }
+
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
         guard let section = Section(rawValue: section) else { return .zero }
 

--- a/Sources/Charcoal/Filters/Inline/InlineFilterView.swift
+++ b/Sources/Charcoal/Filters/Inline/InlineFilterView.swift
@@ -73,11 +73,11 @@ final class InlineFilterView: UIView {
 // MARK: - Collection view data source
 
 extension InlineFilterView: UICollectionViewDataSource {
-    public func numberOfSections(in collectionView: UICollectionView) -> Int {
+    func numberOfSections(in collectionView: UICollectionView) -> Int {
         return Section.allCases.count
     }
 
-    public func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         guard let section = Section(rawValue: section) else { return 0 }
 
         switch section {
@@ -88,7 +88,7 @@ extension InlineFilterView: UICollectionViewDataSource {
         }
     }
 
-    public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         guard let section = Section(rawValue: indexPath.section) else { fatalError("InlineFilter not configured correctly") }
         let cell = collectionView.dequeue(InlineSegmentCell.self, for: indexPath)
 

--- a/Sources/Charcoal/Filters/Inline/InlineSegmentCell.swift
+++ b/Sources/Charcoal/Filters/Inline/InlineSegmentCell.swift
@@ -31,7 +31,6 @@ private extension InlineSegmentCell {
             view.topAnchor.constraint(equalTo: contentView.topAnchor),
             view.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
             view.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
-            contentView.heightAnchor.constraint(equalToConstant: InlineSegmentCell.cellHeight),
         ])
     }
 }

--- a/Sources/Charcoal/Filters/Inline/Segment.swift
+++ b/Sources/Charcoal/Filters/Inline/Segment.swift
@@ -32,8 +32,23 @@ class Segment: UIControl {
         setup(isExpandable: isExpandable)
     }
 
-    public required init?(coder aDecoder: NSCoder) {
+    required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Overrides
+
+    override var intrinsicContentSize: CGSize {
+        return buttons.reduce(.zero) { (result, button) -> CGSize in
+            var height = result.height
+
+            if button.intrinsicContentSize.height > height {
+                height = button.intrinsicContentSize.height
+            }
+
+            return CGSize(width: result.width + button.intrinsicContentSize.width,
+                          height: height)
+        }
     }
 }
 

--- a/Sources/Charcoal/Filters/Inline/SegmentButton.swift
+++ b/Sources/Charcoal/Filters/Inline/SegmentButton.swift
@@ -12,7 +12,7 @@ extension SegmentButton {
 
 class SegmentButton: UIButton {
     static let borderColor: UIColor = .silver
-    static let borderWidth = 1.5 as CGFloat
+    static let borderWidth: CGFloat = 1.5
 
     var borderStyle: BorderStyle = .middle
 

--- a/Sources/Charcoal/Filters/Inline/SegmentButton.swift
+++ b/Sources/Charcoal/Filters/Inline/SegmentButton.swift
@@ -10,19 +10,19 @@ extension SegmentButton {
     }
 }
 
-public class SegmentButton: UIButton {
-    public static let borderColor: UIColor = .silver
-    public static let borderWidth = 1.5 as CGFloat
+class SegmentButton: UIButton {
+    static let borderColor: UIColor = .silver
+    static let borderWidth = 1.5 as CGFloat
 
-    public var borderStyle: BorderStyle = .middle
+    var borderStyle: BorderStyle = .middle
 
-    public var isExpandable = false {
+    var isExpandable = false {
         didSet {
             setupExpandable()
         }
     }
 
-    public override var isSelected: Bool {
+    override var isSelected: Bool {
         didSet {
             updateSelected(isSelected)
         }
@@ -32,16 +32,16 @@ public class SegmentButton: UIButton {
     private var maskLayer = CAShapeLayer()
     private var selectedBackgroundColor: UIColor = .primaryBlue
 
-    public init(title: String) {
+    init(title: String) {
         super.init(frame: .zero)
         setup(with: title)
     }
 
-    public required init?(coder aDecoder: NSCoder) {
+    required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
-    public override func layoutSubviews() {
+    override func layoutSubviews() {
         super.layoutSubviews()
         drawBorder()
     }

--- a/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
+++ b/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
@@ -149,7 +149,7 @@ extension RootFilterViewController: UITableViewDataSource {
             let cell = tableView.dequeue(InlineFilterCell.self, for: indexPath)
             cell.delegate = self
 
-            cell.configure(withTitles: segmentTitles, vertical: vertical?.title, selectedItems: selectedItems)
+            cell.configure(withTitles: segmentTitles, verticalTitle: vertical?.title, selectedItems: selectedItems)
             return cell
         default:
             let titles = selectionStore.titles(for: currentFilter)

--- a/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
+++ b/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
@@ -142,7 +142,7 @@ extension RootFilterViewController: UITableViewDataSource {
 
             let selectedItems = currentFilter.subfilters.map({
                 $0.subfilters.enumerated().compactMap({ index, filter in
-                    self.selectionStore.isSelected(filter) == true ? index : nil
+                    self.selectionStore.isSelected(filter) ? index : nil
                 })
             })
 

--- a/Sources/Charcoal/Filters/Root/Views/InlineFilterCell.swift
+++ b/Sources/Charcoal/Filters/Root/Views/InlineFilterCell.swift
@@ -32,8 +32,8 @@ final class InlineFilterCell: UITableViewCell {
 
     // MARK: - Setup
 
-    func configure(withTitles titles: [[String]], vertical: String? = nil, selectedItems: [[Int]]) {
-        inlineFilterView.configure(withTitles: titles, vertical: vertical, selectedItems: selectedItems)
+    func configure(withTitles titles: [[String]], verticalTitle: String? = nil, selectedItems: [[Int]]) {
+        inlineFilterView.configure(withTitles: titles, verticalTitle: verticalTitle, selectedItems: selectedItems)
     }
 
     private func setup() {


### PR DESCRIPTION
# Why?

- Selecting filters was wrong when there were both vertical and filter segments. The index was wrong.
- Auto sizing cells caused inline filter to shift when reloading data. 

# What?

- Added `Section` enum to `InlineFilterView` to separate vertical and filter segments. Adjusted `UICollectionViewDelegateFlowLayout` to make the UI correct.
- Removed `estimatedItemSize` and replaced with `sizeForItem` delegation call to set item size.
- Made `SegmentButton` an internal class

# Show me

No UI changes
