### PR TITLE
Enable swipe back navigation in range and map view controllers

### DIFF
--- a/Sources/Charcoal/CharcoalViewController.swift
+++ b/Sources/Charcoal/CharcoalViewController.swift
@@ -265,14 +265,6 @@ extension CharcoalViewController: UINavigationControllerDelegate {
         }
     }
 
-    public func navigationController(_ navigationController: UINavigationController, didShow viewController: UIViewController, animated: Bool) {
-        if viewController is RangeFilterViewController {
-            interactivePopGestureRecognizer?.isEnabled = false
-        } else {
-            interactivePopGestureRecognizer?.isEnabled = true
-        }
-    }
-
     private func showBottomButtonIfNeeded() {
         for viewController in viewControllers where viewController !== rootFilterViewController {
             (viewController as? ListFilterViewController)?.showBottomButton(selectionHasChanged, animated: false)

--- a/Sources/Charcoal/Filters/FilterViewController.swift
+++ b/Sources/Charcoal/Filters/FilterViewController.swift
@@ -78,23 +78,7 @@ class FilterViewController: UIViewController, FilterBottomButtonViewDelegate {
         enableSwipeBack(true)
     }
 
-    // MARK: - Setup
-
-    private func setup() {
-        view.addSubview(topSeparatorView)
-        view.addSubview(bottomButton)
-
-        NSLayoutConstraint.activate([
-            topSeparatorView.topAnchor.constraint(equalTo: view.topAnchor),
-            topSeparatorView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            topSeparatorView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            topSeparatorView.heightAnchor.constraint(equalToConstant: 1),
-
-            bottomButton.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            bottomButton.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            bottomButton.topAnchor.constraint(lessThanOrEqualTo: view.bottomAnchor),
-        ])
-    }
+    // MARK: - Internal functions
 
     func showBottomButton(_ show: Bool, animated: Bool) {
         view.layoutIfNeeded()
@@ -120,6 +104,24 @@ class FilterViewController: UIViewController, FilterBottomButtonViewDelegate {
         if gestureRecognizer?.isEnabled != isEnabled {
             gestureRecognizer?.isEnabled = isEnabled
         }
+    }
+
+    // MARK: - Setup
+
+    private func setup() {
+        view.addSubview(topSeparatorView)
+        view.addSubview(bottomButton)
+
+        NSLayoutConstraint.activate([
+            topSeparatorView.topAnchor.constraint(equalTo: view.topAnchor),
+            topSeparatorView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            topSeparatorView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            topSeparatorView.heightAnchor.constraint(equalToConstant: 1),
+
+            bottomButton.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            bottomButton.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            bottomButton.topAnchor.constraint(lessThanOrEqualTo: view.bottomAnchor),
+        ])
     }
 
     // MARK: - Top separator

--- a/Sources/Charcoal/Filters/FilterViewController.swift
+++ b/Sources/Charcoal/Filters/FilterViewController.swift
@@ -61,10 +61,10 @@ class FilterViewController: UIViewController, FilterBottomButtonViewDelegate {
         setup()
         hideTopSeparator()
 
-        let gestureRecornizer = UIScreenEdgePanGestureRecognizer()
-        gestureRecornizer.delegate = self
-        gestureRecornizer.edges = .left
-        view.addGestureRecognizer(gestureRecornizer)
+        let gestureRecognizer = UIScreenEdgePanGestureRecognizer()
+        gestureRecognizer.delegate = self
+        gestureRecognizer.edges = .left
+        view.addGestureRecognizer(gestureRecognizer)
     }
 
     public override func viewWillAppear(_ animated: Bool) {

--- a/Sources/Charcoal/Filters/FilterViewController.swift
+++ b/Sources/Charcoal/Filters/FilterViewController.swift
@@ -70,6 +70,7 @@ class FilterViewController: UIViewController, FilterBottomButtonViewDelegate {
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         view.bringSubviewToFront(bottomButton)
+        enableSwipeBack(true)
     }
 
     override func viewWillDisappear(_ animated: Bool) {

--- a/Sources/Charcoal/Filters/FilterViewController.swift
+++ b/Sources/Charcoal/Filters/FilterViewController.swift
@@ -60,11 +60,21 @@ class FilterViewController: UIViewController, FilterBottomButtonViewDelegate {
         view.backgroundColor = .milk
         setup()
         hideTopSeparator()
+
+        let gestureRecornizer = UIScreenEdgePanGestureRecognizer()
+        gestureRecornizer.delegate = self
+        gestureRecornizer.edges = .left
+        view.addGestureRecognizer(gestureRecornizer)
     }
 
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         view.bringSubviewToFront(bottomButton)
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        enableSwipeBack(true)
     }
 
     // MARK: - Setup
@@ -103,6 +113,14 @@ class FilterViewController: UIViewController, FilterBottomButtonViewDelegate {
         })
     }
 
+    func enableSwipeBack(_ isEnabled: Bool) {
+        let gestureRecognizer = navigationController?.interactivePopGestureRecognizer
+
+        if gestureRecognizer?.isEnabled != isEnabled {
+            gestureRecognizer?.isEnabled = isEnabled
+        }
+    }
+
     // MARK: - Top separator
 
     private func showTopSeparator() {
@@ -130,5 +148,12 @@ extension FilterViewController: UIScrollViewDelegate {
         } else {
             hideTopSeparator()
         }
+    }
+}
+
+extension FilterViewController: UIGestureRecognizerDelegate {
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
+        enableSwipeBack(!(touch.view is UISlider))
+        return false
     }
 }

--- a/Sources/Charcoal/Filters/Map/MapFilterViewController.swift
+++ b/Sources/Charcoal/Filters/Map/MapFilterViewController.swift
@@ -158,6 +158,7 @@ extension MapFilterViewController: MapFilterViewDelegate {
     func mapFilterView(_ mapFilterView: MapFilterView, didChangeRadius radius: Int) {
         hasChanges = true
         self.radius = radius
+        enableSwipeBack(true)
     }
 }
 

--- a/Sources/Charcoal/Filters/Range/RangeFilterViewController.swift
+++ b/Sources/Charcoal/Filters/Range/RangeFilterViewController.swift
@@ -56,6 +56,7 @@ extension RangeFilterViewController: RangeFilterViewDelegate {
         selectionStore.setValue(value, for: subfilter)
         delegate?.filterViewController(self, didSelectFilter: subfilter)
         showBottomButton(true, animated: true)
+        enableSwipeBack(true)
     }
 }
 


### PR DESCRIPTION
# Why?

Because it's natural to have swipe back navigation for every view controller pushed into navigation stack.

# What?

- Detect left edge swipes and disable `interactivePopGestureRecognizer` if touch received from an instance of `UISlider`
- Enable `interactivePopGestureRecognizer` on `viewWillAppear` and `viewWillDisappear` in case it's disabled after using the slider

# Show me

![swipe_back](https://user-images.githubusercontent.com/10529867/57224185-ea08b800-7008-11e9-8280-758305ce9c6f.gif)