### PR TITLE
Disable vertical selector when free text search in triggered

### DIFF
--- a/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
+++ b/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
@@ -398,11 +398,13 @@ extension RootFilterViewController: FreeTextFilterViewControllerDelegate {
 
     func freeTextFilterViewControllerWillBeginEditing(_ viewController: FreeTextFilterViewController) {
         resetButton.isEnabled = false
+        verticalSelectorView.isEnabled = false
         add(viewController)
     }
 
     func freeTextFilterViewControllerWillEndEditing(_ viewController: FreeTextFilterViewController) {
         resetButton.isEnabled = true
+        verticalSelectorView.isEnabled = true
         viewController.remove()
         tableView.reloadData()
     }


### PR DESCRIPTION
# Why?

Because it was possible to change verticals while being in the free text search editing mode.

# What?

Disable vertical selector when free text search is triggered.

# Show me

![verticals](https://user-images.githubusercontent.com/10529867/56580288-875bf900-65d2-11e9-8ece-8ad7b91523e4.gif)
