### PR TITLE
Make inline filter cell not selectable

### DIFF
--- a/Sources/Charcoal/Filters/Root/Views/InlineFilterCell.swift
+++ b/Sources/Charcoal/Filters/Root/Views/InlineFilterCell.swift
@@ -41,6 +41,7 @@ final class InlineFilterCell: UITableViewCell {
     }
 
     private func setup() {
+        selectionStyle = .none
         contentView.addSubview(inlineFilterView)
         inlineFilterView.fillInSuperview(insets: UIEdgeInsets(top: 0, leading: 0, bottom: -.smallSpacing, trailing: 0))
     }


### PR DESCRIPTION
# Why?

Because inline filter cell shouldn't be selectable.

# What?

Make inline filter cell not selectable.

# Show me

No UI.