### PR TITLE
Show/hide navigation bar separator on scroll

### DIFF
--- a/Sources/Charcoal/CharcoalViewController.swift
+++ b/Sources/Charcoal/CharcoalViewController.swift
@@ -117,12 +117,6 @@ public final class CharcoalViewController: UINavigationController {
         navigationBar.isTranslucent = false
         navigationBar.setBackgroundImage(UIImage(), for: .default)
         navigationBar.shadowImage = UIImage()
-
-        navigationBar.layer.masksToBounds = false
-        navigationBar.layer.shadowColor = UIColor.white.cgColor
-        navigationBar.layer.shadowOpacity = 1
-        navigationBar.layer.shadowOffset = CGSize(width: 0, height: 6)
-        navigationBar.layer.shadowRadius = 3
     }
 }
 

--- a/Sources/Charcoal/Filters/FilterViewController.swift
+++ b/Sources/Charcoal/Filters/FilterViewController.swift
@@ -23,12 +23,12 @@ class FilterViewController: UIViewController, FilterBottomButtonViewDelegate {
     lazy var bottomButtonBottomConstraint = bottomButton.bottomAnchor.constraint(equalTo: view.bottomAnchor)
 
     private lazy var topSeparatorView: UIView = {
-        let view = UIView()
-        view.backgroundColor = .clear
+        let view = UIView(withAutoLayout: true)
+        view.backgroundColor = .white
         view.layer.masksToBounds = false
         view.layer.shadowColor = UIColor.black.cgColor
-        view.layer.shadowOpacity = 1
-        view.layer.shadowOffset = CGSize(width: 0, height: 6)
+        view.layer.shadowOpacity = 0.7
+        view.layer.shadowOffset = CGSize(width: 0, height: 1)
         view.layer.shadowRadius = 3
         return view
     }()
@@ -85,15 +85,6 @@ class FilterViewController: UIViewController, FilterBottomButtonViewDelegate {
         ])
     }
 
-    func showTopSeparator() {
-        view.bringSubviewToFront(topSeparatorView)
-        topSeparatorView.isHidden = false
-    }
-
-    func hideTopSeparator() {
-        topSeparatorView.isHidden = true
-    }
-
     func showBottomButton(_ show: Bool, animated: Bool) {
         view.layoutIfNeeded()
         isShowingBottomButton = show
@@ -112,9 +103,32 @@ class FilterViewController: UIViewController, FilterBottomButtonViewDelegate {
         })
     }
 
+    // MARK: - Top separator
+
+    private func showTopSeparator() {
+        view.bringSubviewToFront(topSeparatorView)
+        topSeparatorView.isHidden = false
+    }
+
+    private func hideTopSeparator() {
+        topSeparatorView.isHidden = true
+    }
+
     // MARK: - FilterBottomButtonViewDelegate
 
     func filterBottomButtonView(_ filterBottomButtonView: FilterBottomButtonView, didTapButton button: UIButton) {
         delegate?.filterViewControllerDidPressBottomButton(self)
+    }
+}
+
+// MARK: - UIScrollViewDelegate
+
+extension FilterViewController: UIScrollViewDelegate {
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        if scrollView.contentOffset.y > 0 {
+            showTopSeparator()
+        } else {
+            hideTopSeparator()
+        }
     }
 }

--- a/Sources/Charcoal/Filters/FilterViewController.swift
+++ b/Sources/Charcoal/Filters/FilterViewController.swift
@@ -22,6 +22,17 @@ class FilterViewController: UIViewController, FilterBottomButtonViewDelegate {
 
     lazy var bottomButtonBottomConstraint = bottomButton.bottomAnchor.constraint(equalTo: view.bottomAnchor)
 
+    private lazy var topSeparatorView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .clear
+        view.layer.masksToBounds = false
+        view.layer.shadowColor = UIColor.black.cgColor
+        view.layer.shadowOpacity = 1
+        view.layer.shadowOffset = CGSize(width: 0, height: 6)
+        view.layer.shadowRadius = 3
+        return view
+    }()
+
     private(set) lazy var bottomButton: FilterBottomButtonView = {
         let view = FilterBottomButtonView()
         view.delegate = self
@@ -48,6 +59,7 @@ class FilterViewController: UIViewController, FilterBottomButtonViewDelegate {
         super.viewDidLoad()
         view.backgroundColor = .milk
         setup()
+        hideTopSeparator()
     }
 
     public override func viewWillAppear(_ animated: Bool) {
@@ -58,13 +70,28 @@ class FilterViewController: UIViewController, FilterBottomButtonViewDelegate {
     // MARK: - Setup
 
     private func setup() {
+        view.addSubview(topSeparatorView)
         view.addSubview(bottomButton)
 
         NSLayoutConstraint.activate([
+            topSeparatorView.topAnchor.constraint(equalTo: view.topAnchor),
+            topSeparatorView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            topSeparatorView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            topSeparatorView.heightAnchor.constraint(equalToConstant: 1),
+
             bottomButton.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             bottomButton.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             bottomButton.topAnchor.constraint(lessThanOrEqualTo: view.bottomAnchor),
         ])
+    }
+
+    func showTopSeparator() {
+        view.bringSubviewToFront(topSeparatorView)
+        topSeparatorView.isHidden = false
+    }
+
+    func hideTopSeparator() {
+        topSeparatorView.isHidden = true
     }
 
     func showBottomButton(_ show: Bool, animated: Bool) {


### PR DESCRIPTION
# Why?

Because we want to show separator with shadow on scroll.

# What?

Add top separator view with shadow to show on scroll in `FilterViewController`. Since both `RootFilterViewController` and `ListFilterViewController` have table views and extend `FilterViewController`, they get this behavior for free.

# Show me

![separator](https://user-images.githubusercontent.com/10529867/57074635-c1b94a80-6ce4-11e9-89c9-b488d67dc44e.gif)
