### PR TITLE
Map filter:  change the logic for finding user location

### DIFF
--- a/Sources/Charcoal/Filters/Map/MapFilterViewController.swift
+++ b/Sources/Charcoal/Filters/Map/MapFilterViewController.swift
@@ -201,7 +201,7 @@ extension MapFilterViewController: MKMapViewDelegate {
         let zoomLevel = mapView.calcZoomLevel()
 
         mapFilterView.updateRadiusView()
-        mapFilterView.isUserLocatonButtonHighlighted = coordinate == mapView.userLocation.coordinate
+        mapFilterView.isUserLocationButtonHighlighted = coordinate == mapView.userLocation.coordinate
 
         if nextRegionChangeIsFromUserInteraction {
             hasChanges = true

--- a/Sources/Charcoal/Filters/Map/MapView/MapFilterView.swift
+++ b/Sources/Charcoal/Filters/Map/MapView/MapFilterView.swift
@@ -41,9 +41,9 @@ final class MapFilterView: UIView {
         return mapView.centerCoordinate
     }
 
-    var isUserLocatonButtonHighlighted = false {
+    var isUserLocationButtonHighlighted = false {
         didSet {
-            userLocationButton.isHighlighted = isUserLocatonButtonHighlighted
+            userLocationButton.isHighlighted = isUserLocationButtonHighlighted
         }
     }
 

--- a/Sources/Charcoal/Filters/Map/MapView/MapFilterView.swift
+++ b/Sources/Charcoal/Filters/Map/MapView/MapFilterView.swift
@@ -41,16 +41,14 @@ final class MapFilterView: UIView {
         return mapView.centerCoordinate
     }
 
-    var isUserLocatonButtonEnabled = false {
+    var isUserLocatonButtonHighlighted = false {
         didSet {
-            userLocationButton.isHidden = !isUserLocatonButtonEnabled
-            mapView.showsUserLocation = isUserLocatonButtonEnabled
+            userLocationButton.isHighlighted = isUserLocatonButtonHighlighted
         }
     }
 
     private(set) var radius: Int
     private let initialCenterCoordinate: CLLocationCoordinate2D?
-    private let pulseAnimationKey = "LocateUserPulseAnimation"
 
     private var updateViewDispatchWorkItem: DispatchWorkItem? {
         didSet {
@@ -69,6 +67,7 @@ final class MapFilterView: UIView {
 
     private lazy var mapView: MKMapView = {
         let view = MKMapView(frame: .zero)
+        view.showsUserLocation = true
         view.isRotateEnabled = false
         view.isPitchEnabled = false
         view.isZoomEnabled = false
@@ -77,12 +76,19 @@ final class MapFilterView: UIView {
 
     private lazy var userLocationButton: UIButton = {
         let button = UIButton(withAutoLayout: true)
-        button.backgroundColor = UIColor(white: 1, alpha: 0.8)
+        button.backgroundColor = .milk
         button.tintColor = .primaryBlue
+
         button.layer.cornerRadius = MapFilterView.userLocationButtonWidth / 2
+        button.layer.shadowColor = UIColor.black.cgColor
+        button.layer.shadowOffset = CGSize(width: 0, height: 1)
+        button.layer.shadowRadius = 3
+        button.layer.shadowOpacity = 0.5
+
         button.setImage(UIImage(named: .locateUserOutlined), for: .normal)
         button.setImage(UIImage(named: .locateUserFilled), for: .highlighted)
         button.addTarget(self, action: #selector(didTapLocateUserButton), for: .touchUpInside)
+
         return button
     }()
 
@@ -153,25 +159,6 @@ final class MapFilterView: UIView {
         if let location = mapView.userLocation.location {
             centerOnCoordinate(location.coordinate, animated: true)
         }
-    }
-
-    func startAnimatingLocationButton() {
-        stopAnimatingLocationButton()
-
-        let pulseAnimation = CABasicAnimation(keyPath: "opacity")
-        pulseAnimation.fromValue = 0.6
-        pulseAnimation.toValue = 1.0
-        pulseAnimation.repeatCount = Float.greatestFiniteMagnitude
-        pulseAnimation.autoreverses = true
-        pulseAnimation.duration = 0.8
-
-        userLocationButton.isHighlighted = true
-        userLocationButton.layer.add(pulseAnimation, forKey: pulseAnimationKey)
-    }
-
-    func stopAnimatingLocationButton() {
-        userLocationButton.isHighlighted = false
-        userLocationButton.layer.removeAnimation(forKey: pulseAnimationKey)
     }
 
     func updateRadiusView() {

--- a/Sources/Charcoal/Filters/Map/MapView/MapFilterView.swift
+++ b/Sources/Charcoal/Filters/Map/MapView/MapFilterView.swift
@@ -156,6 +156,8 @@ final class MapFilterView: UIView {
     }
 
     func startAnimatingLocationButton() {
+        stopAnimatingLocationButton()
+
         let pulseAnimation = CABasicAnimation(keyPath: "opacity")
         pulseAnimation.fromValue = 0.6
         pulseAnimation.toValue = 1.0

--- a/Sources/Charcoal/Selection/FilterSelectionStore.swift
+++ b/Sources/Charcoal/Selection/FilterSelectionStore.swift
@@ -137,9 +137,12 @@ extension FilterSelectionStore {
             }
         case .stepper:
             return value(for: filter).map({ [$0] }) ?? []
-        case let .map(_, _, _, locationNameFilter):
-            if let locationName: String = value(for: locationNameFilter) {
-                return [locationName]
+        case let .map(_, _, radiusFilter, locationNameFilter):
+            let locationName: String? = value(for: locationNameFilter)
+            let radius: Int? = value(for: radiusFilter)
+
+            if let title = locationName ?? radius.map({ MapDistanceValueFormatter().title(for: $0) }) {
+                return [title]
             } else {
                 fallthrough
             }

--- a/Sources/Charcoal/Selection/FilterSelectionStore.swift
+++ b/Sources/Charcoal/Selection/FilterSelectionStore.swift
@@ -137,10 +137,9 @@ extension FilterSelectionStore {
             }
         case .stepper:
             return value(for: filter).map({ [$0] }) ?? []
-        case let .map(_, _, radiusFilter, _):
-            if let radius: Int = value(for: radiusFilter) {
-                let formatter = MapDistanceValueFormatter()
-                return [formatter.title(for: radius)]
+        case let .map(_, _, _, locationNameFilter):
+            if let locationName: String = value(for: locationNameFilter) {
+                return [locationName]
             } else {
                 fallthrough
             }


### PR DESCRIPTION
# Why?

Because there were a few bugs in the map filter.

# What?

- Change the logic for finding user location
- Always show location button, even when location services are disabled
- Remove pulsating animations
- Show area name instead of radius in selection tag
- Don't center on user location on enter 

# Show me

No UI changes.