### PR TITLE
Rename list filter to standard filter

### DIFF
--- a/Demo/Models/DemoVertical.swift
+++ b/Demo/Models/DemoVertical.swift
@@ -1,5 +1,5 @@
 //
-//  Copyright © 2019 FINN.no. All rights reserved.
+//  Copyright © FINN.no AS, Inc. All rights reserved.
 //
 
 import Charcoal

--- a/Sources/Charcoal/CharcoalViewController.swift
+++ b/Sources/Charcoal/CharcoalViewController.swift
@@ -155,6 +155,21 @@ extension CharcoalViewController: FilterViewControllerDelegate {
 
     func filterViewController(_ viewController: FilterViewController, didSelectFilter filter: Filter) {
         switch filter.kind {
+        case .standard:
+            guard !filter.subfilters.isEmpty else { break }
+
+            let listViewController = ListFilterViewController(filter: filter, selectionStore: selectionStore)
+            let showBottomButton = viewController === rootFilterViewController ? false : viewController.isShowingBottomButton
+
+            listViewController.showBottomButton(showBottomButton, animated: false)
+            pushViewController(listViewController)
+        case .grid:
+            guard !filter.subfilters.isEmpty else { break }
+
+            let gridViewController = GridFilterViewController(filter: filter, selectionStore: selectionStore)
+            gridViewController.showBottomButton(viewController.isShowingBottomButton, animated: false)
+
+            pushViewController(gridViewController)
         case let .range(lowValueFilter, highValueFilter, filterConfig):
             let rangeViewController = RangeFilterViewController(
                 title: filter.title,
@@ -185,21 +200,6 @@ extension CharcoalViewController: FilterViewControllerDelegate {
             mapViewController.searchLocationDataSource = searchLocationDataSource
 
             pushViewController(mapViewController)
-        case .list:
-            guard !filter.subfilters.isEmpty else { break }
-
-            let listViewController = ListFilterViewController(filter: filter, selectionStore: selectionStore)
-            let showBottomButton = viewController === rootFilterViewController ? false : viewController.isShowingBottomButton
-
-            listViewController.showBottomButton(showBottomButton, animated: false)
-            pushViewController(listViewController)
-        case .grid:
-            guard !filter.subfilters.isEmpty else { break }
-
-            let gridViewController = GridFilterViewController(filter: filter, selectionStore: selectionStore)
-            gridViewController.showBottomButton(viewController.isShowingBottomButton, animated: false)
-
-            pushViewController(gridViewController)
         case .external:
             selectionDelegate?.charcoalViewController(self, didSelectExternalFilterWithKey: filter.key, value: filter.value)
         }

--- a/Sources/Charcoal/Models/Filter.swift
+++ b/Sources/Charcoal/Models/Filter.swift
@@ -65,19 +65,6 @@ extension Filter: Equatable {
 // MARK: - Factory
 
 extension Filter {
-    public static func list(title: String, key: String, value: String? = nil, numberOfResults: Int = 0,
-                            style: Style = .normal, subfilters: [Filter] = []) -> Filter {
-        return Filter(
-            kind: .standard,
-            title: title,
-            key: key,
-            value: value,
-            numberOfResults: numberOfResults,
-            style: style,
-            subfilters: subfilters
-        )
-    }
-
     public static func freeText(title: String? = nil, key: String) -> Filter {
         let title = title ?? "searchPlaceholder".localized()
         return Filter(title: title, key: key, value: nil, numberOfResults: 0)

--- a/Sources/Charcoal/Models/Filter.swift
+++ b/Sources/Charcoal/Models/Filter.swift
@@ -11,7 +11,7 @@ public final class Filter {
     }
 
     public enum Kind: Equatable {
-        case list
+        case standard
         case grid
         case stepper(config: StepperFilterConfiguration)
         case external
@@ -31,7 +31,7 @@ public final class Filter {
 
     // MARK: - Init
 
-    public init(kind: Kind, title: String, key: String, value: String? = nil, numberOfResults: Int = 0,
+    public init(kind: Kind = .standard, title: String, key: String, value: String? = nil, numberOfResults: Int = 0,
                 style: Style = .normal, subfilters: [Filter] = []) {
         self.title = title
         self.key = key
@@ -68,7 +68,7 @@ extension Filter {
     public static func list(title: String, key: String, value: String? = nil, numberOfResults: Int = 0,
                             style: Style = .normal, subfilters: [Filter] = []) -> Filter {
         return Filter(
-            kind: .list,
+            kind: .standard,
             title: title,
             key: key,
             value: value,
@@ -80,11 +80,11 @@ extension Filter {
 
     public static func freeText(title: String? = nil, key: String) -> Filter {
         let title = title ?? "searchPlaceholder".localized()
-        return Filter(kind: .list, title: title, key: key, value: nil, numberOfResults: 0)
+        return Filter(title: title, key: key, value: nil, numberOfResults: 0)
     }
 
     public static func inline(title: String, key: String, subfilters: [Filter]) -> Filter {
-        return Filter(kind: .list, title: title, key: key, value: nil, numberOfResults: 0, subfilters: subfilters)
+        return Filter(title: title, key: key, value: nil, numberOfResults: 0, subfilters: subfilters)
     }
 
     public static func stepper(title: String, key: String,
@@ -106,8 +106,8 @@ extension Filter {
 
     public static func range(title: String, key: String, lowValueKey: String, highValueKey: String,
                              config: RangeFilterConfiguration, style: Style = .normal) -> Filter {
-        let lowValueFilter = Filter(kind: .list, title: "", key: lowValueKey)
-        let highValueFilter = Filter(kind: .list, title: "", key: highValueKey)
+        let lowValueFilter = Filter(title: "", key: lowValueKey)
+        let highValueFilter = Filter(title: "", key: highValueKey)
         let kind = Kind.range(lowValueFilter: lowValueFilter, highValueFilter: highValueFilter, config: config)
         let subfilters = [lowValueFilter, highValueFilter]
 
@@ -117,10 +117,10 @@ extension Filter {
     public static func map(title: String? = nil, key: String, latitudeKey: String,
                            longitudeKey: String, radiusKey: String, locationKey: String) -> Filter {
         let title = title ?? "map.title".localized()
-        let latitudeFilter = Filter(kind: .list, title: "", key: latitudeKey)
-        let longitudeFilter = Filter(kind: .list, title: "", key: longitudeKey)
-        let radiusFilter = Filter(kind: .list, title: "", key: radiusKey)
-        let locationNameFilter = Filter(kind: .list, title: "", key: locationKey)
+        let latitudeFilter = Filter(title: "", key: latitudeKey)
+        let longitudeFilter = Filter(title: "", key: longitudeKey)
+        let radiusFilter = Filter(title: "", key: radiusKey)
+        let locationNameFilter = Filter(title: "", key: locationKey)
 
         let kind = Kind.map(
             latitudeFilter: latitudeFilter,

--- a/Sources/FINNSetup/BackendModel/FilterSetup.swift
+++ b/Sources/FINNSetup/BackendModel/FilterSetup.swift
@@ -63,7 +63,7 @@ public struct FilterSetup: Decodable {
         }
 
         let preferenceFilters = config.preferenceFilterKeys.compactMap {
-            filterData(forKey: $0).flatMap({ makeFilter(from: $0, withKind: .list, style: .normal) })
+            filterData(forKey: $0).flatMap({ makeFilter(from: $0, withKind: .standard, style: .normal) })
         }
 
         return FilterContainer(
@@ -95,7 +95,7 @@ public struct FilterSetup: Decodable {
                     return nil
                 }
             } else {
-                return makeFilter(from: data, withKind: .list, style: style)
+                return makeFilter(from: data, withKind: .standard, style: style)
             }
         }
     }

--- a/Sources/FINNSetup/BackendModel/FilterSetup.swift
+++ b/Sources/FINNSetup/BackendModel/FilterSetup.swift
@@ -154,7 +154,7 @@ public struct FilterSetup: Decodable {
         if ["2.69.3964.268", "1.69.3965"].contains(query.value) {
             return Filter.external(title: query.title, key: key, value: query.value, numberOfResults: query.totalResults)
         } else {
-            return Filter.list(
+            return Filter(
                 title: query.title,
                 key: key,
                 value: query.value,

--- a/UnitTests/Charcoal/Models/FilterTests.swift
+++ b/UnitTests/Charcoal/Models/FilterTests.swift
@@ -27,7 +27,7 @@ final class FilterTests: XCTestCase {
         XCTAssertEqual(filter.numberOfResults, 10)
         XCTAssertEqual(filter.style, .context)
         XCTAssertEqual(filter.subfilters.count, 2)
-        XCTAssertEqual(filter.kind, .list)
+        XCTAssertEqual(filter.kind, .standard)
     }
 
     func testFreeTextFilter() {
@@ -39,7 +39,7 @@ final class FilterTests: XCTestCase {
         XCTAssertEqual(filter.numberOfResults, 0)
         XCTAssertEqual(filter.style, .normal)
         XCTAssertTrue(filter.subfilters.isEmpty)
-        XCTAssertEqual(filter.kind, .list)
+        XCTAssertEqual(filter.kind, .standard)
     }
 
     func testInlineFilter() {
@@ -55,7 +55,7 @@ final class FilterTests: XCTestCase {
         XCTAssertEqual(filter.numberOfResults, 0)
         XCTAssertEqual(filter.style, .normal)
         XCTAssertEqual(filter.subfilters.count, 2)
-        XCTAssertEqual(filter.kind, .list)
+        XCTAssertEqual(filter.kind, .standard)
     }
 
     func testStepperFilter() {

--- a/UnitTests/Charcoal/Models/FilterTests.swift
+++ b/UnitTests/Charcoal/Models/FilterTests.swift
@@ -9,10 +9,10 @@ import XCTest
 final class FilterTests: XCTestCase {
     func testListFilter() {
         let subfilters = [
-            Filter.list(title: "Child A", key: "childA"),
-            Filter.list(title: "Child B", key: "childB"),
+            Filter(title: "Child A", key: "childA"),
+            Filter(title: "Child B", key: "childB"),
         ]
-        let filter = Filter.list(
+        let filter = Filter(
             title: "List",
             key: "list",
             value: "value",
@@ -44,8 +44,8 @@ final class FilterTests: XCTestCase {
 
     func testInlineFilter() {
         let subfilters = [
-            Filter.list(title: "Child A", key: "childA"),
-            Filter.list(title: "Child B", key: "childB"),
+            Filter(title: "Child A", key: "childA"),
+            Filter(title: "Child B", key: "childB"),
         ]
         let filter = Filter.inline(title: "Inline", key: "inline", subfilters: subfilters)
 
@@ -147,36 +147,36 @@ final class FilterTests: XCTestCase {
     }
 
     func testEquatable() {
-        var filter1 = Filter.list(title: "Title1", key: "key1")
-        var filter2 = Filter.list(title: "Title1", key: "key1")
+        var filter1 = Filter(title: "Title1", key: "key1")
+        var filter2 = Filter(title: "Title1", key: "key1")
         XCTAssertEqual(filter1, filter2)
 
-        filter1 = Filter.list(title: "Title1", key: "key1")
-        filter2 = Filter.list(title: "Title1", key: "key1", value: "value1")
+        filter1 = Filter(title: "Title1", key: "key1")
+        filter2 = Filter(title: "Title1", key: "key1", value: "value1")
         XCTAssertNotEqual(filter1, filter2)
 
-        filter1 = Filter.list(title: "Title1", key: "key1")
-        filter2 = Filter.list(title: "Title1", key: "key2")
+        filter1 = Filter(title: "Title1", key: "key1")
+        filter2 = Filter(title: "Title1", key: "key2")
         XCTAssertNotEqual(filter1, filter2)
 
-        filter1 = Filter.list(title: "Title1", key: "key1", value: "value1")
-        filter2 = Filter.list(title: "Title1", key: "key1", value: "value2")
+        filter1 = Filter(title: "Title1", key: "key1", value: "value1")
+        filter2 = Filter(title: "Title1", key: "key1", value: "value2")
         XCTAssertNotEqual(filter1, filter2)
 
-        filter1 = Filter.list(title: "Title1", key: "key1", value: "value1")
-        filter2 = Filter.list(title: "Title1", key: "key1", value: "value1")
+        filter1 = Filter(title: "Title1", key: "key1", value: "value1")
+        filter2 = Filter(title: "Title1", key: "key1", value: "value1")
         XCTAssertEqual(filter1, filter2)
     }
 
     func testMergeFilters() {
-        let filter1 = Filter.list(title: "Title1", key: "key1", subfilters: [
-            Filter.list(title: "Subtitle1", key: "subkey1"),
-            Filter.list(title: "Subtitle3", key: "subkey3"),
+        let filter1 = Filter(title: "Title1", key: "key1", subfilters: [
+            Filter(title: "Subtitle1", key: "subkey1"),
+            Filter(title: "Subtitle3", key: "subkey3"),
         ])
 
-        let filter2 = Filter.list(title: "Title1", key: "key1", subfilters: [
-            Filter.list(title: "Subtitle1", key: "subkey1"),
-            Filter.list(title: "Subtitle2", key: "subkey2"),
+        let filter2 = Filter(title: "Title1", key: "key1", subfilters: [
+            Filter(title: "Subtitle1", key: "subkey1"),
+            Filter(title: "Subtitle2", key: "subkey2"),
         ])
 
         filter1.mergeSubfilters(with: filter2)

--- a/UnitTests/Charcoal/Selection/FilterSelectionStoreTests.swift
+++ b/UnitTests/Charcoal/Selection/FilterSelectionStoreTests.swift
@@ -16,8 +16,8 @@ final class FilterSelectionStoreTests: XCTestCase {
     // MARK: - Tests
 
     func testClear() {
-        let filterA = Filter.list(title: "Test A", key: "testA", value: "valueB")
-        let filterB = Filter.list(title: "Test B", key: "testB", value: "valueB")
+        let filterA = Filter(title: "Test A", key: "testA", value: "valueB")
+        let filterB = Filter(title: "Test B", key: "testB", value: "valueB")
 
         store.setValue(from: filterA)
         store.setValue(from: filterB)
@@ -32,14 +32,14 @@ final class FilterSelectionStoreTests: XCTestCase {
     }
 
     func testSetValueFromfilter() {
-        let filter = Filter.list(title: "Test", key: "test", value: "valueA")
+        let filter = Filter(title: "Test", key: "test", value: "valueA")
 
         store.setValue(from: filter)
         XCTAssertEqual(store.value(for: filter), "valueA")
     }
 
     func testSetValueForfilter() {
-        let filter = Filter.list(title: "Test", key: "test")
+        let filter = Filter(title: "Test", key: "test")
 
         store.setValue("valueB", for: filter)
         XCTAssertEqual(store.value(for: filter), "valueB")
@@ -49,7 +49,7 @@ final class FilterSelectionStoreTests: XCTestCase {
     }
 
     func testRemoveValuesForfilter() {
-        let filter = Filter.list(title: "Test", key: "test", value: "value")
+        let filter = Filter(title: "Test", key: "test", value: "value")
 
         store.setValue(from: filter)
         XCTAssertTrue(store.isSelected(filter))
@@ -59,10 +59,10 @@ final class FilterSelectionStoreTests: XCTestCase {
     }
 
     func testRemoveValuesForfilterWithSubfilters() {
-        let subfilterA = Filter.list(title: "subfilter A", key: "subfilterA", value: "valueB")
-        let subfilterB = Filter.list(title: "subfilter B", key: "subfilterB", value: "valueB")
+        let subfilterA = Filter(title: "subfilter A", key: "subfilterA", value: "valueB")
+        let subfilterB = Filter(title: "subfilter B", key: "subfilterB", value: "valueB")
         let subfilters = [subfilterA, subfilterB]
-        let filter = Filter.list(title: "Test", key: "filter", value: "value", subfilters: subfilters)
+        let filter = Filter(title: "Test", key: "filter", value: "value", subfilters: subfilters)
 
         store.setValue(from: filter)
         store.setValue(from: subfilterA)
@@ -75,7 +75,7 @@ final class FilterSelectionStoreTests: XCTestCase {
     }
 
     func testToggleValueForfilter() {
-        let filter = Filter.list(title: "Test", key: "test", value: "value")
+        let filter = Filter(title: "Test", key: "test", value: "value")
 
         store.toggleValue(for: filter)
         XCTAssertTrue(store.isSelected(filter))
@@ -85,10 +85,10 @@ final class FilterSelectionStoreTests: XCTestCase {
     }
 
     func testIsSelected() {
-        let subfilterA = Filter.list(title: "subfilter A", key: "subfilterA", value: "valueB")
-        let subfilterB = Filter.list(title: "subfilter B", key: "subfilterB", value: "valueB")
+        let subfilterA = Filter(title: "subfilter A", key: "subfilterA", value: "valueB")
+        let subfilterB = Filter(title: "subfilter B", key: "subfilterB", value: "valueB")
         let subfilters = [subfilterA, subfilterB]
-        let filter = Filter.list(title: "Test", key: "filter", value: "value", subfilters: subfilters)
+        let filter = Filter(title: "Test", key: "filter", value: "value", subfilters: subfilters)
 
         store.setValue(from: subfilterA)
         XCTAssertTrue(store.isSelected(subfilterA))
@@ -133,7 +133,7 @@ final class FilterSelectionStoreTests: XCTestCase {
     }
 
     func testQueryItemsForFilter() {
-        let filter = Filter.list(title: "Test", key: "test", value: "value")
+        let filter = Filter(title: "Test", key: "test", value: "value")
         store.setValue(from: filter)
 
         let expected = [URLQueryItem(name: "test", value: "value")]
@@ -141,10 +141,10 @@ final class FilterSelectionStoreTests: XCTestCase {
     }
 
     func testQueryItemsForFiltersWithSubfilters() {
-        let subfilterA = Filter.list(title: "subfilter A", key: "subfilterA", value: "valueA")
-        let subfilterB = Filter.list(title: "subfilter B", key: "subfilterB", value: "valueB")
+        let subfilterA = Filter(title: "subfilter A", key: "subfilterA", value: "valueA")
+        let subfilterB = Filter(title: "subfilter B", key: "subfilterB", value: "valueB")
         let subfilters = [subfilterA, subfilterB]
-        let filter = Filter.list(title: "Test", key: "filter", value: "value", subfilters: subfilters)
+        let filter = Filter(title: "Test", key: "filter", value: "value", subfilters: subfilters)
 
         store.setValue(from: subfilterA)
         store.setValue(from: subfilterB)
@@ -158,7 +158,7 @@ final class FilterSelectionStoreTests: XCTestCase {
     }
 
     func testQueryItemsForFilterContainer() {
-        let filter = Filter.list(title: "Test", key: "test", value: "value")
+        let filter = Filter(title: "Test", key: "test", value: "value")
         let container = FilterContainer(rootFilters: [filter], freeTextFilter: nil, inlineFilter: nil, numberOfResults: 0)
 
         store.setValue(from: filter)
@@ -168,17 +168,17 @@ final class FilterSelectionStoreTests: XCTestCase {
     }
 
     func testTitles() {
-        let filter = Filter.list(title: "Test", key: "test", value: "value")
+        let filter = Filter(title: "Test", key: "test", value: "value")
 
         store.setValue(from: filter)
         XCTAssertEqual(store.titles(for: filter), [SelectionTitle(value: "Test")])
     }
 
     func testTitlesWithSubfilters() {
-        let subfilterA = Filter.list(title: "subfilter A", key: "subfilterA", value: "valueA")
-        let subfilterB = Filter.list(title: "subfilter B", key: "subfilterB", value: "valueB")
+        let subfilterA = Filter(title: "subfilter A", key: "subfilterA", value: "valueA")
+        let subfilterB = Filter(title: "subfilter B", key: "subfilterB", value: "valueB")
         let subfilters = [subfilterA, subfilterB]
-        let filter = Filter.list(title: "filter", key: "filter", value: "value", subfilters: subfilters)
+        let filter = Filter(title: "filter", key: "filter", value: "value", subfilters: subfilters)
 
         store.setValue(from: subfilterA)
         store.setValue(from: subfilterB)
@@ -232,7 +232,7 @@ final class FilterSelectionStoreTests: XCTestCase {
     }
 
     func testIsValid() {
-        let filter = Filter.list(title: "Test", key: "test", value: "value")
+        let filter = Filter(title: "Test", key: "test", value: "value")
 
         store.setValue(from: filter)
         XCTAssertTrue(store.isValid(filter))
@@ -268,16 +268,16 @@ final class FilterSelectionStoreTests: XCTestCase {
     }
 
     func testHasSelectedSubfilters() {
-        let subfilter = Filter.list(title: "subfilter A", key: "subfilterA", value: "valueA")
-        let filter = Filter.list(title: "filter", key: "filter", value: "value", subfilters: [subfilter])
+        let subfilter = Filter(title: "subfilter A", key: "subfilterA", value: "valueA")
+        let filter = Filter(title: "filter", key: "filter", value: "value", subfilters: [subfilter])
 
         store.setValue(from: subfilter)
         XCTAssertTrue(store.hasSelectedSubfilters(for: filter))
     }
 
     func testHasSelectedSubfiltersWithPredicate() {
-        let subfilter = Filter.list(title: "subfilter A", key: "subfilterA", value: "valueA")
-        let filter = Filter.list(title: "filter", key: "filter", value: "value", subfilters: [subfilter])
+        let subfilter = Filter(title: "subfilter A", key: "subfilterA", value: "valueA")
+        let filter = Filter(title: "filter", key: "filter", value: "value", subfilters: [subfilter])
 
         store.setValue(from: subfilter)
         XCTAssertTrue(store.hasSelectedSubfilters(for: filter, where: { $0.key == "subfilterA" }))
@@ -285,16 +285,16 @@ final class FilterSelectionStoreTests: XCTestCase {
     }
 
     func testSelectedSubfilters() {
-        let subfilter = Filter.list(title: "subfilter A", key: "subfilterA", value: "valueA")
-        let filter = Filter.list(title: "filter", key: "filter", value: "value", subfilters: [subfilter])
+        let subfilter = Filter(title: "subfilter A", key: "subfilterA", value: "valueA")
+        let filter = Filter(title: "filter", key: "filter", value: "value", subfilters: [subfilter])
 
         store.setValue(from: subfilter)
         XCTAssertEqual(store.selectedSubfilters(for: filter).count, 1)
     }
 
     func testSelectedSubfiltersWithPredicate() {
-        let subfilter = Filter.list(title: "subfilter A", key: "subfilterA", value: "valueA")
-        let filter = Filter.list(title: "filter", key: "filter", value: "value", subfilters: [subfilter])
+        let subfilter = Filter(title: "subfilter A", key: "subfilterA", value: "valueA")
+        let filter = Filter(title: "filter", key: "filter", value: "value", subfilters: [subfilter])
 
         store.setValue(from: subfilter)
         XCTAssertEqual(store.selectedSubfilters(for: filter, where: { $0.key == "subfilterA" }).count, 1)
@@ -303,15 +303,15 @@ final class FilterSelectionStoreTests: XCTestCase {
 
     func testSyncSelection() {
         let rootFilters = [
-            Filter.list(title: "subfilter A", key: "subfilterA", value: "valueA"),
-            Filter.list(title: "subfilter B", key: "subfilterB", value: "valueB"),
+            Filter(title: "subfilter A", key: "subfilterA", value: "valueA"),
+            Filter(title: "subfilter B", key: "subfilterB", value: "valueB"),
         ]
         let inlineFilter = Filter.inline(
             title: "Inline",
             key: "inline",
             subfilters: [
-                Filter.list(title: "subfilter C", key: "subfilterC", value: "valueC"),
-                Filter.list(title: "subfilter D", key: "subfilterD", value: "valueD"),
+                Filter(title: "subfilter C", key: "subfilterC", value: "valueC"),
+                Filter(title: "subfilter D", key: "subfilterD", value: "valueD"),
         ])
         let queryItems = Set([
             URLQueryItem(name: "filter", value: "value"),


### PR DESCRIPTION
# Why?

Because `list` filter kind was a misleading since it's used for different kinds of filters, e.g. lists, sub filters of map and range filters, etc. 

# What?

- Rename list filter to standard filter
- Remove helper function to create list in favor of init method

# Show me

No UI changes.