### PR TITLE
Vertical selector: improve animations

### DIFF
--- a/Sources/Charcoal/CharcoalViewController.swift
+++ b/Sources/Charcoal/CharcoalViewController.swift
@@ -98,9 +98,9 @@ public final class CharcoalViewController: UINavigationController {
 
         navigationBar.layer.masksToBounds = false
         navigationBar.layer.shadowColor = UIColor.white.cgColor
-        navigationBar.layer.shadowOpacity = 0.7
-        navigationBar.layer.shadowOffset = CGSize(width: 0, height: .mediumSpacing)
-        navigationBar.layer.shadowRadius = 2
+        navigationBar.layer.shadowOpacity = 1
+        navigationBar.layer.shadowOffset = CGSize(width: 0, height: 6)
+        navigationBar.layer.shadowRadius = 3
     }
 }
 

--- a/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
+++ b/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
@@ -366,12 +366,20 @@ extension RootFilterViewController: VerticalSelectorViewDelegate {
         resetButton.isEnabled = true
         verticalSelectorView.arrowDirection = .down
 
+        tableView.alpha = 0
+        bottomButton.alpha = 0
+
         UIView.animate(withDuration: 0.2, delay: 0, options: .curveEaseInOut, animations: ({ [weak self] in
             self?.verticalViewController.view.frame.origin.y = -.veryLargeSpacing
             self?.verticalViewController.view.alpha = 0
         }), completion: ({ [weak self] _ in
             self?.verticalViewController.remove()
         }))
+
+        UIView.animate(withDuration: 0.4, animations: { [weak self] in
+            self?.tableView.alpha = 1
+            self?.bottomButton.alpha = 1
+        })
     }
 }
 

--- a/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
+++ b/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
@@ -377,7 +377,7 @@ extension RootFilterViewController: VerticalSelectorViewDelegate {
             self?.verticalViewController.remove()
         }))
 
