### PR TITLE
Map filter: fix selection

### DIFF
--- a/Sources/Charcoal/Selection/FilterSelectionStore.swift
+++ b/Sources/Charcoal/Selection/FilterSelectionStore.swift
@@ -84,7 +84,9 @@ extension FilterSelectionStore {
 
     func isSelected(_ filter: Filter) -> Bool {
         switch filter.kind {
-        case .map, .range:
+        case .map(_, _, let radiusFilter, _):
+            return isSelected(radiusFilter)
+        case .range:
             return filter.subfilters.contains(where: { isSelected($0) })
         default:
             return queryItem(for: filter) != nil
@@ -146,7 +148,7 @@ extension FilterSelectionStore {
             if let title = locationName ?? radius.map({ MapDistanceValueFormatter().title(for: $0) }) {
                 return [title]
             } else {
-                fallthrough
+                return []
             }
         default:
             if isSelected(filter) {


### PR DESCRIPTION
# Why?

We shouldn't rely on `latitude` and `longitude` filters because sometimes they come from sorting by location.

# What?

Consider map filter as selected only when radius is selected.

# Show me

No UI changes.