### PR TITLE
update version to match tag 2.0.1

### DIFF
--- a/Charcoal.podspec
+++ b/Charcoal.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = 'Charcoal'
   s.summary          = 'A library that simplifies the creation of modern filtering experiences'
-  s.version          = '0.1.0'
+  s.version          = '2.0.1'
   s.author           = 'FINN.no'
   s.homepage         = 'https://github.com/finn-no/charcoal-ios'
   s.social_media_url = 'https://twitter.com/FINN_tech'


### PR DESCRIPTION
# Why?

Its nice to have the version the same as the last tag. 

# What?

Set version to match the tag. 