### PR TITLE
Formatter numbers with thousand separator 

### DIFF
--- a/Charcoal.xcodeproj/project.pbxproj
+++ b/Charcoal.xcodeproj/project.pbxproj
@@ -120,6 +120,7 @@
 		CF33D9D5224A4D2200A24DF0 /* XCUIApplicationExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF33D9D4224A4D2200A24DF0 /* XCUIApplicationExtensions.swift */; };
 		CF33D9D7224A6B0600A24DF0 /* CommandLineExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF33D9D6224A6B0600A24DF0 /* CommandLineExtensions.swift */; };
 		CF33D9D9224BACBC00A24DF0 /* NumberFormatterExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF33D9D8224BACBC00A24DF0 /* NumberFormatterExtensions.swift */; };
+		CF33D9DC224BB5B400A24DF0 /* NumberFormatterExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF33D9DB224BB5B400A24DF0 /* NumberFormatterExtensionsTests.swift */; };
 		CF4C870A221AFC0900DFAF2A /* ListFilterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF4C8709221AFC0900DFAF2A /* ListFilterViewController.swift */; };
 		CF4C870C221AFC8500DFAF2A /* RangeFilterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF4C870B221AFC8500DFAF2A /* RangeFilterViewController.swift */; };
 		CF4C870E221AFCC900DFAF2A /* RootFilterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF4C870D221AFCC900DFAF2A /* RootFilterViewController.swift */; };
@@ -389,6 +390,7 @@
 		CF33D9D4224A4D2200A24DF0 /* XCUIApplicationExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCUIApplicationExtensions.swift; sourceTree = "<group>"; };
 		CF33D9D6224A6B0600A24DF0 /* CommandLineExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandLineExtensions.swift; sourceTree = "<group>"; };
 		CF33D9D8224BACBC00A24DF0 /* NumberFormatterExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberFormatterExtensions.swift; sourceTree = "<group>"; };
+		CF33D9DB224BB5B400A24DF0 /* NumberFormatterExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberFormatterExtensionsTests.swift; sourceTree = "<group>"; };
 		CF4C8709221AFC0900DFAF2A /* ListFilterViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListFilterViewController.swift; sourceTree = "<group>"; };
 		CF4C870B221AFC8500DFAF2A /* RangeFilterViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RangeFilterViewController.swift; sourceTree = "<group>"; };
 		CF4C870D221AFCC900DFAF2A /* RootFilterViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RootFilterViewController.swift; sourceTree = "<group>"; };
@@ -884,6 +886,14 @@
 			path = Core;
 			sourceTree = "<group>";
 		};
+		CF33D9DA224BB59E00A24DF0 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				CF33D9DB224BB5B400A24DF0 /* NumberFormatterExtensionsTests.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
 		CF4C8702221ADF2700DFAF2A /* Charcoal */ = {
 			isa = PBXGroup;
 			children = (
@@ -1003,6 +1013,7 @@
 		CFCB35E92236697A004E6EB3 /* Charcoal */ = {
 			isa = PBXGroup;
 			children = (
+				CF33D9DA224BB59E00A24DF0 /* Extensions */,
 				CFCB35EA223669A5004E6EB3 /* Filters */,
 				DA8D6840220D88C600D31941 /* Models */,
 				CF81E10E221C549200D00423 /* Selection */,
@@ -1134,9 +1145,9 @@
 		DA8D6840220D88C600D31941 /* Models */ = {
 			isa = PBXGroup;
 			children = (
-				CF794C7622300096003425E2 /* RangerFilterConfiguration+Stubs.swift */,
 				DA8D683B220D874400D31941 /* FilterTests.swift */,
 				CFFD9F8C21F09F7500997D14 /* RangeFilterConfigurationTests.swift */,
+				CF794C7622300096003425E2 /* RangerFilterConfiguration+Stubs.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1604,6 +1615,7 @@
 				DA8D683C220D874400D31941 /* FilterTests.swift in Sources */,
 				CFFD9F8D21F09F7500997D14 /* RangeFilterConfigurationTests.swift in Sources */,
 				CFB13DB021FF2B1800F8D126 /* StepTests.swift in Sources */,
+				CF33D9DC224BB5B400A24DF0 /* NumberFormatterExtensionsTests.swift in Sources */,
 				55BDA76620DB7FC000331FFC /* TestDataDecoder.swift in Sources */,
 				CFB13DB221FF2CBB00F8D126 /* ArrayStepTests.swift in Sources */,
 				DA8D683F220D88A300D31941 /* FilterSelectionStoreTests.swift in Sources */,

--- a/Charcoal.xcodeproj/project.pbxproj
+++ b/Charcoal.xcodeproj/project.pbxproj
@@ -119,6 +119,7 @@
 		CF33D9D3224A4B9D00A24DF0 /* UITestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF33D9D2224A4B9D00A24DF0 /* UITestCase.swift */; };
 		CF33D9D5224A4D2200A24DF0 /* XCUIApplicationExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF33D9D4224A4D2200A24DF0 /* XCUIApplicationExtensions.swift */; };
 		CF33D9D7224A6B0600A24DF0 /* CommandLineExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF33D9D6224A6B0600A24DF0 /* CommandLineExtensions.swift */; };
+		CF33D9D9224BACBC00A24DF0 /* NumberFormatterExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF33D9D8224BACBC00A24DF0 /* NumberFormatterExtensions.swift */; };
 		CF4C870A221AFC0900DFAF2A /* ListFilterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF4C8709221AFC0900DFAF2A /* ListFilterViewController.swift */; };
 		CF4C870C221AFC8500DFAF2A /* RangeFilterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF4C870B221AFC8500DFAF2A /* RangeFilterViewController.swift */; };
 		CF4C870E221AFCC900DFAF2A /* RootFilterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF4C870D221AFCC900DFAF2A /* RootFilterViewController.swift */; };
