### PR TITLE
Scroll to top

### DIFF
--- a/Sources/Charcoal/CharcoalViewController.swift
+++ b/Sources/Charcoal/CharcoalViewController.swift
@@ -80,6 +80,11 @@ public class CharcoalViewController: UINavigationController {
         rootFilterViewController?.reloadFilters()
     }
 
+    public func returnToRoot(animated: Bool) {
+        popToRootViewController(animated: animated)
+        rootFilterViewController?.scrollToTop(animated: animated)
+    }
+
     // MARK: - Private
 
     private func updateLoading() {

--- a/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
+++ b/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
@@ -81,6 +81,10 @@ final class RootFilterViewController: FilterViewController {
 
     // MARK: - Public
 
+    func scrollToTop(animated: Bool) {
+        tableView.scrollToRow(at: IndexPath(row: 0, section: 0), at: .top, animated: animated)
+    }
+
     func reloadFilters() {
         tableView.reloadData()
     }
@@ -113,6 +117,7 @@ final class RootFilterViewController: FilterViewController {
         rootDelegate?.rootFilterViewControllerDidResetAllFilters(self)
         freeTextFilterViewController?.searchBar.text = nil
         tableView.reloadData()
+        scrollToTop(animated: true)
     }
 }
 

--- a/Sources/Charcoal/Selection/FilterSelectionStore.swift
+++ b/Sources/Charcoal/Selection/FilterSelectionStore.swift
@@ -84,7 +84,7 @@ extension FilterSelectionStore {
 
     func isSelected(_ filter: Filter) -> Bool {
         switch filter.kind {
-        case .map(_, _, let radiusFilter, _):
+        case let .map(_, _, radiusFilter, _):
             return isSelected(radiusFilter)
         case .range:
             return filter.subfilters.contains(where: { isSelected($0) })


### PR DESCRIPTION
# Why?

The root filter should scroll to top when tapping the reset button and we should have to the option to return to root filters from outside.

# What?

- Added method `scrollToTop(animated: Bool)` to `RootFilterViewController`
- Root filters scroll to top when tapping reset button
- Added `returnToRoot(animate: Bool)` to `CharcoalViewController`. This will also scroll to top
