### PR TITLE
Add placeholder text in location search bar

### DIFF
--- a/Sources/Charcoal/Filters/Map/SearchLocationViewController.swift
+++ b/Sources/Charcoal/Filters/Map/SearchLocationViewController.swift
@@ -62,6 +62,7 @@ public class SearchLocationViewController: UIViewController {
 
     private(set) lazy var searchBar: UISearchBar = {
         let searchBar = SearchLocationSearchBar(frame: .zero)
+        searchBar.placeholder = "map.search.placeholder".localized()
         searchBar.searchBarStyle = .minimal
         searchBar.delegate = self
         searchBar.backgroundColor = .milk

--- a/Sources/Charcoal/Resources/en.lproj/Localizable.strings
+++ b/Sources/Charcoal/Resources/en.lproj/Localizable.strings
@@ -61,6 +61,7 @@
 "map.valueSliderAccessibilityLabel" = "Slider for verdi";
 "map.locationError.title" = "Informasjon";
 "map.locationError.message" = "For å bruke denne funksjonaliteten må du gi oss tilgang til din posisjon. Dette gjøres i hovedinnstillingene på enheten din, under personvern og deretter stedtjenester.";
+"map.search.placeholder" = "Søk etter sted eller adresse";
 
 "onboarding.button.done" = "Ta meg til filteret";
 


### PR DESCRIPTION
# Why?

Because it's good practice to show placeholder in search bars.

# What?

Add placeholder text in location search bar.

# Show me

![Simulator Screen Shot - iPhone XS - 2019-04-09 at 12 28 31](https://user-images.githubusercontent.com/10529867/55793444-3375ee00-5ac3-11e9-9782-da2e2646ed8a.png)
