### PR TITLE
Fix filter freeze when free text editing

### DIFF
--- a/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
+++ b/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
@@ -269,10 +269,12 @@ extension RootFilterViewController: FreeTextFilterViewControllerDelegate {
     }
 
     func freeTextFilterViewControllerWillBeginEditing(_ viewController: FreeTextFilterViewController) {
+        resetButton.isEnabled = false
         add(viewController)
     }
 
     func freeTextFilterViewControllerWillEndEditing(_ viewController: FreeTextFilterViewController) {
+        resetButton.isEnabled = true
         viewController.remove()
         tableView.reloadData()
     }


### PR DESCRIPTION
# Why?

Filter freezes if the user taps the reset button during free text editing.

# What?

- Disables the reset button during free text editing.

# Show me

No UI.
