### PR TITLE
Hide reset button in free text and vertical selector

### DIFF
--- a/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
+++ b/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
@@ -334,7 +334,7 @@ extension RootFilterViewController: VerticalSelectorViewDelegate {
     private func showVerticalViewController() {
         guard let verticals = filterContainer.verticals else { return }
 
-        resetButton.isEnabled = false
+        navigationItem.rightBarButtonItem = nil
         verticalSelectorView.arrowDirection = .up
 
         add(verticalViewController)
@@ -357,7 +357,7 @@ extension RootFilterViewController: VerticalSelectorViewDelegate {
     }
 
     private func hideVerticalViewController() {
-        resetButton.isEnabled = true
+        navigationItem.rightBarButtonItem = resetButton
         verticalSelectorView.arrowDirection = .down
 
         tableView.alpha = 0
@@ -407,14 +407,14 @@ extension RootFilterViewController: FreeTextFilterViewControllerDelegate {
 
     func freeTextFilterViewControllerWillBeginEditing(_ viewController: FreeTextFilterViewController) {
         rootDelegate?.filterViewControllerWillBeginTextEditing(self)
-        resetButton.isEnabled = false
+        navigationItem.rightBarButtonItem = nil
         verticalSelectorView.isEnabled = false
         add(viewController)
     }
 
     func freeTextFilterViewControllerWillEndEditing(_ viewController: FreeTextFilterViewController) {
         rootDelegate?.filterViewControllerWillEndTextEditing(self)
-        resetButton.isEnabled = true
+        navigationItem.rightBarButtonItem = resetButton
         verticalSelectorView.isEnabled = true
         viewController.remove()
 


### PR DESCRIPTION
# Why?

We want to hide the reset button.

# What?

- Set `navigationItem.rightBarButtonItem` to `nil` or to `resetButton` depending on whether we want to show or hide it.

# Show me

![hide-reset](https://user-images.githubusercontent.com/19956175/57446811-de5e0100-7255-11e9-8059-6bb5de14a7ef.gif)
