### PR TITLE
Don't reload filters if currently selected vertical gets selected again

### DIFF
--- a/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
+++ b/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
@@ -266,8 +266,19 @@ extension RootFilterViewController: InlineFilterViewDelegate {
 extension RootFilterViewController: VerticalListViewControllerDelegate {
     func verticalListViewController(_ verticalViewController: VerticalListViewController, didSelectVerticalAtIndex index: Int) {
         freeTextFilterViewController?.searchBar.text = nil
-        verticalViewController.dismiss(animated: false)
-        rootDelegate?.rootFilterViewController(self, didSelectVerticalAt: index)
+
+        func dismissVerticalViewController(animated: Bool) {
+            DispatchQueue.main.async {
+                verticalViewController.dismiss(animated: animated)
+            }
+        }
+
+        if verticals?.firstIndex(where: { $0.isCurrent }) != index {
+            dismissVerticalViewController(animated: false)
+            rootDelegate?.rootFilterViewController(self, didSelectVerticalAt: index)
+        } else {
+            dismissVerticalViewController(animated: true)
+        }
     }
 }
 

--- a/Sources/Charcoal/Vertical/VerticalListViewController.swift
+++ b/Sources/Charcoal/Vertical/VerticalListViewController.swift
@@ -27,6 +27,8 @@ public class VerticalListViewController: UIViewController {
 
     private let verticals: [Vertical]
 
+    // MARK: - Init
+
     public required init(verticals: [Vertical]) {
         self.verticals = verticals
         super.init(nibName: nil, bundle: nil)
@@ -38,23 +40,28 @@ public class VerticalListViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
+    // MARK: - Lifecycle
+
     public override func viewDidLoad() {
         super.viewDidLoad()
-
         setup()
     }
 
-    func setup(withSourceView source: UIView, inContainerView view: UIView) {
+    // MARK: - Setup
+
+    private func setup(withSourceView source: UIView, inContainerView view: UIView) {
         let sourceViewBottom = view.convert(CGPoint(x: 0, y: source.bounds.maxY), from: source).y
         let maxHeightForPopover = view.bounds.height - sourceViewBottom - 20
         let numberOfRowsFitting = maxHeightForPopover / VerticalListViewController.rowHeight
 
         let popoverHeight: CGFloat
+
         if numberOfRowsFitting < CGFloat(verticals.count) {
             popoverHeight = (floor(numberOfRowsFitting) - 0.5) * VerticalListViewController.rowHeight
         } else {
             popoverHeight = CGFloat(verticals.count) * VerticalListViewController.rowHeight
         }
+
         preferredContentSize = CGSize(width: view.frame.size.width, height: popoverHeight)
     }
 
@@ -78,6 +85,8 @@ public class VerticalListViewController: UIViewController {
     }
 }
 
+// MARK: - UITableViewDataSource
+
 extension VerticalListViewController: UITableViewDataSource {
     public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return verticals.count
@@ -91,6 +100,8 @@ extension VerticalListViewController: UITableViewDataSource {
         return cell
     }
 }
+
+// MARK: - UITableViewDelegate
 
 extension VerticalListViewController: UITableViewDelegate {
     public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {


### PR DESCRIPTION
# Why?

Because it's not necessary to reload filters if vertical hasn't been changed.

# What?

Don't reload filters if currently selected vertical gets selected again.

# Show me

### Before

![before](https://user-images.githubusercontent.com/10529867/55073773-e2133b00-508e-11e9-82a0-a77eca849d01.gif)

### After

![after](https://user-images.githubusercontent.com/10529867/55073777-e6d7ef00-508e-11e9-9e68-0007a2e925b1.gif)
