### PR TITLE
Sync selection store with filters from filter container

### DIFF
--- a/Sources/Charcoal/CharcoalViewController.swift
+++ b/Sources/Charcoal/CharcoalViewController.swift
@@ -94,6 +94,8 @@ public class CharcoalViewController: UINavigationController {
     private func configure(with filter: FilterContainer?) {
         guard let filter = filter else { return }
 
+        selectionStore.syncSelection(with: filter)
+
         if let rootFilterViewController = rootFilterViewController {
             rootFilterViewController.set(filter: filter.rootFilter, verticals: filter.verticals)
         } else {

--- a/Sources/Charcoal/Selection/FilterSelectionStore.swift
+++ b/Sources/Charcoal/Selection/FilterSelectionStore.swift
@@ -102,13 +102,15 @@ private extension FilterSelectionStore {
         }
     }
 
-    func _removeValues(for filter: Filter) {
+    func _removeValues(for filter: Filter, withSubfilters: Bool = true) {
         if let queryItem = queryItem(for: filter) {
             queryItems.remove(queryItem)
         }
 
-        filter.subfilters.forEach {
-            _removeValues(for: $0)
+        if withSubfilters {
+            filter.subfilters.forEach {
+                _removeValues(for: $0)
+            }
         }
     }
 }
@@ -185,5 +187,32 @@ extension FilterSelectionStore {
         }
 
         return filter.subfilters.reduce([]) { $0 + selectedSubfilters(for: $1, where: predicate) }
+    }
+
+    func syncSelection(with filterContainer: FilterContainer) {
+        let keys = syncSelection(with: filterContainer.rootFilter)
+        queryItems = queryItems.filter({ keys.contains($0.name) })
+    }
+
+    /**
+     Cleans up selected values based on filter hierarchy (e.g. deselect filters with selected subfilters).
+     - Parameter filter: The root filter.
+     - Returns: Keys of all processed filters.
+    **/
+    private func syncSelection(with filter: Filter) -> Set<String> {
+        var isSelected = self.isSelected(filter)
+        var keys = Set([filter.key])
+
+        for subfilter in filter.subfilters {
+            if isSelected && hasSelectedSubfilters(for: subfilter) {
+                _removeValues(for: filter, withSubfilters: false)
+                isSelected = false
+            }
+
+            let subfilterKeys = syncSelection(with: subfilter)
+            keys = keys.union(subfilterKeys)
+        }
+
+        return keys
     }
 }

--- a/Sources/Charcoal/Selection/FilterSelectionStore.swift
+++ b/Sources/Charcoal/Selection/FilterSelectionStore.swift
@@ -198,7 +198,7 @@ extension FilterSelectionStore {
      Cleans up selected values based on filter hierarchy (e.g. deselect filters with selected subfilters).
      - Parameter filter: The root filter.
      - Returns: Keys of all processed filters.
-    **/
+     **/
     private func syncSelection(with filter: Filter) -> Set<String> {
         var isSelected = self.isSelected(filter)
         var keys = Set([filter.key])

--- a/UnitTests/Charcoal/Selection/FilterSelectionStoreTests.swift
+++ b/UnitTests/Charcoal/Selection/FilterSelectionStoreTests.swift
@@ -276,4 +276,44 @@ final class FilterSelectionStoreTests: XCTestCase {
         XCTAssertEqual(store.selectedSubfilters(for: filter, where: { $0.key == "subfilterA" }).count, 1)
         XCTAssertTrue(store.selectedSubfilters(for: filter, where: { $0.key == "subfilterB" }).isEmpty)
     }
+
+    func testSyncSelectionWithSelectedFilterAndSubfilter() {
+        let filter = Filter.list(
+            title: "filter",
+            key: "filter",
+            value: "value",
+            subfilters: [
+                Filter.list(title: "subfilter A", key: "subfilterA", value: "valueA"),
+                Filter.list(title: "subfilter B", key: "subfilterB", value: "valueB"),
+            ]
+        )
+
+        let queryItems = Set([
+            URLQueryItem(name: "filter", value: "value"),
+            URLQueryItem(name: "subfilterB", value: "valueB"),
+        ])
+
+        store.set(selection: queryItems)
+        store.syncSelection(with: FilterContainer(root: filter))
+
+        XCTAssertFalse(store.isSelected(filter))
+        XCTAssertFalse(store.isSelected(filter.subfilters[0]))
+        XCTAssertTrue(store.isSelected(filter.subfilters[1]))
+    }
+
+    func testSyncSelectionWithOldQueryItems() {
+        let filterA = Filter.list(title: "filter A", key: "filterA", value: "valueA")
+        let filterB = Filter.list(title: "filter B", key: "filterB", value: "valueB")
+
+        store.setValue(from: filterA)
+        XCTAssertTrue(store.isSelected(filterA))
+
+        let queryItems = Set([URLQueryItem(name: "filterB", value: "valueB")])
+
+        store.set(selection: queryItems)
+        store.syncSelection(with: FilterContainer(root: filterB))
+
+        XCTAssertFalse(store.isSelected(filterA))
+        XCTAssertTrue(store.isSelected(filterB))
+    }
 }


### PR DESCRIPTION
# Why?

In order to keep selection store up-to-date with filter container. 

# What?

This PR adds a new method on `FilterSelectionStore` to sync selection with filters from `FilterContainer`. We call it in `CharcoalViewController` while configuring it with new filter container to remove selections for:
- filters that have at least one subfilter selected
- filters that have been removed, e.g. context filters

# Show me

No UI changes.