### PR TITLE
Move "Område i kart" above "Område" for all markets

### DIFF
--- a/Sources/FINNSetup/FilterMarkets/FilterMarketB2B.swift
+++ b/Sources/FINNSetup/FilterMarkets/FilterMarketB2B.swift
@@ -27,8 +27,8 @@ extension FilterMarketB2B: FilterConfiguration {
         switch self {
         case .truck, .truckAbroad:
             return [
-                .location,
                 .map,
+                .location,
                 .truckSegment,
                 .make,
                 .price,
@@ -38,8 +38,8 @@ extension FilterMarketB2B: FilterConfiguration {
             ]
         case .bus:
             return [
-                .location,
                 .map,
+                .location,
                 .busSegment,
                 .make,
                 .price,
@@ -48,8 +48,8 @@ extension FilterMarketB2B: FilterConfiguration {
             ]
         case .construction:
             return [
-                .location,
                 .map,
+                .location,
                 .constructionSegment,
                 .make,
                 .price,
@@ -58,8 +58,8 @@ extension FilterMarketB2B: FilterConfiguration {
             ]
         case .agricultureTractor, .agricultureThresher:
             return [
-                .location,
                 .map,
+                .location,
                 .make,
                 .price,
                 .year,
@@ -67,8 +67,8 @@ extension FilterMarketB2B: FilterConfiguration {
             ]
         case .agricultureTools:
             return [
-                .location,
                 .map,
+                .location,
                 .category,
                 .price,
                 .year,
@@ -80,8 +80,8 @@ extension FilterMarketB2B: FilterConfiguration {
                 .mileage,
                 .price,
                 .bodyType,
-                .location,
                 .map,
+                .location,
                 .engineFuel,
                 .exteriorColour,
                 .engineEffect,

--- a/Sources/FINNSetup/FilterMarkets/FilterMarketBap.swift
+++ b/Sources/FINNSetup/FilterMarkets/FilterMarketBap.swift
@@ -33,8 +33,8 @@ extension FilterMarketBap: FilterConfiguration {
             .shoeSize,
             .womenClothingBrand,
             .lengthCm,
-            .location,
             .map,
+            .location,
             .price,
         ]
     }

--- a/Sources/FINNSetup/FilterMarkets/FilterMarketBoat.swift
+++ b/Sources/FINNSetup/FilterMarkets/FilterMarketBoat.swift
@@ -31,8 +31,8 @@ extension FilterMarketBoat: FilterConfiguration {
         switch self {
         case .boatSale:
             return [
-                .location,
                 .map,
+                .location,
                 .motorAdLocation,
                 .boatClass,
                 .make,
@@ -49,15 +49,15 @@ extension FilterMarketBoat: FilterConfiguration {
             ]
         case .boatUsedWanted:
             return [
-                .location,
                 .map,
+                .location,
                 .boatClass,
                 .price,
             ]
         case .boatRent:
             return [
-                .location,
                 .map,
+                .location,
                 .boatClass,
                 .price,
                 .lengthFeet,
@@ -69,8 +69,8 @@ extension FilterMarketBoat: FilterConfiguration {
             ]
         case .boatMotor, .boatParts:
             return [
-                .location,
                 .map,
+                .location,
                 .type,
                 .price,
                 .engineEffect,
@@ -78,24 +78,24 @@ extension FilterMarketBoat: FilterConfiguration {
             ]
         case .boatPartsMotorWanted:
             return [
-                .location,
                 .map,
+                .location,
                 .type,
                 .price,
                 .engineEffect,
             ]
         case .boatDock:
             return [
-                .location,
                 .map,
+                .location,
                 .width,
                 .price,
                 .dealerSegment,
             ]
         case .boatDockWanted:
             return [
-                .location,
                 .map,
+                .location,
                 .width,
                 .price,
             ]

--- a/Sources/FINNSetup/FilterMarkets/FilterMarketJob.swift
+++ b/Sources/FINNSetup/FilterMarkets/FilterMarketJob.swift
@@ -21,8 +21,8 @@ extension FilterMarketJob: FilterConfiguration {
         switch self {
         case .partTime:
             return [
-                .location,
                 .map,
+                .location,
                 .occupation,
                 .industry,
                 .jobDuration,
@@ -31,8 +31,8 @@ extension FilterMarketJob: FilterConfiguration {
             ]
         case .fullTime, .management:
             return [
-                .location,
                 .map,
+                .location,
                 .occupation,
                 .industry,
                 .jobDuration,

--- a/Sources/FINNSetup/FilterMarkets/FilterMarketMC.swift
+++ b/Sources/FINNSetup/FilterMarkets/FilterMarketMC.swift
@@ -27,8 +27,8 @@ extension FilterMarketMC: FilterConfiguration {
         switch self {
         case .mc:
             return [
-                .location,
                 .map,
+                .location,
                 .category,
                 .make,
                 .price,
@@ -39,8 +39,8 @@ extension FilterMarketMC: FilterConfiguration {
             ]
         case .mopedScooter:
             return [
-                .location,
                 .map,
+                .location,
                 .category,
                 .make,
                 .price,
@@ -51,8 +51,8 @@ extension FilterMarketMC: FilterConfiguration {
             ]
         case .snowmobile, .atv:
             return [
-                .location,
                 .map,
+                .location,
                 .make,
                 .price,
                 .year,

--- a/UITests/FilterSelectionUITests.swift
+++ b/UITests/FilterSelectionUITests.swift
@@ -14,7 +14,7 @@ final class FilterSelectionUITests: UITestCase {
         XCTAssertTrue(app.hasNavigationTitle("Filtrer søket"))
 
         // 2. Open filter
-        app.tables.element(boundBy: 1).cells.element(boundBy: 3).tap()
+        app.tables.element(boundBy: 1).cells.element(boundBy: 4).tap()
         sleep(1)
         XCTAssertTrue(app.hasNavigationTitle("Område"))
         XCTAssertFalse(app.bottomButton.exists)

--- a/version.swift
+++ b/version.swift
@@ -1,3 +1,7 @@
+//
+//  Copyright © FINN.no AS, Inc. All rights reserved.
+//
+
 #!/usr/bin/swift
 
 import Foundation
@@ -131,7 +135,7 @@ var message = arguments.firstIndex(where: { Set(["-m", "--message"]).contains($0
 var nextTags = [
     "patch": { currentTag.nextPatch() },
     "minor": { currentTag.nextMinor() },
-    "major": { currentTag.nextMajor() }
+    "major": { currentTag.nextMajor() },
 ]
 
 switch action {


### PR DESCRIPTION
# Why?

Because there are new requirements for the order of "Område i kart" and "Område" filters.

# What?

- Move "Område i kart" above "Område" for all verticals
- Update UI tests

# Show me

No UI changes.