### PR TITLE
Add a separate selection change origin for free text suggestions

### DIFF
--- a/Sources/Charcoal/CharcoalViewController.swift
+++ b/Sources/Charcoal/CharcoalViewController.swift
@@ -124,7 +124,7 @@ extension CharcoalViewController: RootFilterViewControllerDelegate {
     }
 
     func rootFilterViewController(_ viewController: RootFilterViewController, didSelectSuggestionAt index: Int, filter: Filter) {
-        handleFilterSelectionChange(from: .suggestion(index: index))
+        handleFilterSelectionChange(from: .freeTextSuggestion(index: index))
     }
 
     func rootFilterViewController(_ viewController: RootFilterViewController, didSelectVertical vertical: Vertical) {

--- a/Sources/Charcoal/CharcoalViewController.swift
+++ b/Sources/Charcoal/CharcoalViewController.swift
@@ -123,6 +123,10 @@ extension CharcoalViewController: RootFilterViewControllerDelegate {
         handleFilterSelectionChange(from: .freeTextInput)
     }
 
+    func rootFilterViewController(_ viewController: RootFilterViewController, didSelectSuggestionAt index: Int, filter: Filter) {
+        handleFilterSelectionChange(from: .suggestion(index: index))
+    }
+
     func rootFilterViewController(_ viewController: RootFilterViewController, didSelectVertical vertical: Vertical) {
         selectionDelegate?.charcoalViewController(self, didSelect: vertical)
     }

--- a/Sources/Charcoal/Filters/FreeText/FreeTextFilterViewController.swift
+++ b/Sources/Charcoal/Filters/FreeText/FreeTextFilterViewController.swift
@@ -18,7 +18,11 @@ public protocol FreeTextFilterDelegate: AnyObject {
 protocol FreeTextFilterViewControllerDelegate: AnyObject {
     func freeTextFilterViewControllerWillBeginEditing(_ viewController: FreeTextFilterViewController)
     func freeTextFilterViewControllerWillEndEditing(_ viewController: FreeTextFilterViewController)
-    func freeTextFilterViewController(_ viewController: FreeTextFilterViewController, didSelect value: String?, for filter: Filter)
+    func freeTextFilterViewController(_ viewController: FreeTextFilterViewController, didEnter value: String?, for filter: Filter)
+    func freeTextFilterViewController(_ viewController: FreeTextFilterViewController,
+                                      didSelectSuggestion suggestion: String,
+                                      at index: Int,
+                                      for filter: Filter)
 }
 
 public class FreeTextFilterViewController: UIViewController {
@@ -106,7 +110,7 @@ extension FreeTextFilterViewController: UITableViewDelegate {
         tableView.deselectRow(at: indexPath, animated: true)
 
         selectionStore.setValue(value, for: filter)
-        delegate?.freeTextFilterViewController(self, didSelect: value, for: filter)
+        delegate?.freeTextFilterViewController(self, didSelectSuggestion: value, at: indexPath.row, for: filter)
 
         returnToSuperView()
     }
@@ -144,7 +148,7 @@ extension FreeTextFilterViewController: UISearchBarDelegate {
         guard let value = searchBar.text else { return }
 
         selectionStore.setValue(value, for: filter)
-        delegate?.freeTextFilterViewController(self, didSelect: value, for: filter)
+        delegate?.freeTextFilterViewController(self, didEnter: value, for: filter)
 
         returnToSuperView()
     }
@@ -152,7 +156,7 @@ extension FreeTextFilterViewController: UISearchBarDelegate {
     public func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {
         if selectionStore.value(for: filter) as String? != nil, searchBar.text == nil || searchBar.text?.isEmpty == true {
             selectionStore.removeValues(for: filter)
-            delegate?.freeTextFilterViewController(self, didSelect: nil, for: filter)
+            delegate?.freeTextFilterViewController(self, didEnter: nil, for: filter)
         }
 
         searchBar.text = selectionStore.value(for: filter)
@@ -167,7 +171,7 @@ extension FreeTextFilterViewController: UISearchBarDelegate {
             didClearText = true
 
             selectionStore.removeValues(for: filter)
-            delegate?.freeTextFilterViewController(self, didSelect: nil, for: filter)
+            delegate?.freeTextFilterViewController(self, didEnter: nil, for: filter)
 
             filterDelegate?.freeTextFilterViewController(self, didChangeText: nil)
             return

--- a/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
+++ b/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
@@ -9,6 +9,7 @@ protocol RootFilterViewControllerDelegate: AnyObject {
     func rootFilterViewController(_ viewController: RootFilterViewController, didRemoveFilter filter: Filter)
     func rootFilterViewController(_ viewController: RootFilterViewController, didSelectInlineFilter filter: Filter)
     func rootFilterViewController(_ viewController: RootFilterViewController, didSelectFreeTextFilter filter: Filter)
+    func rootFilterViewController(_ viewController: RootFilterViewController, didSelectSuggestionAt index: Int, filter: Filter)
     func rootFilterViewController(_ viewController: RootFilterViewController, didSelectVertical vertical: Vertical)
 }
 
@@ -401,8 +402,15 @@ extension RootFilterViewController: VerticalListViewControllerDelegate {
 // MARK: - FreeTextFilterViewControllerDelegate
 
 extension RootFilterViewController: FreeTextFilterViewControllerDelegate {
-    func freeTextFilterViewController(_ viewController: FreeTextFilterViewController, didSelect value: String?, for filter: Filter) {
+    func freeTextFilterViewController(_ viewController: FreeTextFilterViewController, didEnter value: String?, for filter: Filter) {
         rootDelegate?.rootFilterViewController(self, didSelectFreeTextFilter: filter)
+    }
+
+    func freeTextFilterViewController(_ viewController: FreeTextFilterViewController,
+                                      didSelectSuggestion suggestion: String,
+                                      at index: Int,
+                                      for filter: Filter) {
+        rootDelegate?.rootFilterViewController(self, didSelectSuggestionAt: index, filter: filter)
     }
 
     func freeTextFilterViewControllerWillBeginEditing(_ viewController: FreeTextFilterViewController) {

--- a/Sources/Charcoal/Selection/SelectionChangeOrigin.swift
+++ b/Sources/Charcoal/Selection/SelectionChangeOrigin.swift
@@ -2,11 +2,12 @@
 //  Copyright © FINN.no AS, Inc. All rights reserved.
 //
 
-public enum SelectionChangeOrigin: Int {
+public enum SelectionChangeOrigin {
     case bottomButton
     case freeTextInput
     case inlineFilter
     case navigation
     case removeFilterButton
     case resetAllButton
+    case suggestion(index: Int)
 }

--- a/Sources/Charcoal/Selection/SelectionChangeOrigin.swift
+++ b/Sources/Charcoal/Selection/SelectionChangeOrigin.swift
@@ -5,9 +5,9 @@
 public enum SelectionChangeOrigin {
     case bottomButton
     case freeTextInput
+    case freeTextSuggestion(index: Int)
     case inlineFilter
     case navigation
     case removeFilterButton
     case resetAllButton
-    case suggestion(index: Int)
 }


### PR DESCRIPTION
# Why?

Because there are two possible ways of changing values in free text search: by entering text manually and by selecting autosuggestion.

# What?

Add a separate selection change origin for free text suggestions

# Show me

No UI changes.