### PR TITLE
Don't center input separator

### DIFF
--- a/Sources/Charcoal/Filters/Range/Input/RangeNumberInputView.swift
+++ b/Sources/Charcoal/Filters/Range/Input/RangeNumberInputView.swift
@@ -152,14 +152,15 @@ final class RangeNumberInputView: UIView {
             lowValueInputView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -.mediumSpacing),
             lowValueInputView.leadingAnchor.constraint(greaterThanOrEqualTo: leadingAnchor),
             lowValueInputView.trailingAnchor.constraint(equalTo: inputSeparatorView.leadingAnchor, constant: -.mediumSpacing),
+            lowValueInputView.widthAnchor.constraint(lessThanOrEqualTo: widthAnchor, multiplier: 0.6),
 
             highValueInputView.topAnchor.constraint(equalTo: topAnchor, constant: .largeSpacing),
             highValueInputView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -.mediumSpacing),
             highValueInputView.leadingAnchor.constraint(equalTo: inputSeparatorView.trailingAnchor, constant: .mediumSpacing),
             highValueInputView.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor),
+            highValueInputView.widthAnchor.constraint(lessThanOrEqualTo: widthAnchor, multiplier: 0.6),
 
             inputSeparatorView.centerYAnchor.constraint(equalTo: centerYAnchor, constant: 20),
-            inputSeparatorView.centerXAnchor.constraint(equalTo: centerXAnchor),
         ])
     }
 


### PR DESCRIPTION
# Why?

Because it didn't look good with small values.

# What?

- Don't center input separator
- Set maximum width for text fields to make it look better when entering large numbers

# Show me

![range](https://user-images.githubusercontent.com/10529867/55800422-0120bc80-5ad4-11e9-9a91-1b663109ea78.gif)