-        UIView.animate(withDuration: 0.4, animations: { [weak self] in
+        UIView.animate(withDuration: 0.3, animations: { [weak self] in
             self?.tableView.alpha = 1
             self?.bottomButton.alpha = 1
         })

--- a/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
+++ b/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
@@ -115,6 +115,7 @@ final class RootFilterViewController: FilterViewController {
         verticalSelectorView.isEnabled = !show
 
         if show {
+            tableView.scrollToRow(at: IndexPath(row: 0, section: 0), at: .top, animated: false)
             add(loadingViewController)
             loadingViewController.viewWillAppear(false)
         } else {

--- a/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
+++ b/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
@@ -366,7 +366,7 @@ extension RootFilterViewController: VerticalSelectorViewDelegate {
         resetButton.isEnabled = true
         verticalSelectorView.arrowDirection = .down
 
-        UIView.animate(withDuration: 0.4, delay: 0, options: .curveEaseInOut, animations: ({ [weak self] in
+        UIView.animate(withDuration: 0.1, delay: 0, options: .curveEaseInOut, animations: ({ [weak self] in
             self?.verticalViewController.view.frame.origin.y = -.veryLargeSpacing
             self?.verticalViewController.view.alpha = 0
         }), completion: ({ [weak self] _ in

--- a/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
+++ b/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
@@ -366,7 +366,7 @@ extension RootFilterViewController: VerticalSelectorViewDelegate {
         resetButton.isEnabled = true
         verticalSelectorView.arrowDirection = .down
 
-        UIView.animate(withDuration: 0.1, delay: 0, options: .curveEaseInOut, animations: ({ [weak self] in
+        UIView.animate(withDuration: 0.2, delay: 0, options: .curveEaseInOut, animations: ({ [weak self] in
             self?.verticalViewController.view.frame.origin.y = -.veryLargeSpacing
             self?.verticalViewController.view.alpha = 0
         }), completion: ({ [weak self] _ in

--- a/Sources/Charcoal/Filters/Root/Views/VerticalSelectorView.swift
+++ b/Sources/Charcoal/Filters/Root/Views/VerticalSelectorView.swift
@@ -30,7 +30,7 @@ final class VerticalSelectorView: UIView {
     }
 
     private lazy var titleLabel: UILabel = {
-        let label = UILabel(frame: .zero)
+        let label = UILabel(withAutoLayout: true)
         label.font = UIFont.captionStrong.withSize(12)
         label.textColor = .spaceGray
         label.textAlignment = .center
@@ -38,8 +38,7 @@ final class VerticalSelectorView: UIView {
     }()
 
     private lazy var button: UIButton = {
-        let button = UIButton()
-        button.backgroundColor = .milk
+        let button = UIButton(withAutoLayout: true)
         button.titleLabel?.font = UIFont.bodyStrong.withSize(17)
 
         button.setTitleColor(.primaryBlue, for: .normal)
@@ -53,7 +52,7 @@ final class VerticalSelectorView: UIView {
         button.imageEdgeInsets = UIEdgeInsets(top: spacing, leading: spacing, bottom: 0, trailing: -spacing)
         button.titleEdgeInsets = UIEdgeInsets(top: 0, leading: -spacing, bottom: 0, trailing: spacing)
         button.contentEdgeInsets = UIEdgeInsets(
-            top: 0,
+            top: titleLabel.font.pointSize,
             leading: .mediumLargeSpacing + spacing,
             bottom: 0,
             trailing: .mediumLargeSpacing + spacing
@@ -64,13 +63,13 @@ final class VerticalSelectorView: UIView {
         return button
     }()
 
-    private lazy var stackView: UIStackView = {
-        let stackView = UIStackView(arrangedSubviews: [titleLabel, button])
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.axis = .vertical
-        stackView.distribution = .equalSpacing
-        return stackView
-    }()
+//    private lazy var stackView: UIStackView = {
+//        let stackView = UIStackView(arrangedSubviews: [titleLabel, button])
+//        stackView.translatesAutoresizingMaskIntoConstraints = false
+//        stackView.axis = .vertical
+//        stackView.distribution = .equalSpacing
+//        return stackView
+//    }()
 
     // MARK: - Init
 
@@ -94,9 +93,18 @@ final class VerticalSelectorView: UIView {
         arrowDirection = .down
         isEnabled = true
 
-        addSubview(stackView)
-        stackView.fillInSuperview()
-        stackView.widthAnchor.constraint(lessThanOrEqualToConstant: 250).isActive = true
+        addSubview(titleLabel)
+        addSubview(button)
+
+        NSLayoutConstraint.activate([
+            titleLabel.topAnchor.constraint(equalTo: topAnchor),
+            titleLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
+            button.topAnchor.constraint(equalTo: topAnchor),
+            button.leadingAnchor.constraint(equalTo: leadingAnchor),
+            button.trailingAnchor.constraint(equalTo: trailingAnchor),
+            button.widthAnchor.constraint(lessThanOrEqualToConstant: 250),
+            button.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ])
     }
 
     // MARK: - Actions

--- a/Sources/Charcoal/Filters/Root/Views/VerticalSelectorView.swift
+++ b/Sources/Charcoal/Filters/Root/Views/VerticalSelectorView.swift
@@ -63,14 +63,6 @@ final class VerticalSelectorView: UIView {
         return button
     }()
 
-//    private lazy var stackView: UIStackView = {
-//        let stackView = UIStackView(arrangedSubviews: [titleLabel, button])
-//        stackView.translatesAutoresizingMaskIntoConstraints = false
-//        stackView.axis = .vertical
-//        stackView.distribution = .equalSpacing
-//        return stackView
-//    }()
-
     // MARK: - Init
 
     override init(frame: CGRect) {

--- a/Sources/Charcoal/Filters/Root/Views/VerticalSelectorView.swift
+++ b/Sources/Charcoal/Filters/Root/Views/VerticalSelectorView.swift
@@ -88,14 +88,13 @@ final class VerticalSelectorView: UIView {
         addSubview(titleLabel)
         addSubview(button)
 
+        button.fillInSuperview()
+
         NSLayoutConstraint.activate([
             titleLabel.topAnchor.constraint(equalTo: topAnchor),
             titleLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
-            button.topAnchor.constraint(equalTo: topAnchor),
-            button.leadingAnchor.constraint(equalTo: leadingAnchor),
-            button.trailingAnchor.constraint(equalTo: trailingAnchor),
+
             button.widthAnchor.constraint(lessThanOrEqualToConstant: 250),
-            button.bottomAnchor.constraint(equalTo: bottomAnchor),
         ])
     }
 


### PR DESCRIPTION
# Why?

To make show/hide animations smother.

# What?

- Tweak animations for showing/hiding vertical selector
- Make tappable area bigger for vertical selector
- Tweak navigation bar shadow
- Scroll table view to top when loading indicator is shown in `RootFilterViewController`

# Show me

![verticals](https://user-images.githubusercontent.com/10529867/56668712-4c2ff780-66b0-11e9-99df-7fef69b1ef90.gif)
