### PR TITLE
Align numbers no matter if the cell has a chevron or not

### DIFF
--- a/Sources/Charcoal/Filters/List/ListFilterCellViewModel.swift
+++ b/Sources/Charcoal/Filters/List/ListFilterCellViewModel.swift
@@ -25,7 +25,7 @@ struct ListFilterCellViewModel: SelectableTableViewCellViewModel {
     let isEnabled: Bool
 
     var hasChevron: Bool {
-        return accessoryStyle != .none
+        return true
     }
 
     var isSelected: Bool {

--- a/Sources/Charcoal/Filters/List/Views/ListFilterCell.swift
+++ b/Sources/Charcoal/Filters/List/Views/ListFilterCell.swift
@@ -78,10 +78,15 @@ final class ListFilterCell: CheckboxTableViewCell {
 
         selectionStyle = .none
 
-        if viewModel.accessoryStyle == .external {
+        switch viewModel.accessoryStyle {
+        case .external:
             let accessoryView = UIImageView(image: UIImage(named: .webview).withRenderingMode(.alwaysTemplate))
             accessoryView.tintColor = .chevron
             self.accessoryView = accessoryView
+        case .none:
+            accessoryView = UIView()
+        case .chevron:
+            break
         }
 
         switch viewModel.checkboxStyle {


### PR DESCRIPTION
# Why?

There should be an alignment with all the numbers, no matter if they have a chevron/arrow or not.

# What?

Add empty accessoryView on list cells without chevron or external link icon.

# Show me

### Before

![before](https://user-images.githubusercontent.com/10529867/57127685-7c068b80-6d91-11e9-8897-8834a1e1fc37.png)

### After

![after](https://user-images.githubusercontent.com/10529867/57127701-858ff380-6d91-11e9-8726-6f5e93b73988.png)