### PR TITLE
Stepper filter remember selection

### DIFF
--- a/Sources/Charcoal/Filters/Stepper/StepperViewController.swift
+++ b/Sources/Charcoal/Filters/Stepper/StepperViewController.swift
@@ -38,6 +38,11 @@ final class StepperFilterViewController: FilterViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         bottomButton.buttonTitle = "apply_button_title".localized()
+
+        if let value: Int = selectionStore.value(for: filter) {
+            stepperFilterView.value = value
+        }
+
         view.addSubview(stepperFilterView)
         NSLayoutConstraint.activate([
             topConstraint,


### PR DESCRIPTION
# Why?

If we set a value for the stepper filter it doesn't remember that value the next time we open the filter.

# What?

- Sets the value for the stepper filter in `viewDidLoad`

# Show me

No UI
