### PR TITLE
Fix Inline Filter scrollToItem crash

### DIFF
--- a/Sources/Charcoal/Filters/Inline/InlineFilterView.swift
+++ b/Sources/Charcoal/Filters/Inline/InlineFilterView.swift
@@ -70,7 +70,8 @@ final class InlineFilterView: UIView {
     }
 
     func resetContentOffset() {
-        collectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .left, animated: false)
+        let section = vertical == nil ? 1 : 0
+        collectionView.scrollToItem(at: IndexPath(item: 0, section: section), at: .left, animated: false)
     }
 }
 


### PR DESCRIPTION
# Why?

There was a bug where `scrollToItem` would crash because the index path was invalid. 

# What?

- Make sure index path is valid by checking if there is a vertical in section 0. Otherwise scroll to item 0 in section 1.

# Show me

No UI