### PR TITLE
Hide free text search when search bar did end editing

### DIFF
--- a/Sources/Charcoal/Filters/FreeText/FreeTextFilterViewController.swift
+++ b/Sources/Charcoal/Filters/FreeText/FreeTextFilterViewController.swift
@@ -212,7 +212,7 @@ private extension FreeTextFilterViewController {
             tableView.topAnchor.constraint(equalTo: searchBar.bottomAnchor),
             tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            ])
+        ])
     }
 }
 

--- a/Sources/Charcoal/Filters/FreeText/FreeTextFilterViewController.swift
+++ b/Sources/Charcoal/Filters/FreeText/FreeTextFilterViewController.swift
@@ -129,6 +129,10 @@ extension FreeTextFilterViewController: UISearchBarDelegate {
         return true
     }
 
+    public func searchBarTextDidEndEditing(_ searchBar: UISearchBar) {
+        returnToSuperView()
+    }
+
     public func searchBarTextDidBeginEditing(_ searchBar: UISearchBar) {
         searchBar.setShowsCancelButton(true, animated: false)
     }
@@ -187,9 +191,11 @@ extension FreeTextFilterViewController: UISearchBarDelegate {
 
 private extension FreeTextFilterViewController {
     func returnToSuperView() {
-        searchBar.endEditing(false)
-        searchBar.setShowsCancelButton(false, animated: false)
-        delegate?.freeTextFilterViewControllerWillEndEditing(self)
+        if view.superview != nil {
+            searchBar.endEditing(false)
+            searchBar.setShowsCancelButton(false, animated: false)
+            delegate?.freeTextFilterViewControllerWillEndEditing(self)
+        }
     }
 
     func setup() {
@@ -206,7 +212,7 @@ private extension FreeTextFilterViewController {
             tableView.topAnchor.constraint(equalTo: searchBar.bottomAnchor),
             tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-        ])
+            ])
     }
 }
 


### PR DESCRIPTION
# Why?

Because we had a bug with free text view still visible when you click on preferences and search bar simultaneously.

# What?

Hide free text search when search bar did end editing

# Show me

No UI changes.