### PR TITLE
Bil: change filter configuration according to new requirements

### DIFF
--- a/Sources/FINNSetup/FilterMarkets/FilterMarketCar.swift
+++ b/Sources/FINNSetup/FilterMarkets/FilterMarketCar.swift
@@ -34,8 +34,8 @@ extension FilterMarketCar: FilterConfiguration {
                 .leasepriceInit,
                 .leasepriceMonth,
                 .price,
-                .location,
                 .map,
+                .location,
                 .bodyType,
                 .engineFuel,
                 .exteriorColour,
@@ -53,8 +53,8 @@ extension FilterMarketCar: FilterConfiguration {
             return [
                 .make,
                 .salesForm,
-                .location,
                 .map,
+                .location,
                 .year,
                 .price,
                 .mileage,
@@ -76,8 +76,8 @@ extension FilterMarketCar: FilterConfiguration {
         case .mobileHome:
             return [
                 .salesForm,
-                .location,
                 .map,
+                .location,
                 .make,
                 .year,
                 .price,
@@ -94,8 +94,8 @@ extension FilterMarketCar: FilterConfiguration {
         case .caravan:
             return [
                 .salesForm,
-                .location,
                 .map,
+                .location,
                 .make,
                 .year,
                 .price,

--- a/Sources/FINNSetup/FilterMarkets/FilterMarketCar.swift
+++ b/Sources/FINNSetup/FilterMarkets/FilterMarketCar.swift
@@ -75,19 +75,19 @@ extension FilterMarketCar: FilterConfiguration {
             ]
         case .mobileHome:
             return [
-                .make,
                 .salesForm,
-                .year,
-                .mileage,
-                .price,
                 .location,
                 .map,
+                .make,
+                .year,
+                .price,
+                .mileage,
+                .mobileHomeSegment,
                 .noOfSleepers,
                 .numberOfSeats,
                 .engineEffect,
-                .mobileHomeSegment,
-                .transmission,
                 .wheelDrive,
+                .transmission,
                 .length,
                 .weight,
             ]

--- a/Sources/FINNSetup/FilterMarkets/FilterMarketCar.swift
+++ b/Sources/FINNSetup/FilterMarkets/FilterMarketCar.swift
@@ -93,15 +93,15 @@ extension FilterMarketCar: FilterConfiguration {
             ]
         case .caravan:
             return [
-                .make,
                 .salesForm,
-                .year,
-                .mileage,
-                .price,
                 .location,
                 .map,
-                .noOfSleepers,
+                .make,
+                .year,
+                .price,
+                .mileage,
                 .caravanSegment,
+                .noOfSleepers,
                 .length,
                 .width,
                 .weight,

--- a/Sources/FINNSetup/FilterMarkets/FilterMarketCar.swift
+++ b/Sources/FINNSetup/FilterMarkets/FilterMarketCar.swift
@@ -17,7 +17,7 @@ extension FilterMarketCar: FilterConfiguration {
     public var preferenceFilterKeys: [FilterKey] {
         switch self {
         case .norway, .abroad:
-            return [.published, .priceChanged, .dealerSegment]
+            return [.published, .dealerSegment, .priceChanged]
         case .mobileHome, .caravan:
             return [.published, .caravanDealerSegment]
         }
@@ -53,18 +53,18 @@ extension FilterMarketCar: FilterConfiguration {
             return [
                 .make,
                 .salesForm,
-                .year,
-                .mileage,
-                .leasepriceInit,
-                .leasepriceMonth,
-                .price,
                 .location,
                 .map,
+                .year,
+                .price,
+                .mileage,
+                .engineEffect,
+                .numberOfSeats,
+                .leasepriceInit,
+                .leasepriceMonth,
                 .bodyType,
                 .engineFuel,
                 .exteriorColour,
-                .engineEffect,
-                .numberOfSeats,
                 .wheelDrive,
                 .transmission,
                 .carEquipment,


### PR DESCRIPTION
# Why?

Because there are new requirements for the order of filters in "Bil" market.

# What?

- Move "Område i kart" above "Område" for all verticals
- Change the order of filters according to new requirements.

# Show me

No UI changes.