### PR TITLE
Enabling root view self sizing cells on pre iOS 11

### DIFF
--- a/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
+++ b/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
@@ -40,6 +40,13 @@ final class RootFilterViewController: FilterViewController {
         tableView.register(RootFilterCell.self)
         tableView.separatorStyle = .none
         tableView.translatesAutoresizingMaskIntoConstraints = false
+
+        if #available(iOS 11, *) {
+            tableView.estimatedRowHeight = UITableView.automaticDimension
+        } else {
+            // This is needed for autosizing to work on pre iOS 11 device
+            tableView.estimatedRowHeight = 54
+        }
         return tableView
     }()
 


### PR DESCRIPTION
# Why?
The root view looked awful on pre iOS 11 devices

# What?
Enables auto-sizing cells on pre iOS 11.

# Show me
### Before
![Simulator Screen Shot - iPhone 5s - 2019-05-02 at 09 52 50](https://user-images.githubusercontent.com/3169203/57062306-0f6f8c00-6cc0-11e9-83cf-18512738ceae.png)

### After
![Simulator Screen Shot - iPhone 5s - 2019-05-02 at 09 52 09](https://user-images.githubusercontent.com/3169203/57062276-fb2b8f00-6cbf-11e9-8acf-4b7d601cae61.png)
