### PR TITLE
Change "til" to "opptil" in selection tags

### DIFF
--- a/Sources/Charcoal/Models/FilterUnit.swift
+++ b/Sources/Charcoal/Models/FilterUnit.swift
@@ -118,7 +118,7 @@ public enum FilterUnit: Equatable {
         }
     }
 
-    public var tilValueText: String {
+    public var toValueText: String {
         switch self {
         case .year:
             return "before".localized().lowercased()

--- a/Sources/Charcoal/Models/FilterUnit.swift
+++ b/Sources/Charcoal/Models/FilterUnit.swift
@@ -123,7 +123,7 @@ public enum FilterUnit: Equatable {
         case .year:
             return "before".localized().lowercased()
         default:
-            return "to".localized().lowercased()
+            return "upTo".localized().lowercased()
         }
     }
 }

--- a/Sources/Charcoal/Resources/en.lproj/Localizable.strings
+++ b/Sources/Charcoal/Resources/en.lproj/Localizable.strings
@@ -18,7 +18,7 @@
 "before" = "Før";
 "after" = "Etter";
 "from" = "fra";
-"to" = "til";
+"upTo" = "opptil";
 "remove" = "Fjern";
 "selected" = "Markert";
 "numberOfResults" = "Treff";

--- a/Sources/Charcoal/Selection/FilterSelectionStore.swift
+++ b/Sources/Charcoal/Selection/FilterSelectionStore.swift
@@ -147,7 +147,7 @@ extension FilterSelectionStore {
             case let (.some(lowValue), .none):
                 value = "\(config.unit.fromValueText) \(lowValue)"
             case let (.none, .some(highValue)):
-                value = "\(config.unit.tilValueText) \(highValue)"
+                value = "\(config.unit.toValueText) \(highValue)"
             case let (.some(lowValue), .some(highValue)):
                 value = "\(lowValue) - \(highValue)"
             }

--- a/Sources/Charcoal/Selection/FilterSelectionStore.swift
+++ b/Sources/Charcoal/Selection/FilterSelectionStore.swift
@@ -246,7 +246,7 @@ extension FilterSelectionStore {
 private extension String {
     var accessibilityLabelForRanges: String {
         if contains("-") {
-            let formattedAccessibilityLabel = replacingOccurrences(of: "-", with: "to".localized())
+            let formattedAccessibilityLabel = replacingOccurrences(of: "-", with: "upTo".localized())
             return "from".localized() + " " + formattedAccessibilityLabel
         } else {
             return self

--- a/UnitTests/Charcoal/Models/FilterUnitTests.swift
+++ b/UnitTests/Charcoal/Models/FilterUnitTests.swift
@@ -102,18 +102,18 @@ final class FilterUnitTests: XCTestCase {
         XCTAssertEqual(customUnit.fromValueText, "from".localized())
     }
 
-    func testTilValueText() {
-        XCTAssertEqual(FilterUnit.centimeters.tilValueText, "upTo".localized())
-        XCTAssertEqual(FilterUnit.cubicCentimeters.tilValueText, "upTo".localized())
-        XCTAssertEqual(FilterUnit.currency.tilValueText, "upTo".localized())
-        XCTAssertEqual(FilterUnit.feet.tilValueText, "upTo".localized())
-        XCTAssertEqual(FilterUnit.horsePower.tilValueText, "upTo".localized())
-        XCTAssertEqual(FilterUnit.items.tilValueText, "upTo".localized())
-        XCTAssertEqual(FilterUnit.kilograms.tilValueText, "upTo".localized())
-        XCTAssertEqual(FilterUnit.kilometers.tilValueText, "upTo".localized())
-        XCTAssertEqual(FilterUnit.seats.tilValueText, "upTo".localized())
-        XCTAssertEqual(FilterUnit.squareMeters.tilValueText, "upTo".localized())
-        XCTAssertEqual(FilterUnit.year.tilValueText, "before".localized().lowercased())
-        XCTAssertEqual(customUnit.tilValueText, "upTo".localized())
+    func testToValueText() {
+        XCTAssertEqual(FilterUnit.centimeters.toValueText, "upTo".localized())
+        XCTAssertEqual(FilterUnit.cubicCentimeters.toValueText, "upTo".localized())
+        XCTAssertEqual(FilterUnit.currency.toValueText, "upTo".localized())
+        XCTAssertEqual(FilterUnit.feet.toValueText, "upTo".localized())
+        XCTAssertEqual(FilterUnit.horsePower.toValueText, "upTo".localized())
+        XCTAssertEqual(FilterUnit.items.toValueText, "upTo".localized())
+        XCTAssertEqual(FilterUnit.kilograms.toValueText, "upTo".localized())
+        XCTAssertEqual(FilterUnit.kilometers.toValueText, "upTo".localized())
+        XCTAssertEqual(FilterUnit.seats.toValueText, "upTo".localized())
+        XCTAssertEqual(FilterUnit.squareMeters.toValueText, "upTo".localized())
+        XCTAssertEqual(FilterUnit.year.toValueText, "before".localized().lowercased())
+        XCTAssertEqual(customUnit.toValueText, "upTo".localized())
     }
 }

--- a/UnitTests/Charcoal/Models/FilterUnitTests.swift
+++ b/UnitTests/Charcoal/Models/FilterUnitTests.swift
@@ -103,17 +103,17 @@ final class FilterUnitTests: XCTestCase {
     }
 
     func testTilValueText() {
-        XCTAssertEqual(FilterUnit.centimeters.tilValueText, "to".localized())
-        XCTAssertEqual(FilterUnit.cubicCentimeters.tilValueText, "to".localized())
-        XCTAssertEqual(FilterUnit.currency.tilValueText, "to".localized())
-        XCTAssertEqual(FilterUnit.feet.tilValueText, "to".localized())
-        XCTAssertEqual(FilterUnit.horsePower.tilValueText, "to".localized())
-        XCTAssertEqual(FilterUnit.items.tilValueText, "to".localized())
-        XCTAssertEqual(FilterUnit.kilograms.tilValueText, "to".localized())
-        XCTAssertEqual(FilterUnit.kilometers.tilValueText, "to".localized())
-        XCTAssertEqual(FilterUnit.seats.tilValueText, "to".localized())
-        XCTAssertEqual(FilterUnit.squareMeters.tilValueText, "to".localized())
+        XCTAssertEqual(FilterUnit.centimeters.tilValueText, "upTo".localized())
+        XCTAssertEqual(FilterUnit.cubicCentimeters.tilValueText, "upTo".localized())
+        XCTAssertEqual(FilterUnit.currency.tilValueText, "upTo".localized())
+        XCTAssertEqual(FilterUnit.feet.tilValueText, "upTo".localized())
+        XCTAssertEqual(FilterUnit.horsePower.tilValueText, "upTo".localized())
+        XCTAssertEqual(FilterUnit.items.tilValueText, "upTo".localized())
+        XCTAssertEqual(FilterUnit.kilograms.tilValueText, "upTo".localized())
+        XCTAssertEqual(FilterUnit.kilometers.tilValueText, "upTo".localized())
+        XCTAssertEqual(FilterUnit.seats.tilValueText, "upTo".localized())
+        XCTAssertEqual(FilterUnit.squareMeters.tilValueText, "upTo".localized())
         XCTAssertEqual(FilterUnit.year.tilValueText, "before".localized().lowercased())
-        XCTAssertEqual(customUnit.tilValueText, "to".localized())
+        XCTAssertEqual(customUnit.tilValueText, "upTo".localized())
     }
 }

--- a/UnitTests/Charcoal/Selection/FilterSelectionStoreTests.swift
+++ b/UnitTests/Charcoal/Selection/FilterSelectionStoreTests.swift
@@ -195,13 +195,13 @@ final class FilterSelectionStoreTests: XCTestCase {
         store.removeValues(for: lowValueFilter)
         store.setValue(100, for: highValueFilter)
         XCTAssertEqual(store.titles(for: filter), [
-            SelectionTitle(value: "til 100 kr", accessibilityLabel: "til 100 kroner"),
+            SelectionTitle(value: "opptil 100 kr", accessibilityLabel: "opptil 100 kroner"),
         ])
 
         store.setValue(10, for: lowValueFilter)
         store.setValue(100, for: highValueFilter)
         XCTAssertEqual(store.titles(for: filter), [
-            SelectionTitle(value: "10 - 100 kr", accessibilityLabel: "fra 10 til 100 kroner"),
+            SelectionTitle(value: "10 - 100 kr", accessibilityLabel: "fra 10 opptil 100 kroner"),
         ])
     }
 


### PR DESCRIPTION
# Why?

Because it makes sense to mention that the upper values is also included in selection.

# What?

Change "til" to "opptil" in selection tags, both in UI and VoiceOver.

# Show me

![Simulator Screen Shot - iPhone XS - 2019-04-03 at 11 07 08](https://user-images.githubusercontent.com/10529867/55467003-a9301480-5600-11e9-8372-e05802741496.png)

