### PR TITLE
Free text reset bug

### DIFF
--- a/Sources/Charcoal/Filters/FreeText/FreeTextFilterViewController.swift
+++ b/Sources/Charcoal/Filters/FreeText/FreeTextFilterViewController.swift
@@ -68,6 +68,12 @@ public class FreeTextFilterViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
+    func reset() {
+        searchBar.text = nil
+        currentQuery = nil
+        didClearText = false
+    }
+
     // MARK: - Public methods
 
     public func reloadData() {

--- a/Sources/Charcoal/Filters/FreeText/FreeTextFilterViewController.swift
+++ b/Sources/Charcoal/Filters/FreeText/FreeTextFilterViewController.swift
@@ -150,7 +150,7 @@ extension FreeTextFilterViewController: UISearchBarDelegate {
     }
 
     public func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {
-        if let _ = selectionStore.value(for: filter) as String?, searchBar.text == nil || searchBar.text?.isEmpty == true {
+        if selectionStore.value(for: filter) as String? != nil, searchBar.text == nil || searchBar.text?.isEmpty == true {
             selectionStore.removeValues(for: filter)
             delegate?.freeTextFilterViewController(self, didSelect: nil, for: filter)
         }

--- a/Sources/Charcoal/Filters/FreeText/FreeTextFilterViewController.swift
+++ b/Sources/Charcoal/Filters/FreeText/FreeTextFilterViewController.swift
@@ -31,7 +31,6 @@ public class FreeTextFilterViewController: UIViewController {
 
     // MARK: - Private Properties
 
-    private var currentQuery: String?
     private var didClearText = false
 
     private let filter: Filter
@@ -70,8 +69,8 @@ public class FreeTextFilterViewController: UIViewController {
 
     func reset() {
         searchBar.text = nil
-        currentQuery = nil
         didClearText = false
+        filterDelegate?.freeTextFilterViewController(self, didChangeText: nil)
     }
 
     // MARK: - Public methods
@@ -109,7 +108,6 @@ extension FreeTextFilterViewController: UITableViewDelegate {
         selectionStore.setValue(value, for: filter)
         delegate?.freeTextFilterViewController(self, didSelect: value, for: filter)
 
-        currentQuery = value
         returnToSuperView()
     }
 }
@@ -148,23 +146,17 @@ extension FreeTextFilterViewController: UISearchBarDelegate {
         selectionStore.setValue(value, for: filter)
         delegate?.freeTextFilterViewController(self, didSelect: value, for: filter)
 
-        currentQuery = searchBar.text
         returnToSuperView()
     }
 
     public func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {
-        if let currentQuery = currentQuery {
-            // return to previous search
-            searchBar.text = currentQuery
-            filterDelegate?.freeTextFilterViewController(self, didChangeText: currentQuery)
-        } else {
+        if let _ = selectionStore.value(for: filter) as String?, searchBar.text == nil || searchBar.text?.isEmpty == true {
             selectionStore.removeValues(for: filter)
             delegate?.freeTextFilterViewController(self, didSelect: nil, for: filter)
-
-            searchBar.text = nil
-            searchBar.setShowsCancelButton(false, animated: false)
-            filterDelegate?.freeTextFilterViewController(self, didChangeText: nil)
         }
+
+        searchBar.text = selectionStore.value(for: filter)
+        filterDelegate?.freeTextFilterViewController(self, didChangeText: selectionStore.value(for: filter))
 
         returnToSuperView()
     }
@@ -177,13 +169,6 @@ extension FreeTextFilterViewController: UISearchBarDelegate {
             selectionStore.removeValues(for: filter)
             delegate?.freeTextFilterViewController(self, didSelect: nil, for: filter)
 
-            currentQuery = nil
-            filterDelegate?.freeTextFilterViewController(self, didChangeText: nil)
-            return
-        }
-        // If the user clears the search field and then hits cancel, the search is cancelled
-        if currentQuery != nil, searchText.isEmpty {
-            currentQuery = nil
             filterDelegate?.freeTextFilterViewController(self, didChangeText: nil)
             return
         }

--- a/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
+++ b/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
@@ -161,7 +161,7 @@ final class RootFilterViewController: FilterViewController {
     @objc private func handleResetButtonTap() {
         selectionStore.removeValues(for: filterContainer.allFilters)
         rootDelegate?.rootFilterViewControllerDidResetAllFilters(self)
-        freeTextFilterViewController?.searchBar.text = nil
+        freeTextFilterViewController?.reset()
         shouldResetInlineFilterCell = true
 
         tableView.scrollToRow(at: IndexPath(row: 0, section: 0), at: .top, animated: false)


### PR DESCRIPTION
# Why?

There was a bug with the free text filter when pressing reset.

# What?

- Add `reset()` to `FreeTextFilterViewController` which resets suggestions and search bar text.
- Replaced `currentQuery` with `selectionStore.value(for: filter)`
- Refactored cancel logic. If there is a value in selection store it will return to that value when pressing cancel, unless the search bar text is empty or nil, then it will remove the search selection. 

# Show me

![reset-bug](https://user-images.githubusercontent.com/19956175/56728109-5c98ae80-6752-11e9-82b8-d905cf4aa032.gif)
