### PR TITLE
Parse object count in filter setup

### DIFF
--- a/Demo/Resources/realestate/realestate-homes.json
+++ b/Demo/Resources/realestate/realestate-homes.json
@@ -1,6 +1,7 @@
 {
     "market": "realestate-homes",
     "hits": 23636,
+    "objectCount": 35231,
     "label": "Bolig til salgs",
     "type": "search",
     "filters": [

--- a/Sources/FINNSetup/BackendModel/FilterSetup.swift
+++ b/Sources/FINNSetup/BackendModel/FilterSetup.swift
@@ -6,18 +6,28 @@ import Foundation
 
 public struct FilterSetup: Decodable {
     public let market: String
-    public let hits: Int
     public let filterTitle: String
+    public let hits: Int
+    public let objectCount: Int?
+
     let rawFilterKeys: [String]
     let filters: [FilterData]
 
     enum CodingKeys: String, CodingKey, CaseIterable {
-        case market, hits, filterTitle = "label", rawFilterKeys = "filters", filterData = "filter-data"
+        case market
+        case hits
+        case objectCount
+        case filterTitle = "label"
+        case rawFilterKeys = "filters"
+        case filterData = "filter-data"
     }
 
-    private init(market: String, hits: Int, filterTitle: String, rawFilterKeys: [String], filters: [FilterData]) {
+    // MARK: - Init
+
+    private init(market: String, hits: Int, objectCount: Int?, filterTitle: String, rawFilterKeys: [String], filters: [FilterData]) {
         self.market = market
         self.hits = hits
+        self.objectCount = objectCount
         self.filterTitle = filterTitle
         self.rawFilterKeys = rawFilterKeys
         self.filters = filters
@@ -32,12 +42,13 @@ public struct FilterSetup: Decodable {
 
         market = try container.decode(String.self, forKey: .market)
         hits = try container.decode(Int.self, forKey: .hits)
+        objectCount = try container.decodeIfPresent(Int.self, forKey: .objectCount)
         filterTitle = try container.decode(String.self, forKey: .filterTitle)
         rawFilterKeys = try container.decode([String].self, forKey: .rawFilterKeys)
 
         let filterDataContainer = try container.nestedContainer(keyedBy: FilterKey.self, forKey: .filterData)
-
         let elementKeys = rawFilterKeys.compactMap({ FilterKey(stringValue: $0) })
+
         filters = try elementKeys.compactMap { elementKey -> FilterData? in
             guard let filterData = try filterDataContainer.decodeIfPresent(FilterData.self, forKey: elementKey) else {
                 return nil
@@ -56,7 +67,9 @@ public struct FilterSetup: Decodable {
             return filter
         }
 
-        let root = Filter.list(title: filterTitle, key: market, numberOfResults: hits, subfilters: rootLevelFilters)
+        let numberOfResults = objectCount ?? hits
+        let root = Filter.list(title: filterTitle, key: market, numberOfResults: numberOfResults, subfilters: rootLevelFilters)
+
         return FilterContainer(root: root)
     }
 
@@ -153,21 +166,27 @@ public struct FilterSetup: Decodable {
         guard let dict = dict else {
             return nil
         }
+
         guard let market = dict[CodingKeys.market.rawValue] as? String else {
             return nil
         }
+
         guard let hits = dict[CodingKeys.hits.rawValue] as? Int else {
             return nil
         }
+
         guard let filterTitle = dict[CodingKeys.filterTitle.rawValue] as? String else {
             return nil
         }
+
         guard let rawFilterKeys = dict[CodingKeys.rawFilterKeys.rawValue] as? [String] else {
             return nil
         }
+
         guard let filterDataDict = dict[CodingKeys.filterData.rawValue] as? [AnyHashable: Any] else {
             return nil
         }
+
         let elementKeys = rawFilterKeys.compactMap({ FilterKey(stringValue: $0) })
         let filters = elementKeys.compactMap { elementKey -> FilterData? in
             guard let filterData = FilterData.decode(from: filterDataDict[elementKey.stringValue] as? [AnyHashable: Any]) else {
@@ -179,7 +198,16 @@ public struct FilterSetup: Decodable {
             return filterData
         }
 
-        return FilterSetup(market: market, hits: hits, filterTitle: filterTitle, rawFilterKeys: rawFilterKeys, filters: filters)
+        let objectCount = dict[CodingKeys.objectCount.rawValue] as? Int
+
+        return FilterSetup(
+            market: market,
+            hits: hits,
+            objectCount: objectCount,
+            filterTitle: filterTitle,
+            rawFilterKeys: rawFilterKeys,
+            filters: filters
+        )
     }
 
     func filterData(forKey key: String) -> FilterData? {


### PR DESCRIPTION
# Why?

To support a new field added on the backend.

# What?

Parse `objectCount` in filter setup. This is the number of objects matching, not the number of hits in the result list.

# Show me

No UI changes.