### PR TITLE
Disable reset button when there are no filters selected

### DIFF
--- a/Sources/Charcoal/CharcoalViewController.swift
+++ b/Sources/Charcoal/CharcoalViewController.swift
@@ -240,6 +240,8 @@ extension CharcoalViewController: FilterSelectionStoreDelegate {
         if topViewController !== rootFilterViewController {
             selectionHasChanged = true
         }
+
+        rootFilterViewController?.updateResetButtonVisibility()
     }
 }
 

--- a/Sources/Charcoal/CharcoalViewController.swift
+++ b/Sources/Charcoal/CharcoalViewController.swift
@@ -241,7 +241,7 @@ extension CharcoalViewController: FilterSelectionStoreDelegate {
             selectionHasChanged = true
         }
 
-        rootFilterViewController?.updateResetButtonVisibility()
+        rootFilterViewController?.updateResetButtonAvailability()
     }
 }
 

--- a/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
+++ b/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
@@ -94,6 +94,7 @@ final class RootFilterViewController: FilterViewController {
         super.viewDidLoad()
 
         updateNavigationTitleView()
+        showResetButton(true)
         showBottomButton(true, animated: false)
         updateBottomButtonTitle()
         setup()
@@ -105,7 +106,7 @@ final class RootFilterViewController: FilterViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         tableView.reloadData()
-        updateResetButtonVisibility()
+        updateResetButtonAvailability()
     }
 
     // MARK: - Public
@@ -113,7 +114,7 @@ final class RootFilterViewController: FilterViewController {
     func reloadFilters() {
         configureInlineFilter()
         tableView.reloadData()
-        updateResetButtonVisibility()
+        updateResetButtonAvailability()
     }
 
     func set(filterContainer: FilterContainer) {
@@ -146,18 +147,14 @@ final class RootFilterViewController: FilterViewController {
         }
     }
 
-    func updateResetButtonVisibility() {
-        if selectionStore.isEmpty {
-            hideResetButton()
-        } else {
-            navigationItem.rightBarButtonItem = resetButton
-        }
+    func updateResetButtonAvailability() {
+        resetButton.isEnabled = !selectionStore.isEmpty
     }
 
     // MARK: - Private
 
-    private func hideResetButton() {
-        navigationItem.rightBarButtonItem = nil
+    private func showResetButton(_ show: Bool) {
+        navigationItem.rightBarButtonItem = show ? resetButton : nil
     }
 
     private func updateNavigationTitleView() {
@@ -346,7 +343,7 @@ extension RootFilterViewController: VerticalSelectorViewDelegate {
     private func showVerticalViewController() {
         guard let verticals = filterContainer.verticals else { return }
 
-        hideResetButton()
+        showResetButton(false)
         verticalSelectorView.arrowDirection = .up
 
         add(verticalViewController)
@@ -369,7 +366,7 @@ extension RootFilterViewController: VerticalSelectorViewDelegate {
     }
 
     private func hideVerticalViewController() {
-        updateResetButtonVisibility()
+        showResetButton(true)
         verticalSelectorView.arrowDirection = .down
 
         tableView.alpha = 0
@@ -419,14 +416,14 @@ extension RootFilterViewController: FreeTextFilterViewControllerDelegate {
 
     func freeTextFilterViewControllerWillBeginEditing(_ viewController: FreeTextFilterViewController) {
         rootDelegate?.filterViewControllerWillBeginTextEditing(self)
-        hideResetButton()
+        showResetButton(false)
         verticalSelectorView.isEnabled = false
         add(viewController)
     }
 
     func freeTextFilterViewControllerWillEndEditing(_ viewController: FreeTextFilterViewController) {
         rootDelegate?.filterViewControllerWillEndTextEditing(self)
-        updateResetButtonVisibility()
+        showResetButton(true)
         verticalSelectorView.isEnabled = true
         viewController.remove()
 

--- a/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
+++ b/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
@@ -154,11 +154,11 @@ final class RootFilterViewController: FilterViewController {
         }
     }
 
-    func hideResetButton() {
+    // MARK: - Private
+
+    private func hideResetButton() {
         navigationItem.rightBarButtonItem = nil
     }
-
-    // MARK: - Private
 
     private func updateNavigationTitleView() {
         if let vertical = filterContainer.verticals?.first(where: { $0.isCurrent }) {

--- a/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
+++ b/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
@@ -93,8 +93,6 @@ final class RootFilterViewController: FilterViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        navigationItem.rightBarButtonItem = resetButton
-
         updateNavigationTitleView()
         showBottomButton(true, animated: false)
         updateBottomButtonTitle()
@@ -107,6 +105,7 @@ final class RootFilterViewController: FilterViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         tableView.reloadData()
+        updateResetButtonVisibility()
     }
 
     // MARK: - Public
@@ -114,6 +113,7 @@ final class RootFilterViewController: FilterViewController {
     func reloadFilters() {
         configureInlineFilter()
         tableView.reloadData()
+        updateResetButtonVisibility()
     }
 
     func set(filterContainer: FilterContainer) {
@@ -144,6 +144,18 @@ final class RootFilterViewController: FilterViewController {
                 self?.loadingViewController.remove()
             }
         }
+    }
+
+    func updateResetButtonVisibility() {
+        if selectionStore.isEmpty {
+            hideResetButton()
+        } else {
+            navigationItem.rightBarButtonItem = resetButton
+        }
+    }
+
+    func hideResetButton() {
+        navigationItem.rightBarButtonItem = nil
     }
 
     // MARK: - Private
@@ -334,7 +346,7 @@ extension RootFilterViewController: VerticalSelectorViewDelegate {
     private func showVerticalViewController() {
         guard let verticals = filterContainer.verticals else { return }
 
-        navigationItem.rightBarButtonItem = nil
+        hideResetButton()
         verticalSelectorView.arrowDirection = .up
 
         add(verticalViewController)
@@ -357,7 +369,7 @@ extension RootFilterViewController: VerticalSelectorViewDelegate {
     }
 
     private func hideVerticalViewController() {
-        navigationItem.rightBarButtonItem = resetButton
+        updateResetButtonVisibility()
         verticalSelectorView.arrowDirection = .down
 
         tableView.alpha = 0
@@ -407,14 +419,14 @@ extension RootFilterViewController: FreeTextFilterViewControllerDelegate {
 
     func freeTextFilterViewControllerWillBeginEditing(_ viewController: FreeTextFilterViewController) {
         rootDelegate?.filterViewControllerWillBeginTextEditing(self)
-        navigationItem.rightBarButtonItem = nil
+        hideResetButton()
         verticalSelectorView.isEnabled = false
         add(viewController)
     }
 
     func freeTextFilterViewControllerWillEndEditing(_ viewController: FreeTextFilterViewController) {
         rootDelegate?.filterViewControllerWillEndTextEditing(self)
-        navigationItem.rightBarButtonItem = resetButton
+        updateResetButtonVisibility()
         verticalSelectorView.isEnabled = true
         viewController.remove()
 


### PR DESCRIPTION
# Why?

Because it doesn't make sense to have reset button enabled when there are no filters selected.

# What?

Disable reset button when there are no filters selected.

# Show me

![reset](https://user-images.githubusercontent.com/10529867/57462507-44a84b00-7279-11e9-82ce-0092f860c732.gif)
