### PR TITLE
List filter: fix selection background for cells with animated checkbox

### DIFF
--- a/Sources/Charcoal/Filters/List/Views/ListFilterCell.swift
+++ b/Sources/Charcoal/Filters/List/Views/ListFilterCell.swift
@@ -47,30 +47,39 @@ final class ListFilterCell: CheckboxTableViewCell {
         let isCheckboxHighlighted = checkbox.isHighlighted
         super.setHighlighted(highlighted, animated: animated)
         checkbox.isHighlighted = isCheckboxHighlighted
+
+        guard let selectedBackgroundView = selectedBackgroundView else { return }
+
+        if selectedBackgroundView.superview == nil, highlighted {
+            selectedBackgroundView.alpha = 1
+            insertSubview(selectedBackgroundView, at: 0)
+        } else if !highlighted {
+            selectedBackgroundView.alpha = 0
+            selectedBackgroundView.removeFromSuperview()
+        }
     }
 
     override func animateSelection(isSelected: Bool) {
         super.animateSelection(isSelected: isSelected)
+        updateAccessibilityLabel(isSelected: isSelected)
 
-        guard let selectedBackgroundView = selectedBackgroundView else {
-            return
+        guard let selectedBackgroundView = selectedBackgroundView else { return }
+
+        if selectedBackgroundView.superview == nil {
+            insertSubview(selectedBackgroundView, at: 0)
         }
 
-        insertSubview(selectedBackgroundView, at: 0)
-
         selectedBackgroundView.layer.removeAllAnimations()
-        selectedBackgroundView.alpha = 0
+        selectedBackgroundView.alpha = 1
 
         let animation = CABasicAnimation(keyPath: "opacity")
         animation.duration = 0.2
-        animation.fromValue = 0
-        animation.toValue = 1
-        animation.autoreverses = true
+        animation.fromValue = 1
+        animation.toValue = 0
+        animation.autoreverses = false
         animation.repeatCount = 1
         animation.delegate = self
         selectedBackgroundView.layer.add(animation, forKey: nil)
-
-        updateAccessibilityLabel(isSelected: isSelected)
     }
 
     // MARK: - Setup

--- a/Sources/Charcoal/Filters/List/Views/ListFilterCell.swift
+++ b/Sources/Charcoal/Filters/List/Views/ListFilterCell.swift
@@ -41,26 +41,20 @@ final class ListFilterCell: CheckboxTableViewCell {
         let isCheckboxHighlighted = checkbox.isHighlighted
         super.setSelected(selected, animated: animated)
         checkbox.isHighlighted = isCheckboxHighlighted
-
-        selectedBackgroundView?.layer.removeAllAnimations()
-        selectedBackgroundView?.alpha = selected ? 1 : 0
+        showSelectedBackground(selected)
     }
 
     override func setHighlighted(_ highlighted: Bool, animated: Bool) {
         let isCheckboxHighlighted = checkbox.isHighlighted
         super.setHighlighted(highlighted, animated: animated)
         checkbox.isHighlighted = isCheckboxHighlighted
-
-        selectedBackgroundView?.layer.removeAllAnimations()
-        selectedBackgroundView?.alpha = highlighted ? 1 : 0
+        showSelectedBackground(highlighted)
     }
 
     override func animateSelection(isSelected: Bool) {
         super.animateSelection(isSelected: isSelected)
         updateAccessibilityLabel(isSelected: isSelected)
-
-        selectedBackgroundView?.layer.removeAllAnimations()
-        selectedBackgroundView?.alpha = isSelected ? 0 : 1
+        showSelectedBackground(!isSelected)
 
         let animation = CABasicAnimation(keyPath: "opacity")
         animation.duration = 0.2
@@ -70,6 +64,11 @@ final class ListFilterCell: CheckboxTableViewCell {
         animation.repeatCount = 1
         animation.isRemovedOnCompletion = false
         selectedBackgroundView?.layer.add(animation, forKey: nil)
+    }
+
+    private func showSelectedBackground(_ show: Bool) {
+        selectedBackgroundView?.layer.removeAllAnimations()
+        selectedBackgroundView?.alpha = show ? 1 : 0
     }
 
     // MARK: - Setup


### PR DESCRIPTION
# Why?

The highlight color was only activated upon release in the cells with animated checkbox.

# What?

Show/hide selected background view when the cell is selected/highlighted and animate it together with checkbox.

# Show me

![list](https://user-images.githubusercontent.com/10529867/56128214-513dca00-5f7f-11e9-804c-0de5e0b8541c.gif)
