### PR TITLE
Show current user location straight after granting permissions

### DIFF
--- a/Sources/Charcoal/Filters/Map/MapFilterViewController.swift
+++ b/Sources/Charcoal/Filters/Map/MapFilterViewController.swift
@@ -90,8 +90,6 @@ final class MapFilterViewController: FilterViewController {
 
         showBottomButton(true, animated: false)
         setup()
-
-        locationManager.delegate = self
     }
 
     override func filterBottomButtonView(_ filterBottomButtonView: FilterBottomButtonView, didTapButton button: UIButton) {
@@ -212,20 +210,11 @@ extension MapFilterViewController: MKMapViewDelegate {
 
         nextRegionChangeIsFromUserInteraction = false
     }
-}
 
-// MARK: - CLLocationManagerDelegate
-
-extension MapFilterViewController: CLLocationManagerDelegate {
-    func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
-        switch status {
-        case .authorizedAlways, .authorizedWhenInUse:
-            if hasRequestedLocationAuthorization {
-                hasRequestedLocationAuthorization = false
-                centerOnUserLocation()
-            }
-        case .denied, .notDetermined, .restricted:
-            break
+    func mapView(_ mapView: MKMapView, didUpdate userLocation: MKUserLocation) {
+        if hasRequestedLocationAuthorization {
+            centerOnUserLocation()
+            hasRequestedLocationAuthorization = false
         }
     }
 }


### PR DESCRIPTION
# Why?

Because it makes sense to show current location when the user has granted permissions to use location services.

# What?

Show current user location straight after granting permissions. Before you had to click location button one more time.

# Show me

No UI changes.