### PR TITLE
Nyttekjøretøy: change filter configuration according to new requirements

### DIFF
--- a/Sources/FINNSetup/FilterMarkets/FilterMarketB2B.swift
+++ b/Sources/FINNSetup/FilterMarkets/FilterMarketB2B.swift
@@ -27,14 +27,14 @@ extension FilterMarketB2B: FilterConfiguration {
         switch self {
         case .truck, .truckAbroad:
             return [
-                .map,
-                .location,
                 .truckSegment,
                 .make,
                 .price,
                 .year,
                 .engineEffect,
                 .weight,
+                .map,
+                .location,
             ]
         case .bus:
             return [
@@ -48,40 +48,41 @@ extension FilterMarketB2B: FilterConfiguration {
             ]
         case .construction:
             return [
-                .map,
-                .location,
                 .constructionSegment,
-                .make,
                 .price,
                 .year,
                 .engineEffect,
+                .make,
+                .map,
+                .location,
             ]
         case .agricultureTractor, .agricultureThresher:
             return [
-                .map,
-                .location,
                 .make,
                 .price,
                 .year,
                 .engineEffect,
+                .map,
+                .location,
             ]
         case .agricultureTools:
             return [
-                .map,
-                .location,
                 .category,
                 .price,
                 .year,
+                .map,
+                .location,
             ]
         case .vanNorway, .vanAbroad:
             return [
                 .make,
-                .year,
-                .mileage,
-                .price,
-                .bodyType,
+                .salesForm,
                 .map,
                 .location,
+                .year,
+                .price,
+                .mileage,
+                .bodyType,
                 .engineFuel,
                 .exteriorColour,
                 .engineEffect,
@@ -91,7 +92,6 @@ extension FilterMarketB2B: FilterConfiguration {
                 .wheelSets,
                 .warrantyInsurance,
                 .condition,
-                .salesForm,
             ]
         }
     }

--- a/Sources/FINNSetup/FilterMarkets/FilterMarketBoat.swift
+++ b/Sources/FINNSetup/FilterMarkets/FilterMarketBoat.swift
@@ -69,7 +69,7 @@ extension FilterMarketBoat: FilterConfiguration {
                 .noOfSeats,
                 .motorSize,
             ]
-        case .boatMotor, .boatParts:
+        case .boatMotor, .boatParts, .boatPartsMotorWanted:
             return [
                 .type,
                 .price,
@@ -77,22 +77,7 @@ extension FilterMarketBoat: FilterConfiguration {
                 .location,
                 .engineEffect,
             ]
-        case .boatPartsMotorWanted:
-            return [
-                .price,
-                .map,
-                .location,
-                .type,
-                .engineEffect,
-            ]
-        case .boatDock:
-            return [
-                .price,
-                .width,
-                .map,
-                .location,
-            ]
-        case .boatDockWanted:
+        case .boatDock, .boatDockWanted:
             return [
                 .price,
                 .width,


### PR DESCRIPTION
# Why?

Because there are new requirements for the order of filters in "Nyttekjøretøy" market.

# What?

Change the order of filters according to new requirements.

# Show me

No UI changes.