### PR TITLE
layout if needed after scroll to top

### DIFF
--- a/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
+++ b/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
@@ -83,6 +83,7 @@ final class RootFilterViewController: FilterViewController {
 
     func scrollToTop(animated: Bool) {
         tableView.scrollToRow(at: IndexPath(row: 0, section: 0), at: .top, animated: animated)
+        tableView.layoutIfNeeded()
     }
 
     func reloadFilters() {


### PR DESCRIPTION
# Why?

There is a bug where the table view doesn't scroll all the way to the top if the tableview will reload its data right after.

# What?

- Add a call to `layoutIfNeeded()` on the tableview right after scrolling to top

# Show me

No UI