### PR TITLE
Clear search field when changing vertical

### DIFF
--- a/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
+++ b/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
@@ -256,6 +256,7 @@ extension RootFilterViewController: InlineFilterViewDelegate {
 
 extension RootFilterViewController: VerticalListViewControllerDelegate {
     func verticalListViewController(_ verticalViewController: VerticalListViewController, didSelectVerticalAtIndex index: Int) {
+        freeTextFilterViewController?.searchBar.text = nil
         verticalViewController.dismiss(animated: false)
         rootDelegate?.rootFilterViewController(self, didSelectVerticalAt: index)
     }


### PR DESCRIPTION
# Why?

The previous search bar text is still visible after changing vertical

# What?

Set search bar text to nil in vertical delegate method.