@@ -387,6 +388,7 @@
 		CF33D9D2224A4B9D00A24DF0 /* UITestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITestCase.swift; sourceTree = "<group>"; };
 		CF33D9D4224A4D2200A24DF0 /* XCUIApplicationExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCUIApplicationExtensions.swift; sourceTree = "<group>"; };
 		CF33D9D6224A6B0600A24DF0 /* CommandLineExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandLineExtensions.swift; sourceTree = "<group>"; };
+		CF33D9D8224BACBC00A24DF0 /* NumberFormatterExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberFormatterExtensions.swift; sourceTree = "<group>"; };
 		CF4C8709221AFC0900DFAF2A /* ListFilterViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListFilterViewController.swift; sourceTree = "<group>"; };
 		CF4C870B221AFC8500DFAF2A /* RangeFilterViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RangeFilterViewController.swift; sourceTree = "<group>"; };
 		CF4C870D221AFCC900DFAF2A /* RootFilterViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RootFilterViewController.swift; sourceTree = "<group>"; };
@@ -824,11 +826,12 @@
 		9BE0A04D2091C12A0000632B /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
-				CFEDCE142232BA5A008FCDB1 /* StringExtensions.swift */,
 				9BE0A04E2091C2E90000632B /* ArrayExtensions.swift */,
 				9BD6377D21244C0B00AB9DFE /* Color.swift */,
 				DA51041A21BE6AFE004048BD /* Font.swift */,
 				DA39FA3F220B30E700608AC4 /* Int.swift */,
+				CF33D9D8224BACBC00A24DF0 /* NumberFormatterExtensions.swift */,
+				CFEDCE142232BA5A008FCDB1 /* StringExtensions.swift */,
 				5589322F209C3CDA00512FF8 /* UIKit */,
 			);
 			path = Extensions;
@@ -1562,6 +1565,7 @@
 				55305BBC20BD8CDF005637C2 /* CompactListFilterView.swift in Sources */,
 				9B8D53AE21528F2200FB9573 /* RangeFilterValueFormatter.swift in Sources */,
 				9B741D1621B5592C00D18097 /* MapFilterView.swift in Sources */,
+				CF33D9D9224BACBC00A24DF0 /* NumberFormatterExtensions.swift in Sources */,
 				CFCB36012237DE06004E6EB3 /* SelectionChangeOrigin.swift in Sources */,
 				DA39FA2E220B17DB00608AC4 /* MapFilterViewController.swift in Sources */,
 				559C61F320DA4C8D0083A574 /* (null) in Sources */,

--- a/Demo/Components/RangeFilterDemoView.swift
+++ b/Demo/Components/RangeFilterDemoView.swift
@@ -15,7 +15,7 @@ public class RangeFilterDemoView: UIView {
         accessibilityValueSuffix: nil,
         usesSmallNumberInputFont: false,
         displaysUnitInNumberInput: true,
-        isCurrencyValueRange: true
+        formatWithSeparator: true
     )
 
     private lazy var rangeFilterView: RangeFilterView = {

--- a/Sources/Charcoal/Extensions/NumberFormatterExtensions.swift
+++ b/Sources/Charcoal/Extensions/NumberFormatterExtensions.swift
@@ -1,0 +1,21 @@
+//
+//  Copyright © FINN.no AS, Inc. All rights reserved.
+//
+
+import Foundation
+
+extension NumberFormatter {
+    static let formatterWithSeparator: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .currency
+        formatter.currencySymbol = ""
+        formatter.locale = Locale(identifier: "nb_NO")
+        formatter.maximumFractionDigits = 0
+        return formatter
+    }()
+
+    func string(from value: Int) -> String? {
+        let number = NSNumber(value: value)
+        return string(from: number)
+    }
+}

