### PR TITLE
Don't show context filter if it has only one subfilter

### DIFF
--- a/Sources/FINNSetup/BackendModel/FilterSetup.swift
+++ b/Sources/FINNSetup/BackendModel/FilterSetup.swift
@@ -81,7 +81,7 @@ public struct FilterSetup: Decodable {
             return Filter.search(key: key)
         case FilterKey.preferences.rawValue:
             let subfilters = config.preferenceFilters.compactMap {
-                filterData(forKey: $0).map({ makeListFilter(from: $0, withStyle: .normal) })
+                filterData(forKey: $0).flatMap({ makeListFilter(from: $0, withStyle: .normal) })
             }
             return Filter.inline(title: "", key: key, subfilters: subfilters)
         case FilterKey.map.rawValue:
@@ -132,17 +132,21 @@ public struct FilterSetup: Decodable {
         )
     }
 
-    private func makeListFilter(from filterData: FilterData, withStyle style: Filter.Style) -> Filter {
+    private func makeListFilter(from filterData: FilterData, withStyle style: Filter.Style) -> Filter? {
         let subfilters = filterData.queries.compactMap({
             makeListFilter(withKey: filterData.parameterName, from: $0)
         })
 
-        return Filter.list(
-            title: filterData.title,
-            key: filterData.parameterName,
-            style: style,
-            subfilters: subfilters
-        )
+        if style == .context && subfilters.count < 2 {
+            return nil
+        } else {
+            return Filter.list(
+                title: filterData.title,
+                key: filterData.parameterName,
+                style: style,
+                subfilters: subfilters
+            )
+        }
     }
 
     private func makeListFilter(withKey key: String, from query: FilterDataQuery) -> Filter {

--- a/UnitTests/FINNSetup/Mocks/ContextFilterTestData.json
+++ b/UnitTests/FINNSetup/Mocks/ContextFilterTestData.json
@@ -16,7 +16,21 @@
         },
         "shoe_size": {
             "title": "Skostørrelse",
-            "name": "shoe_size"
+            "name": "shoe_size",
+            "queries": [
+                {
+                    "title": "38",
+                    "name": "shoe_size_1",
+                    "value": "1.744.842",
+                    "total-results": 11
+                },
+                {
+                    "title": "40",
+                    "name": "shoe_size_2",
+                    "value": "1.744.841",
+                    "total-results": 10
+                }
+            ]
         }
     }
 }


### PR DESCRIPTION
# Why?

Because it doesn't affect the search results in any way if you select the only subfilter of a context filter.

# What?

Don't show context filter if it has only one subfilter.

# Show me

No UI changes.