### PR TITLE
Map filter: clear location name after moving the map

### DIFF
--- a/Sources/Charcoal/Filters/Map/MapFilterViewController.swift
+++ b/Sources/Charcoal/Filters/Map/MapFilterViewController.swift
@@ -202,6 +202,7 @@ extension MapFilterViewController: MKMapViewDelegate {
         mapFilterView.isUserLocationButtonHighlighted = coordinate == mapView.userLocation.coordinate
 
         if nextRegionChangeIsFromUserInteraction {
+            locationName = nil
             hasChanges = true
         }
 

--- a/Sources/Charcoal/Selection/FilterSelectionStore.swift
+++ b/Sources/Charcoal/Selection/FilterSelectionStore.swift
@@ -141,9 +141,9 @@ extension FilterSelectionStore {
             }
         case .stepper:
             if let lowValue: Int = value(for: filter) {
-              return ["\(lowValue)+"]
+                return ["\(lowValue)+"]
             } else {
-              return []
+                return []
             }
         case let .map(_, _, radiusFilter, _):
             if let radius: Int = value(for: radiusFilter) {


### PR DESCRIPTION
# Why?

Because location name is no longer valid after moving the map

# What?

Map filter: clear location name after moving the map.

# Show me

![map](https://user-images.githubusercontent.com/10529867/55074611-053eea00-5091-11e9-9643-66b919149085.gif)