### PR TITLE
Removing lease related filters from car abroad

### DIFF
--- a/Sources/FINNSetup/FilterMarkets/FilterMarketCar.swift
+++ b/Sources/FINNSetup/FilterMarkets/FilterMarketCar.swift
@@ -60,8 +60,6 @@ extension FilterMarketCar: FilterConfiguration {
                 .mileage,
                 .engineEffect,
                 .numberOfSeats,
-                .leasepriceInit,
-                .leasepriceMonth,
                 .bodyType,
                 .engineFuel,
                 .exteriorColour,


### PR DESCRIPTION
# Why?
Some filters that should not be there.

# What?
Removed them from car-abroad config.

# Show me

### Before
![Simulator Screen Shot - iPhone 8 - 2019-05-02 at 10 15 26](https://user-images.githubusercontent.com/3169203/57063396-61fe7780-6cc3-11e9-8f75-5cd045c9de16.png)

### After
![Simulator Screen Shot - iPhone 8 - 2019-05-02 at 10 16 59](https://user-images.githubusercontent.com/3169203/57063409-717dc080-6cc3-11e9-9b84-a7c732953382.png)
