### PR TITLE
Enable expanding bottom sheet on text edit

### DIFF
--- a/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
+++ b/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
@@ -400,12 +400,14 @@ extension RootFilterViewController: FreeTextFilterViewControllerDelegate {
     }
 
     func freeTextFilterViewControllerWillBeginEditing(_ viewController: FreeTextFilterViewController) {
+        rootDelegate?.filterViewControllerWillBeginTextEditing(self)
         resetButton.isEnabled = false
         verticalSelectorView.isEnabled = false
         add(viewController)
     }
 
     func freeTextFilterViewControllerWillEndEditing(_ viewController: FreeTextFilterViewController) {
+        rootDelegate?.filterViewControllerWillEndTextEditing(self)
         resetButton.isEnabled = true
         verticalSelectorView.isEnabled = true
         viewController.remove()


### PR DESCRIPTION
# Why?

We want to expand the bottom sheet when editing the free text filter.

# What?

- Calls the `rootDelegate` text editing methods when `FreeTextFilterViewController` will appear and disappear.

# Show me

![free-text-expand](https://user-images.githubusercontent.com/19956175/57376390-2884ab00-71a0-11e9-9d48-75634b7fc375.gif)
