### PR TITLE
Capitalize selection tag for ranges

### DIFF
--- a/Sources/Charcoal/Models/FilterUnit.swift
+++ b/Sources/Charcoal/Models/FilterUnit.swift
@@ -112,18 +112,18 @@ public enum FilterUnit: Equatable {
     public var fromValueText: String {
         switch self {
         case .year:
-            return "after".localized().lowercased()
+            return "after".localized()
         default:
-            return "from".localized().lowercased()
+            return "from".localized()
         }
     }
 
     public var toValueText: String {
         switch self {
         case .year:
-            return "before".localized().lowercased()
+            return "before".localized()
         default:
-            return "upTo".localized().lowercased()
+            return "upTo".localized()
         }
     }
 }

--- a/Sources/Charcoal/Resources/en.lproj/Localizable.strings
+++ b/Sources/Charcoal/Resources/en.lproj/Localizable.strings
@@ -17,8 +17,8 @@
 "under" = "Under";
 "before" = "Før";
 "after" = "Etter";
-"from" = "fra";
-"upTo" = "opptil";
+"from" = "Fra";
+"upTo" = "Opptil";
 "remove" = "Fjern";
 "selected" = "Markert";
 "numberOfResults" = "Treff";

--- a/UnitTests/Charcoal/Models/FilterUnitTests.swift
+++ b/UnitTests/Charcoal/Models/FilterUnitTests.swift
@@ -98,7 +98,7 @@ final class FilterUnitTests: XCTestCase {
         XCTAssertEqual(FilterUnit.kilometers.fromValueText, "from".localized())
         XCTAssertEqual(FilterUnit.seats.fromValueText, "from".localized())
         XCTAssertEqual(FilterUnit.squareMeters.fromValueText, "from".localized())
-        XCTAssertEqual(FilterUnit.year.fromValueText, "after".localized().lowercased())
+        XCTAssertEqual(FilterUnit.year.fromValueText, "after".localized())
         XCTAssertEqual(customUnit.fromValueText, "from".localized())
     }
 
@@ -113,7 +113,7 @@ final class FilterUnitTests: XCTestCase {
         XCTAssertEqual(FilterUnit.kilometers.toValueText, "upTo".localized())
         XCTAssertEqual(FilterUnit.seats.toValueText, "upTo".localized())
         XCTAssertEqual(FilterUnit.squareMeters.toValueText, "upTo".localized())
-        XCTAssertEqual(FilterUnit.year.toValueText, "before".localized().lowercased())
+        XCTAssertEqual(FilterUnit.year.toValueText, "before".localized())
         XCTAssertEqual(customUnit.toValueText, "upTo".localized())
     }
 }

--- a/UnitTests/Charcoal/Selection/FilterSelectionStoreTests.swift
+++ b/UnitTests/Charcoal/Selection/FilterSelectionStoreTests.swift
@@ -189,19 +189,19 @@ final class FilterSelectionStoreTests: XCTestCase {
         store.setValue(10, for: lowValueFilter)
         store.removeValues(for: highValueFilter)
         XCTAssertEqual(store.titles(for: filter), [
-            SelectionTitle(value: "fra 10 kr", accessibilityLabel: "fra 10 kroner"),
+            SelectionTitle(value: "Fra 10 kr", accessibilityLabel: "Fra 10 kroner"),
         ])
 
         store.removeValues(for: lowValueFilter)
         store.setValue(100, for: highValueFilter)
         XCTAssertEqual(store.titles(for: filter), [
-            SelectionTitle(value: "opptil 100 kr", accessibilityLabel: "opptil 100 kroner"),
+            SelectionTitle(value: "Opptil 100 kr", accessibilityLabel: "Opptil 100 kroner"),
         ])
 
         store.setValue(10, for: lowValueFilter)
         store.setValue(100, for: highValueFilter)
         XCTAssertEqual(store.titles(for: filter), [
-            SelectionTitle(value: "10 - 100 kr", accessibilityLabel: "fra 10 opptil 100 kroner"),
+            SelectionTitle(value: "10 - 100 kr", accessibilityLabel: "Fra 10 Opptil 100 kroner"),
         ])
     }
 


### PR DESCRIPTION
# Why?

Because it looks better this way.

# What?

Capitalize selection tag for ranges

# Show me

![Simulator Screen Shot - iPhone XS - 2019-04-04 at 10 26 57](https://user-images.githubusercontent.com/10529867/55540980-57e95900-56c4-11e9-9213-26b716781edb.png)
