### PR TITLE
Grid filter: fix selection

### DIFF
--- a/Sources/Charcoal/Filters/Grid/GridFilterViewController.swift
+++ b/Sources/Charcoal/Filters/Grid/GridFilterViewController.swift
@@ -40,6 +40,10 @@ final class GridFilterViewController: FilterViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         collectionView.reloadData()
+
+        for (index, filter) in filter.subfilters.enumerated() where selectionStore.isSelected(filter) {
+            collectionView.selectItem(at: IndexPath(item: index, section: 0), animated: false, scrollPosition: .left)
+        }
     }
 
     // MARK: - Setup
@@ -60,10 +64,7 @@ extension GridFilterViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeue(GridFilterCell.self, for: indexPath)
         let currentFilter = filter.subfilters[indexPath.row]
-
         cell.configure(withTitle: currentFilter.title, accessibilityPrefix: filter.title)
-        cell.isSelected = selectionStore.isSelected(currentFilter)
-
         return cell
     }
 }


### PR DESCRIPTION
# Why?

Because filters won't toggle if you re-enter the grid filter view.

# What?

Select filter using `selectItem(at:` method from `UICollectionView`.

# Show me

### Before

![before](https://user-images.githubusercontent.com/10529867/57446703-9b9c2900-7255-11e9-9993-00bcfa87373a.gif)

### After

![after](https://user-images.githubusercontent.com/10529867/57446660-81624b00-7255-11e9-991c-6e6e4f74f8c6.gif)
