### PR TITLE
Replace bottom UIButton with FinniversKit Button

### DIFF
--- a/Sources/Charcoal/Filters/FilterViewController.swift
+++ b/Sources/Charcoal/Filters/FilterViewController.swift
@@ -65,7 +65,6 @@ class FilterViewController: UIViewController, FilterBottomButtonViewDelegate {
             bottomButton.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             bottomButton.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             bottomButton.topAnchor.constraint(lessThanOrEqualTo: view.bottomAnchor),
-            bottomButton.heightAnchor.constraint(equalToConstant: bottomButton.height),
         ])
     }
 

--- a/Sources/Charcoal/Filters/Map/MapFilterViewController.swift
+++ b/Sources/Charcoal/Filters/Map/MapFilterViewController.swift
@@ -107,7 +107,7 @@ final class MapFilterViewController: FilterViewController {
 
         NSLayoutConstraint.activate([
             mapFilterView.topAnchor.constraint(equalTo: view.topAnchor),
-            mapFilterView.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -bottomButton.height),
+            mapFilterView.bottomAnchor.constraint(equalTo: bottomButton.topAnchor),
             mapFilterView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             mapFilterView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
         ])

--- a/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
+++ b/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
@@ -71,7 +71,6 @@ final class RootFilterViewController: FilterViewController {
 
         showBottomButton(true, animated: false)
         updateBottomButtonTitle()
-        tableView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: bottomButton.height, right: 0)
         setup()
     }
 
@@ -103,7 +102,7 @@ final class RootFilterViewController: FilterViewController {
             tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             tableView.topAnchor.constraint(equalTo: view.topAnchor),
             tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            tableView.bottomAnchor.constraint(equalTo: bottomButton.topAnchor),
         ])
     }
 

--- a/Sources/Charcoal/Filters/Root/Views/FilterBottomButtonView.swift
+++ b/Sources/Charcoal/Filters/Root/Views/FilterBottomButtonView.swift
@@ -18,10 +18,9 @@ class FilterBottomButtonView: UIView {
         return button
     }()
 
-    private let buttonHeight: CGFloat = 44
-
-    var height: CGFloat {
-        return buttonHeight + .mediumLargeSpacing * 2.0
+    override var intrinsicContentSize: CGSize {
+        return CGSize(width: button.intrinsicContentSize.width,
+                      height: button.intrinsicContentSize.height + .largeSpacing)
     }
 
     init() {

--- a/Sources/Charcoal/Filters/Root/Views/FilterBottomButtonView.swift
+++ b/Sources/Charcoal/Filters/Root/Views/FilterBottomButtonView.swift
@@ -2,7 +2,7 @@
 //  Copyright © FINN.no AS, Inc. All rights reserved.
 //
 
-import UIKit
+import FinniversKit
 
 protocol FilterBottomButtonViewDelegate: AnyObject {
     func filterBottomButtonView(_ filterBottomButtonView: FilterBottomButtonView, didTapButton button: UIButton)
@@ -11,17 +11,14 @@ protocol FilterBottomButtonViewDelegate: AnyObject {
 class FilterBottomButtonView: UIView {
     weak var delegate: FilterBottomButtonViewDelegate?
 
-    private lazy var button: UIButton = {
-        let button = UIButton(frame: .zero)
-        button.backgroundColor = .primaryBlue
-        button.setTitleColor(.milk, for: .normal)
-        button.titleLabel?.font = .bodyStrong
-        button.layer.cornerRadius = 8
+    private lazy var button: Button = {
+        let button = Button(style: .callToAction)
         button.addTarget(self, action: #selector(didTapButton), for: .touchUpInside)
+        button.translatesAutoresizingMaskIntoConstraints = false
         return button
     }()
 
-    private let buttonHeight: CGFloat = 52
+    private let buttonHeight: CGFloat = 44
 
     var height: CGFloat {
         return buttonHeight + .mediumLargeSpacing * 2.0
@@ -41,7 +38,6 @@ class FilterBottomButtonView: UIView {
 private extension FilterBottomButtonView {
     func setup() {
         backgroundColor = .milk
-        button.translatesAutoresizingMaskIntoConstraints = false
         addSubview(button)
 
         let separatorLine = UIView(frame: .zero)
@@ -54,7 +50,6 @@ private extension FilterBottomButtonView {
             button.leadingAnchor.constraint(equalTo: leadingAnchor, constant: .mediumLargeSpacing),
             button.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -.mediumLargeSpacing),
             button.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -.mediumLargeSpacing),
-            button.heightAnchor.constraint(equalToConstant: buttonHeight),
 
             separatorLine.topAnchor.constraint(equalTo: topAnchor),
             separatorLine.leadingAnchor.constraint(equalTo: leadingAnchor),

--- a/Sources/Charcoal/Filters/Stepper/StepperViewController.swift
+++ b/Sources/Charcoal/Filters/Stepper/StepperViewController.swift
@@ -53,7 +53,7 @@ final class StepperFilterViewController: FilterViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        topConstraint.constant = (view.frame.height - bottomButton.height) / 2
+        topConstraint.constant = (view.frame.height - bottomButton.intrinsicContentSize.height) / 2
     }
 }
 


### PR DESCRIPTION
# Why?

Bottom button was too big. The way we had set up constraints could potentially be wrong with big fonts.

# What?

- Changed button from `UIButton` to `Button`
- Replaced constant button height with intrinsic content size
- Update constraints

# Show me

![bottom-button](https://user-images.githubusercontent.com/19956175/55556358-ae1bc380-56e7-11e9-9b88-71b68ef3833e.gif)
