### PR TITLE
Show unit in selection tags for ranges

### DIFF
--- a/Sources/Charcoal/Selection/FilterSelectionStore.swift
+++ b/Sources/Charcoal/Selection/FilterSelectionStore.swift
@@ -139,8 +139,8 @@ extension FilterSelectionStore {
             } else {
                 let formattedLowValue = lowValue.flatMap({ config.formatter.string(from: $0) })
                 let formattedHighValue = highValue.flatMap({ config.formatter.string(from: $0) })
-
-                return ["\(formattedLowValue ?? "...") - \(formattedHighValue ?? "...")"]
+                let suffix = config.displaysUnitInNumberInput ? " \(config.unit)" : ""
+                return ["\(formattedLowValue ?? "...") - \(formattedHighValue ?? "...")\(suffix)"]
             }
         case .stepper:
             if let lowValue: Int = value(for: filter) {

--- a/Sources/FINNSetup/FilterMarkets/FilterMarketBoat.swift
+++ b/Sources/FINNSetup/FilterMarkets/FilterMarketBoat.swift
@@ -161,7 +161,7 @@ extension FilterMarketBoat: FINNFilterConfiguration {
         case .motorSize:
             return .horsePowerConfiguration(minimumValue: 0, maximumValue: 500)
         case .noOfSeats:
-            return .numberOfItemsConfiguration(minimumValue: 0, maximumValue: 20)
+            return .numberOfSeatsConfiguration(maximumValue: 20)
         case .noOfSleepers:
             return .numberOfItemsConfiguration(minimumValue: 0, maximumValue: 10)
         case .width:

--- a/UnitTests/Charcoal/Selection/FilterSelectionStoreTests.swift
+++ b/UnitTests/Charcoal/Selection/FilterSelectionStoreTests.swift
@@ -188,15 +188,23 @@ final class FilterSelectionStoreTests: XCTestCase {
 
         store.setValue(10, for: lowValueFilter)
         store.removeValues(for: highValueFilter)
-        XCTAssertEqual(store.titles(for: filter), ["10 - ..."])
+        XCTAssertEqual(store.titles(for: filter), ["10 - ... kr"])
 
         store.removeValues(for: lowValueFilter)
         store.setValue(100, for: highValueFilter)
-        XCTAssertEqual(store.titles(for: filter), ["... - 100"])
+        XCTAssertEqual(store.titles(for: filter), ["... - 100 kr"])
 
         store.setValue(10, for: lowValueFilter)
         store.setValue(100, for: highValueFilter)
-        XCTAssertEqual(store.titles(for: filter), ["10 - 100"])
+        XCTAssertEqual(store.titles(for: filter), ["10 - 100 kr"])
+    }
+
+    func testTitlesWithSteppers() {
+        let config = StepperFilterConfiguration(minimumValue: 0, maximumValue: 10, unit: "stk.")
+        let filter = Filter.stepper(title: "Stepper", key: "stepper", config: config)
+
+        store.setValue(10, for: filter)
+        XCTAssertEqual(store.titles(for: filter), ["10+"])
     }
 
     func testTitlesWithMap() {


### PR DESCRIPTION
# Why?

Because you should be able to see unit in addition to selected number.

# What?

Show unit in selection tags for ranges.

# Show me

![Simulator Screen Shot - iPhone XS - 2019-03-27 at 16 45 16](https://user-images.githubusercontent.com/10529867/55091308-e51f2300-50b0-11e9-82db-abdc1a2f39a0.png)
