### PR TITLE
Range selection tag: show only one number if low and high numbers are equal

### DIFF
--- a/Sources/Charcoal/Selection/FilterSelectionStore.swift
+++ b/Sources/Charcoal/Selection/FilterSelectionStore.swift
@@ -149,7 +149,7 @@ extension FilterSelectionStore {
             case let (.none, .some(highValue)):
                 value = "\(config.unit.toValueText) \(highValue)"
             case let (.some(lowValue), .some(highValue)):
-                value = "\(lowValue) - \(highValue)"
+                value = lowValue == highValue ? "\(lowValue)" : "\(lowValue) - \(highValue)"
             }
 
             if let value = value {


### PR DESCRIPTION
# Why?

Because showing, for example, "1000 kr" is better than "1000 - 1000 kr"

# What?

 Show only one number in the selection tag if low and high numbers are equal

# Show me

![range2](https://user-images.githubusercontent.com/10529867/55801046-750f9480-5ad5-11e9-8eb7-8b73cae2d2f9.gif)
