### PR TITLE
Fix lower and upper bounds of range sliders

### DIFF
--- a/Sources/Charcoal/Filters/StepSlider/StepSlider.swift
+++ b/Sources/Charcoal/Filters/StepSlider/StepSlider.swift
@@ -97,8 +97,8 @@ final class StepSlider: UISlider {
     }
 
     private func step(from value: Float) -> Step {
-        let valueWithoutOffset = roundf(value - leftOffset)
-        let index = Int(valueWithoutOffset)
+        let valueWithoutOffset = value - leftOffset
+        let index = Int(roundf(value - leftOffset))
 
         if valueWithoutOffset < minimumValue {
             return .lowerBound

--- a/Sources/Charcoal/Filters/StepSlider/StepSlider.swift
+++ b/Sources/Charcoal/Filters/StepSlider/StepSlider.swift
@@ -98,7 +98,7 @@ final class StepSlider: UISlider {
 
     private func step(from value: Float) -> Step {
         let valueWithoutOffset = value - leftOffset
-        let index = Int(roundf(value - leftOffset))
+        let index = Int(roundf(valueWithoutOffset))
 
         if valueWithoutOffset < minimumValue {
             return .lowerBound

--- a/Sources/Charcoal/Models/RangeFilterConfiguration.swift
+++ b/Sources/Charcoal/Models/RangeFilterConfiguration.swift
@@ -22,16 +22,28 @@ public struct RangeFilterConfiguration: Equatable {
     public let displaysUnitInNumberInput: Bool
     public let isCurrencyValueRange: Bool
 
-    public var referenceValues: [Int] {
-        var result = [Int]()
+    private let isIncremented: Bool
 
-        if let first = values.first, let last = values.last {
-            result.append(first)
-            result.append(first + (last - first) / 2)
-            result.append(last)
+    public var referenceValues: [Int] {
+        guard let first = values.first, let last = values.last else {
+            return []
         }
 
-        return result
+        var result = Set<Int>()
+
+        if isIncremented {
+            result = [first, first + (last - first) / 2, last]
+        } else {
+            result = [first, last]
+
+            let centerIndex = Int(values.count / 2)
+
+            if centerIndex > 0, centerIndex < values.count - 1 {
+                result.insert(values[centerIndex])
+            }
+        }
+
+        return Array(result).sorted(by: <)
     }
 
     // MARK: - Init
@@ -59,10 +71,13 @@ public struct RangeFilterConfiguration: Equatable {
         switch valueKind {
         case let .incremented(increment):
             self.values = (minimumValue ... maximumValue).stepValues(with: [(from: minimumValue, increment: increment)])
+            isIncremented = true
         case let .steps(values):
             self.values = ([minimumValue] + values + [maximumValue]).compactMap({ $0 })
+            isIncremented = false
         case let .intervals(array):
             self.values = (minimumValue ... maximumValue).stepValues(with: array)
+            isIncremented = false
         }
     }
 

--- a/Sources/Charcoal/Models/RangeFilterConfiguration.swift
+++ b/Sources/Charcoal/Models/RangeFilterConfiguration.swift
@@ -25,17 +25,9 @@ public struct RangeFilterConfiguration: Equatable {
     public var referenceValues: [Int] {
         var result = [Int]()
 
-        if let first = values.first {
+        if let first = values.first, let last = values.last {
             result.append(first)
-        }
-
-        let centerIndex = Int(values.count / 2)
-
-        if centerIndex > 0, centerIndex < values.count - 1 {
-            result.append(values[centerIndex])
-        }
-
-        if let last = values.last {
+            result.append(first + (last - first) / 2)
             result.append(last)
         }
 
@@ -66,7 +58,7 @@ public struct RangeFilterConfiguration: Equatable {
 
         switch valueKind {
         case let .incremented(increment):
-            self.values = (minimumValue ... maximumValue).stepValues(with: [(from: 0, increment: increment)])
+            self.values = (minimumValue ... maximumValue).stepValues(with: [(from: minimumValue, increment: increment)])
         case let .steps(values):
             self.values = ([minimumValue] + values + [maximumValue]).compactMap({ $0 })
         case let .intervals(array):

--- a/UnitTests/Charcoal/Models/RangeFilterConfigurationTests.swift
+++ b/UnitTests/Charcoal/Models/RangeFilterConfigurationTests.swift
@@ -96,7 +96,7 @@ final class RangeFilterConfigurationTests: XCTestCase {
         XCTAssertTrue(config.hasLowerBoundOffset)
         XCTAssertTrue(config.hasUpperBoundOffset)
         XCTAssertEqual(config.values, [100, 1100, 2100, 3100, 4100, 5000])
-        XCTAssertEqual(config.referenceValues, [100, 3100, 5000])
+        XCTAssertEqual(config.referenceValues, [100, 2550, 5000])
         XCTAssertEqual(config.unit, "stk")
         XCTAssertEqual(config.accessibilityValueSuffix, "test")
         XCTAssertTrue(config.usesSmallNumberInputFont)


### PR DESCRIPTION
# Why?

We had a bug with range slider not able to reach its lower and upper bounds.

# What?

- Fix calculations for getting lower and upper step values
- Calculate reference values differently for incremented ranges

# Show me

### Before

![before](https://user-images.githubusercontent.com/10529867/55065905-fea67780-507c-11e9-99b0-00d7145e53f4.gif)

### After

![after](https://user-images.githubusercontent.com/10529867/55065906-ffd7a480-507c-11e9-99ff-e688b434b481.gif)