### PR TITLE
Root filters: add minimum loading time interval

### DIFF
--- a/Demo/DemoTableViewController.swift
+++ b/Demo/DemoTableViewController.swift
@@ -63,11 +63,8 @@ extension DemoTableViewController: CharcoalViewControllerSelectionDelegate {
         if let submarket = setup.markets.first(where: { $0.name == vertical.name }) {
             setup.current = submarket
             viewController.isLoading = true
-
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                viewController.filterContainer = setup.filterContainer
-                viewController.isLoading = false
-            }
+            viewController.filterContainer = setup.filterContainer
+            viewController.isLoading = false
         }
     }
 

--- a/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
+++ b/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
@@ -126,6 +126,8 @@ final class RootFilterViewController: FilterViewController {
             let diff = loadingStartTimeInterval.map { 0.5 - (timeInterval - $0) } ?? 0.5
             let delay = diff > 0 ? diff : 0
 
+            loadingStartTimeInterval = nil
+
             DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
                 self?.loadingViewController.remove()
             }

--- a/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
+++ b/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
@@ -62,6 +62,7 @@ final class RootFilterViewController: FilterViewController {
     private lazy var loadingViewController = LoadingViewController(backgroundColor: .milk, presentationDelay: 0)
     private var freeTextFilterViewController: FreeTextFilterViewController?
     private var shouldResetInlineFilterCell = false
+    private var loadingStartTimeInterval: TimeInterval?
 
     // MARK: - Filter
 
@@ -117,10 +118,17 @@ final class RootFilterViewController: FilterViewController {
 
         if show {
             tableView.scrollToRow(at: IndexPath(row: 0, section: 0), at: .top, animated: false)
+            loadingStartTimeInterval = Date().timeIntervalSinceReferenceDate
             add(loadingViewController)
             loadingViewController.viewWillAppear(false)
         } else {
-            loadingViewController.remove()
+            let timeInterval = Date().timeIntervalSinceReferenceDate
+            let diff = loadingStartTimeInterval.map { 0.5 - (timeInterval - $0) } ?? 0.5
+            let delay = diff > 0 ? diff : 0
+
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+                self?.loadingViewController.remove()
+            }
         }
     }
 

--- a/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
+++ b/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
@@ -122,8 +122,9 @@ final class RootFilterViewController: FilterViewController {
             add(loadingViewController)
             loadingViewController.viewWillAppear(false)
         } else {
+            let minTimeInterval: TimeInterval = 0.5
             let timeInterval = Date().timeIntervalSinceReferenceDate
-            let diff = loadingStartTimeInterval.map { 0.5 - (timeInterval - $0) } ?? 0.5
+            let diff = loadingStartTimeInterval.map { minTimeInterval - (timeInterval - $0) } ?? minTimeInterval
             let delay = diff > 0 ? diff : 0
 
             loadingStartTimeInterval = nil


### PR DESCRIPTION
# Why?

To be able to show loading indicator for at least 500ms.

# What?

Add a small delay in order to show loading indicator for at least 500ms.

# Show me

No UI changes.