--- a/Sources/Charcoal/Extensions/NumberFormatterExtensions.swift
+++ b/Sources/Charcoal/Extensions/NumberFormatterExtensions.swift
@@ -16,6 +16,6 @@ extension NumberFormatter {
 
     func string(from value: Int) -> String? {
         let number = NSNumber(value: value)
-        return string(from: number)
+        return string(from: number)?.trimmingCharacters(in: .whitespaces)
     }
 }

--- a/Sources/Charcoal/Extensions/NumberFormatterExtensions.swift
+++ b/Sources/Charcoal/Extensions/NumberFormatterExtensions.swift
@@ -5,10 +5,9 @@
 import Foundation
 
 extension NumberFormatter {
-    static let formatterWithSeparator: NumberFormatter = {
+    static let decimalFormatter: NumberFormatter = {
         let formatter = NumberFormatter()
-        formatter.numberStyle = .currency
-        formatter.currencySymbol = ""
+        formatter.numberStyle = .decimal
         formatter.locale = Locale(identifier: "nb_NO")
         formatter.maximumFractionDigits = 0
         return formatter

--- a/Sources/Charcoal/Filters/List/ListFilterCellViewModel.swift
+++ b/Sources/Charcoal/Filters/List/ListFilterCellViewModel.swift
@@ -42,7 +42,7 @@ extension ListFilterCellViewModel {
         return ListFilterCellViewModel(
             title: "all".localized(),
             subtitle: nil,
-            detailText: String(filter.numberOfResults),
+            detailText: filter.formattedNumberOfResults,
             accessoryStyle: .none,
             checkboxStyle: checkboxStyle,
             isEnabled: true
@@ -62,7 +62,7 @@ extension ListFilterCellViewModel {
         return ListFilterCellViewModel(
             title: filter.title,
             subtitle: nil,
-            detailText: String(filter.numberOfResults),
+            detailText: filter.formattedNumberOfResults,
             accessoryStyle: filter.subfilters.isEmpty ? .none : .chevron,
             checkboxStyle: checkboxStyle,
             isEnabled: isEnabled
@@ -73,7 +73,7 @@ extension ListFilterCellViewModel {
         return ListFilterCellViewModel(
             title: filter.title,
             subtitle: "browserText".localized(),
-            detailText: String(filter.numberOfResults),
+            detailText: filter.formattedNumberOfResults,
             accessoryStyle: .external,
             checkboxStyle: .deselected,
             isEnabled: isEnabled

--- a/Sources/Charcoal/Filters/Range/RangeFilterValueFormatter.swift
+++ b/Sources/Charcoal/Filters/Range/RangeFilterValueFormatter.swift
@@ -2,20 +2,13 @@
 //  Copyright © FINN.no AS, Inc. All rights reserved.
 //
 
-class RangeFilterValueFormatter: NSObject, SliderValueFormatter {
+final class RangeFilterValueFormatter: NSObject, SliderValueFormatter {
     private let isValueCurrency: Bool
     private let unit: String
     private let accessibilityUnit: String
 
-    private lazy var formatter: NumberFormatter = {
-        let formatter = NumberFormatter()
-        formatter.numberStyle = isValueCurrency ? .currency : .none
-        formatter.currencySymbol = ""
-        formatter.locale = Locale(identifier: "nb_NO")
-        formatter.maximumFractionDigits = 0
-
-        return formatter
-    }()
+    private static let numberFormatter = NumberFormatter(isValueCurrency: false)
+    private static let currencyFormatter = NumberFormatter(isValueCurrency: true)
 
     init(isValueCurrency: Bool, unit: String, accessibilityUnit: String) {
         self.isValueCurrency = isValueCurrency
@@ -23,8 +16,9 @@ class RangeFilterValueFormatter: NSObject, SliderValueFormatter {
         self.accessibilityUnit = accessibilityUnit
     }
 
-    func string(from value: Int, isCurrency: Bool = false) -> String? {
+    func string(from value: Int) -> String? {
         let value = NSNumber(value: value)
+        let formatter = isValueCurrency ? RangeFilterValueFormatter.currencyFormatter : RangeFilterValueFormatter.numberFormatter
         return formatter.string(from: value)
     }
 
@@ -34,5 +28,17 @@ class RangeFilterValueFormatter: NSObject, SliderValueFormatter {
 
     func title<ValueKind>(for value: ValueKind) -> String {
         return "\(value) \(unit)"
+    }
+}
+
+// MARK: - Private extensions
+
+private extension NumberFormatter {
+    convenience init(isValueCurrency: Bool) {
+        self.init()
+        numberStyle = isValueCurrency ? .currency : .none
+        currencySymbol = ""
+        locale = Locale(identifier: "nb_NO")
+        maximumFractionDigits = 0
     }
 }

--- a/Sources/Charcoal/Filters/Range/RangeFilterValueFormatter.swift
+++ b/Sources/Charcoal/Filters/Range/RangeFilterValueFormatter.swift
@@ -7,11 +7,15 @@ final class RangeFilterValueFormatter: NSObject, SliderValueFormatter {
     private let unit: String
     private let accessibilityUnit: String
 
+    // MARK: - Init
+
     init(formatWithSeparator: Bool, unit: String, accessibilityUnit: String) {
         self.formatWithSeparator = formatWithSeparator
         self.unit = unit
         self.accessibilityUnit = accessibilityUnit
     }
+
+    // MARK: - Formatter
 
     func string(from value: Int) -> String? {
         if formatWithSeparator {

--- a/Sources/Charcoal/Filters/Range/RangeFilterValueFormatter.swift
+++ b/Sources/Charcoal/Filters/Range/RangeFilterValueFormatter.swift
@@ -14,9 +14,12 @@ final class RangeFilterValueFormatter: NSObject, SliderValueFormatter {
     }
 
     func string(from value: Int) -> String? {
-        let value = NSNumber(value: value)
-        let formatter: NumberFormatter = isValueCurrency ? .currencyFormatter : .standardFormatter
-        return formatter.string(from: value)
+        if isValueCurrency {
+            let value = NSNumber(value: value)
+            return NumberFormatter.currencyFormatter.string(from: value)
+        } else {
+            return "\(value)"
+        }
     }
 
     func accessibilityValue<ValueKind>(for value: ValueKind) -> String {
@@ -31,14 +34,12 @@ final class RangeFilterValueFormatter: NSObject, SliderValueFormatter {
 // MARK: - Private extensions
 
 extension NumberFormatter {
-    static let standardFormatter = NumberFormatter(isValueCurrency: true)
-    static let currencyFormatter = NumberFormatter(isValueCurrency: true)
-
-    private convenience init(isValueCurrency: Bool) {
-        self.init()
-        numberStyle = isValueCurrency ? .currency : .none
-        currencySymbol = ""
-        locale = Locale(identifier: "nb_NO")
-        maximumFractionDigits = 0
-    }
+    static let currencyFormatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .currency
+        formatter.currencySymbol = ""
+        formatter.locale = Locale(identifier: "nb_NO")
+        formatter.maximumFractionDigits = 0
+        return formatter
+    }()
 }

--- a/Sources/Charcoal/Filters/Range/RangeFilterValueFormatter.swift
+++ b/Sources/Charcoal/Filters/Range/RangeFilterValueFormatter.swift
@@ -3,20 +3,19 @@
 //
 
 final class RangeFilterValueFormatter: NSObject, SliderValueFormatter {
-    private let isValueCurrency: Bool
+    private let formatWithSeparator: Bool
     private let unit: String
     private let accessibilityUnit: String
 
-    init(isValueCurrency: Bool, unit: String, accessibilityUnit: String) {
-        self.isValueCurrency = isValueCurrency
+    init(formatWithSeparator: Bool, unit: String, accessibilityUnit: String) {
+        self.formatWithSeparator = formatWithSeparator
         self.unit = unit
         self.accessibilityUnit = accessibilityUnit
     }
 
     func string(from value: Int) -> String? {
-        if isValueCurrency {
-            let value = NSNumber(value: value)
-            return NumberFormatter.currencyFormatter.string(from: value)
+        if formatWithSeparator {
+            return NumberFormatter.formatterWithSeparator.string(from: value)
         } else {
             return "\(value)"
         }
@@ -29,17 +28,4 @@ final class RangeFilterValueFormatter: NSObject, SliderValueFormatter {
     func title<ValueKind>(for value: ValueKind) -> String {
         return "\(value) \(unit)"
     }
-}
-
-// MARK: - Private extensions
-
-extension NumberFormatter {
-    static let currencyFormatter: NumberFormatter = {
-        let formatter = NumberFormatter()
-        formatter.numberStyle = .currency
-        formatter.currencySymbol = ""
-        formatter.locale = Locale(identifier: "nb_NO")
-        formatter.maximumFractionDigits = 0
-        return formatter
-    }()
 }

--- a/Sources/Charcoal/Filters/Range/RangeFilterValueFormatter.swift
+++ b/Sources/Charcoal/Filters/Range/RangeFilterValueFormatter.swift
@@ -19,7 +19,7 @@ final class RangeFilterValueFormatter: NSObject, SliderValueFormatter {
 
     func string(from value: Int) -> String? {
         if formatWithSeparator {
-            return NumberFormatter.formatterWithSeparator.string(from: value)
+            return NumberFormatter.decimalFormatter.string(from: value)
         } else {
             return "\(value)"
         }

--- a/Sources/Charcoal/Filters/Range/RangeFilterValueFormatter.swift
+++ b/Sources/Charcoal/Filters/Range/RangeFilterValueFormatter.swift
@@ -7,9 +7,6 @@ final class RangeFilterValueFormatter: NSObject, SliderValueFormatter {
     private let unit: String
     private let accessibilityUnit: String
 
-    private static let numberFormatter = NumberFormatter(isValueCurrency: false)
-    private static let currencyFormatter = NumberFormatter(isValueCurrency: true)
-
     init(isValueCurrency: Bool, unit: String, accessibilityUnit: String) {
         self.isValueCurrency = isValueCurrency
         self.unit = unit
@@ -18,7 +15,7 @@ final class RangeFilterValueFormatter: NSObject, SliderValueFormatter {
 
     func string(from value: Int) -> String? {
         let value = NSNumber(value: value)
-        let formatter = isValueCurrency ? RangeFilterValueFormatter.currencyFormatter : RangeFilterValueFormatter.numberFormatter
+        let formatter: NumberFormatter = isValueCurrency ? .currencyFormatter : .standardFormatter
         return formatter.string(from: value)
     }
 
@@ -33,8 +30,11 @@ final class RangeFilterValueFormatter: NSObject, SliderValueFormatter {
 
 // MARK: - Private extensions
 
-private extension NumberFormatter {
-    convenience init(isValueCurrency: Bool) {
+extension NumberFormatter {
+    static let standardFormatter = NumberFormatter(isValueCurrency: true)
+    static let currencyFormatter = NumberFormatter(isValueCurrency: true)
+
+    private convenience init(isValueCurrency: Bool) {
         self.init()
         numberStyle = isValueCurrency ? .currency : .none
         currencySymbol = ""

--- a/Sources/Charcoal/Filters/Range/RangeFilterView.swift
+++ b/Sources/Charcoal/Filters/Range/RangeFilterView.swift
@@ -61,11 +61,7 @@ final class RangeFilterView: UIView {
 
     init(filterConfig: RangeFilterConfiguration) {
         self.filterConfig = filterConfig
-        formatter = RangeFilterValueFormatter(
-            isValueCurrency: filterConfig.isCurrencyValueRange,
-            unit: filterConfig.unit,
-            accessibilityUnit: filterConfig.accessibilityValueSuffix ?? ""
-        )
+        formatter = filterConfig.formatter
         super.init(frame: .zero)
         numberInputView.accessibilityValueSuffix = filterConfig.accessibilityValueSuffix
         setup()
@@ -168,7 +164,7 @@ extension RangeFilterView {
         referenceValueViews = filterConfig.referenceValues.map({ referenceValue in
             return SliderReferenceValueView(
                 value: referenceValue,
-                displayText: formatter.string(from: referenceValue, isCurrency: filterConfig.isCurrencyValueRange) ?? ""
+                displayText: formatter.string(from: referenceValue) ?? ""
             )
         })
 

--- a/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
+++ b/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
@@ -69,7 +69,7 @@ final class RootFilterViewController: FilterViewController {
         navigationItem.rightBarButtonItem = resetButton
 
         showBottomButton(true, animated: false)
-        bottomButton.buttonTitle = String(format: "showResultsButton".localized(), filter.numberOfResults)
+        updateBottomButtonTitle()
         tableView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: bottomButton.height, right: 0)
         setup()
     }
@@ -96,7 +96,7 @@ final class RootFilterViewController: FilterViewController {
         self.filter = filter
         self.verticals = verticals
         navigationItem.title = filter.title
-        bottomButton.buttonTitle = String(format: "showResultsButton".localized(), filter.numberOfResults)
+        updateBottomButtonTitle()
         tableView.reloadData()
     }
 
@@ -109,6 +109,12 @@ final class RootFilterViewController: FilterViewController {
             tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
         ])
+    }
+
+    private func updateBottomButtonTitle() {
+        let localizedString = String(format: "showResultsButton".localized(), filter.numberOfResults)
+        let title = localizedString.replacingOccurrences(of: "\(filter.numberOfResults)", with: filter.formattedNumberOfResults)
+        bottomButton.buttonTitle = title
     }
 
     // MARK: - Actions

--- a/Sources/Charcoal/Models/Filter.swift
+++ b/Sources/Charcoal/Models/Filter.swift
@@ -152,3 +152,11 @@ extension Filter {
         return filter
     }
 }
+
+// MARK: - Helpers
+
+extension Filter {
+    var formattedNumberOfResults: String {
+        return NumberFormatter.formatterWithSeparator.string(from: numberOfResults) ?? ""
+    }
+}

--- a/Sources/Charcoal/Models/Filter.swift
+++ b/Sources/Charcoal/Models/Filter.swift
@@ -157,6 +157,6 @@ extension Filter {
 
 extension Filter {
     var formattedNumberOfResults: String {
-        return NumberFormatter.formatterWithSeparator.string(from: numberOfResults) ?? ""
+        return NumberFormatter.decimalFormatter.string(from: numberOfResults) ?? ""
     }
 }

--- a/Sources/Charcoal/Models/RangeFilterConfiguration.swift
+++ b/Sources/Charcoal/Models/RangeFilterConfiguration.swift
@@ -22,6 +22,7 @@ public struct RangeFilterConfiguration: Equatable {
     public let displaysUnitInNumberInput: Bool
     public let isCurrencyValueRange: Bool
 
+    let formatter: RangeFilterValueFormatter
     private let isIncremented: Bool
 
     public var referenceValues: [Int] {
@@ -79,6 +80,12 @@ public struct RangeFilterConfiguration: Equatable {
             self.values = (minimumValue ... maximumValue).stepValues(with: array)
             isIncremented = false
         }
+
+        formatter = RangeFilterValueFormatter(
+            isValueCurrency: isCurrencyValueRange,
+            unit: unit,
+            accessibilityUnit: accessibilityValueSuffix ?? ""
+        )
     }
 
     // MARK: - Helpers

--- a/Sources/Charcoal/Models/RangeFilterConfiguration.swift
+++ b/Sources/Charcoal/Models/RangeFilterConfiguration.swift
@@ -20,7 +20,7 @@ public struct RangeFilterConfiguration: Equatable {
     public let accessibilityValueSuffix: String?
     public let usesSmallNumberInputFont: Bool
     public let displaysUnitInNumberInput: Bool
-    public let isCurrencyValueRange: Bool
+    public let formatWithSeparator: Bool
 
     let formatter: RangeFilterValueFormatter
     private let isIncremented: Bool
@@ -58,7 +58,7 @@ public struct RangeFilterConfiguration: Equatable {
                 accessibilityValueSuffix: String?,
                 usesSmallNumberInputFont: Bool,
                 displaysUnitInNumberInput: Bool,
-                isCurrencyValueRange: Bool) {
+                formatWithSeparator: Bool) {
         self.minimumValue = minimumValue
         self.maximumValue = maximumValue
         self.hasLowerBoundOffset = hasLowerBoundOffset
@@ -67,7 +67,7 @@ public struct RangeFilterConfiguration: Equatable {
         self.accessibilityValueSuffix = accessibilityValueSuffix
         self.usesSmallNumberInputFont = usesSmallNumberInputFont
         self.displaysUnitInNumberInput = displaysUnitInNumberInput
-        self.isCurrencyValueRange = isCurrencyValueRange
+        self.formatWithSeparator = formatWithSeparator
 
         switch valueKind {
         case let .incremented(increment):
@@ -82,7 +82,7 @@ public struct RangeFilterConfiguration: Equatable {
         }
 
         formatter = RangeFilterValueFormatter(
-            isValueCurrency: isCurrencyValueRange,
+            formatWithSeparator: formatWithSeparator,
             unit: unit,
             accessibilityUnit: accessibilityValueSuffix ?? ""
         )

--- a/Sources/Charcoal/Selection/FilterSelectionStore.swift
+++ b/Sources/Charcoal/Selection/FilterSelectionStore.swift
@@ -141,9 +141,9 @@ extension FilterSelectionStore {
             }
         case .stepper:
             if let lowValue: Int = value(for: filter) {
-              return ["\(lowValue)+"]
+                return ["\(lowValue)+"]
             } else {
-              return []
+                return []
             }
         case let .map(_, _, radiusFilter, _):
             if let radius: Int = value(for: radiusFilter) {

--- a/Sources/Charcoal/Selection/FilterSelectionStore.swift
+++ b/Sources/Charcoal/Selection/FilterSelectionStore.swift
@@ -130,14 +130,17 @@ extension FilterSelectionStore {
 
     func titles(for filter: Filter) -> [String] {
         switch filter.kind {
-        case let .range(lowValueFilter, highValueFilter, _):
-            let lowValue: String? = value(for: lowValueFilter)
-            let highValue: String? = value(for: highValueFilter)
+        case let .range(lowValueFilter, highValueFilter, config):
+            let lowValue: Int? = value(for: lowValueFilter)
+            let highValue: Int? = value(for: highValueFilter)
 
             if lowValue == nil && highValue == nil {
                 return []
             } else {
-                return ["\(lowValue ?? "...") - \(highValue ?? "...")"]
+                let formattedLowValue = lowValue.flatMap({ config.formatter.string(from: $0) })
+                let formattedHighValue = highValue.flatMap({ config.formatter.string(from: $0) })
+
+                return ["\(formattedLowValue ?? "...") - \(formattedHighValue ?? "...")"]
             }
         case .stepper:
             if let lowValue: Int = value(for: filter) {

--- a/Sources/FINNSetup/Extensions/RangeFilterConfiguration+FINNSetup.swift
+++ b/Sources/FINNSetup/Extensions/RangeFilterConfiguration+FINNSetup.swift
@@ -16,7 +16,7 @@ extension RangeFilterConfiguration {
             accessibilityValueSuffix: nil,
             usesSmallNumberInputFont: maximumValue > 1_000_000,
             displaysUnitInNumberInput: unit != .year,
-            isCurrencyValueRange: unit == .currency
+            formatWithSeparator: unit != .year
         )
     }
 

--- a/Sources/FINNSetup/FilterMarkets/FilterMarketBap.swift
+++ b/Sources/FINNSetup/FilterMarkets/FilterMarketBap.swift
@@ -97,7 +97,7 @@ extension FilterMarketBap: FINNFilterConfiguration {
                 accessibilityValueSuffix: nil,
                 usesSmallNumberInputFont: false,
                 displaysUnitInNumberInput: true,
-                isCurrencyValueRange: true
+                formatWithSeparator: true
             )
         default:
             return nil

--- a/UnitTests/Charcoal/Extensions/NumberFormatterExtensionsTests.swift
+++ b/UnitTests/Charcoal/Extensions/NumberFormatterExtensionsTests.swift
@@ -6,8 +6,8 @@
 import XCTest
 
 final class NumberFormatterExtensionsTests: XCTestCase {
-    func testFormatterWithSeparator() {
-        let formatter = NumberFormatter.formatterWithSeparator
+    func testDecimalFormatter() {
+        let formatter = NumberFormatter.decimalFormatter
         XCTAssertEqual(formatter.string(from: 10), "10")
         XCTAssertEqual(formatter.string(from: 100), "100")
         XCTAssertEqual(formatter.string(from: 1000), "1 000")

--- a/UnitTests/Charcoal/Extensions/NumberFormatterExtensionsTests.swift
+++ b/UnitTests/Charcoal/Extensions/NumberFormatterExtensionsTests.swift
@@ -1,0 +1,18 @@
+//
+//  Copyright © FINN.no AS, Inc. All rights reserved.
+//
+
+@testable import Charcoal
+import XCTest
+
+final class NumberFormatterExtensionsTests: XCTestCase {
+    func testFormatterWithSeparator() {
+        let formatter = NumberFormatter.formatterWithSeparator
+        XCTAssertEqual(formatter.string(from: 10), "10")
+        XCTAssertEqual(formatter.string(from: 100), "100")
+        XCTAssertEqual(formatter.string(from: 1000), "1 000")
+        XCTAssertEqual(formatter.string(from: 10000), "10 000")
+        XCTAssertEqual(formatter.string(from: 100_000), "100 000")
+        XCTAssertEqual(formatter.string(from: 1_000_000), "1 000 000")
+    }
+}

--- a/UnitTests/Charcoal/Models/FilterTests.swift
+++ b/UnitTests/Charcoal/Models/FilterTests.swift
@@ -213,6 +213,11 @@ final class FilterTests: XCTestCase {
         XCTAssertEqual(filter1.subfilters.count, 3)
         XCTAssertEqual(filter1.subfilter(at: 2)?.key, "subkey3")
     }
+
+    func testFormattedNumberOfResults() {
+        let filter = Filter.list(title: "List", key: "list", numberOfResults: 10_000_000)
+        XCTAssertEqual(filter.formattedNumberOfResults, "10 000 000")
+    }
 }
 
 // MARK: - TestDataDecoder

--- a/UnitTests/Charcoal/Models/RangeFilterConfigurationTests.swift
+++ b/UnitTests/Charcoal/Models/RangeFilterConfigurationTests.swift
@@ -17,7 +17,7 @@ final class RangeFilterConfigurationTests: XCTestCase {
             accessibilityValueSuffix: "test",
             usesSmallNumberInputFont: true,
             displaysUnitInNumberInput: true,
-            isCurrencyValueRange: false
+            formatWithSeparator: false
         )
 
         XCTAssertEqual(config.minimumValue, 100)
@@ -30,7 +30,7 @@ final class RangeFilterConfigurationTests: XCTestCase {
         XCTAssertEqual(config.accessibilityValueSuffix, "test")
         XCTAssertTrue(config.usesSmallNumberInputFont)
         XCTAssertTrue(config.displaysUnitInNumberInput)
-        XCTAssertFalse(config.isCurrencyValueRange)
+        XCTAssertFalse(config.formatWithSeparator)
     }
 
     func testInitWithStepValuesAndOffsets() {
@@ -44,7 +44,7 @@ final class RangeFilterConfigurationTests: XCTestCase {
             accessibilityValueSuffix: "test",
             usesSmallNumberInputFont: true,
             displaysUnitInNumberInput: true,
-            isCurrencyValueRange: false
+            formatWithSeparator: false
         )
 
         XCTAssertEqual(config.minimumValue, 100)
@@ -57,7 +57,7 @@ final class RangeFilterConfigurationTests: XCTestCase {
         XCTAssertEqual(config.accessibilityValueSuffix, "test")
         XCTAssertTrue(config.usesSmallNumberInputFont)
         XCTAssertTrue(config.displaysUnitInNumberInput)
-        XCTAssertFalse(config.isCurrencyValueRange)
+        XCTAssertFalse(config.formatWithSeparator)
     }
 
     func testReferenceValuesWithTwoElements() {
@@ -71,7 +71,7 @@ final class RangeFilterConfigurationTests: XCTestCase {
             accessibilityValueSuffix: "test",
             usesSmallNumberInputFont: true,
             displaysUnitInNumberInput: true,
-            isCurrencyValueRange: false
+            formatWithSeparator: false
         )
 
         XCTAssertEqual(config.referenceValues, [0, 1])
@@ -88,7 +88,7 @@ final class RangeFilterConfigurationTests: XCTestCase {
             accessibilityValueSuffix: "test",
             usesSmallNumberInputFont: true,
             displaysUnitInNumberInput: true,
-            isCurrencyValueRange: false
+            formatWithSeparator: false
         )
 
         XCTAssertEqual(config.minimumValue, 100)
@@ -101,7 +101,7 @@ final class RangeFilterConfigurationTests: XCTestCase {
         XCTAssertEqual(config.accessibilityValueSuffix, "test")
         XCTAssertTrue(config.usesSmallNumberInputFont)
         XCTAssertTrue(config.displaysUnitInNumberInput)
-        XCTAssertFalse(config.isCurrencyValueRange)
+        XCTAssertFalse(config.formatWithSeparator)
     }
 
     func testInitWithIntervals() {
@@ -122,7 +122,7 @@ final class RangeFilterConfigurationTests: XCTestCase {
             accessibilityValueSuffix: "test",
             usesSmallNumberInputFont: false,
             displaysUnitInNumberInput: true,
-            isCurrencyValueRange: true
+            formatWithSeparator: true
         )
 
         XCTAssertEqual(config.minimumValue, 0)
@@ -135,7 +135,7 @@ final class RangeFilterConfigurationTests: XCTestCase {
         XCTAssertEqual(config.accessibilityValueSuffix, "test")
         XCTAssertFalse(config.usesSmallNumberInputFont)
         XCTAssertTrue(config.displaysUnitInNumberInput)
-        XCTAssertTrue(config.isCurrencyValueRange)
+        XCTAssertTrue(config.formatWithSeparator)
     }
 
     func testValueForStepWithoutOffsets() {
@@ -149,7 +149,7 @@ final class RangeFilterConfigurationTests: XCTestCase {
             accessibilityValueSuffix: "test",
             usesSmallNumberInputFont: true,
             displaysUnitInNumberInput: true,
-            isCurrencyValueRange: false
+            formatWithSeparator: false
         )
 
         XCTAssertNil(config.value(for: .lowerBound))
@@ -170,7 +170,7 @@ final class RangeFilterConfigurationTests: XCTestCase {
             accessibilityValueSuffix: "test",
             usesSmallNumberInputFont: true,
             displaysUnitInNumberInput: true,
-            isCurrencyValueRange: false
+            formatWithSeparator: false
         )
 
         XCTAssertEqual(config.value(for: .lowerBound), 0)

--- a/UnitTests/Charcoal/Models/RangerFilterConfiguration+Stubs.swift
+++ b/UnitTests/Charcoal/Models/RangerFilterConfiguration+Stubs.swift
@@ -17,7 +17,7 @@ extension RangeFilterConfiguration {
             accessibilityValueSuffix: nil,
             usesSmallNumberInputFont: false,
             displaysUnitInNumberInput: true,
-            isCurrencyValueRange: true
+            formatWithSeparator: true
         )
     }
 }


### PR DESCRIPTION
# Why?

Because big numbers look better with separator.

# What?

- Add static number formatter to use across the app
- Format numbers with thousand separator everywhere except for years

# Show me

### Before

![before](https://user-images.githubusercontent.com/10529867/55080095-cbc0ab80-509d-11e9-8235-c3890d761f0d.gif)

### After

![after](https://user-images.githubusercontent.com/10529867/55080107-cfecc900-509d-11e9-881f-83bf0f42d25f.gif)