### PR TITLE
Automatically adjust fonts for content size category

### DIFF
--- a/Sources/Charcoal/Filters/FreeText/FreeTextFilterViewController.swift
+++ b/Sources/Charcoal/Filters/FreeText/FreeTextFilterViewController.swift
@@ -137,6 +137,7 @@ extension FreeTextFilterViewController: UITableViewDataSource {
         let cell = tableView.dequeue(IconTitleTableViewCell.self, for: indexPath)
         let title = filterDataSource?.freeTextFilterViewController(self, suggestionAt: indexPath)
         cell.titleLabel.font = .bodyRegular
+        cell.titleLabel.adjustsFontForContentSizeCategory = true
         cell.configure(with: FreeTextSuggestionCellViewModel(title: title ?? ""))
         cell.separatorInset = .leadingInset(48)
         return cell
@@ -258,12 +259,14 @@ private class FreeTextFilterSearchBar: UISearchBar {
     // Makes sure to setup appearance proxy one time and one time only
     private static let setupSearchQuerySearchBarAppereanceOnce: () = {
         let textFieldAppearanceInRoot = UITextField.appearance(whenContainedInInstancesOf: [UITableView.self])
+        textFieldAppearanceInRoot.adjustsFontForContentSizeCategory = true
         textFieldAppearanceInRoot.defaultTextAttributes = [
             NSAttributedString.Key.foregroundColor: UIColor.primaryBlue,
             NSAttributedString.Key.font: UIFont.bodyRegular,
         ]
 
         let textFieldAppearanceInSearch = UITextField.appearance(whenContainedInInstancesOf: [FreeTextFilterSearchBar.self])
+        textFieldAppearanceInRoot.adjustsFontForContentSizeCategory = true
         textFieldAppearanceInSearch.defaultTextAttributes = [
             NSAttributedString.Key.foregroundColor: UIColor.licorice,
             NSAttributedString.Key.font: UIFont.bodyRegular,

--- a/Sources/Charcoal/Filters/Grid/GridFilterCell.swift
+++ b/Sources/Charcoal/Filters/Grid/GridFilterCell.swift
@@ -7,6 +7,7 @@ import UIKit
 final class GridFilterCell: UICollectionViewCell {
     private lazy var titleLabel: UILabel = {
         let label = UILabel(withAutoLayout: true)
+        label.adjustsFontForContentSizeCategory = true
         label.textAlignment = .center
         return label
     }()

--- a/Sources/Charcoal/Filters/Inline/SegmentButton.swift
+++ b/Sources/Charcoal/Filters/Inline/SegmentButton.swift
@@ -54,6 +54,8 @@ final class SegmentButton: UIButton {
 private extension SegmentButton {
     func setup(with title: String) {
         titleLabel?.font = .bodyRegular
+        titleLabel?.adjustsFontForContentSizeCategory = true
+
         setTitle(title, for: .normal)
         setTitleColor(.licorice, for: .normal)
         setTitleColor(.milk, for: .selected)

--- a/Sources/Charcoal/Filters/List/Views/ListFilterCell.swift
+++ b/Sources/Charcoal/Filters/List/Views/ListFilterCell.swift
@@ -111,10 +111,14 @@ final class ListFilterCell: CheckboxTableViewCell {
             selectedBackgroundView.alpha = 0
             insertSubview(selectedBackgroundView, at: 0)
         }
+
+        detailLabel.adjustsFontForContentSizeCategory = true
+        subtitleLabel.adjustsFontForContentSizeCategory = true
     }
 
     private func setup() {
         titleLabel.font = .bodyRegular
+        titleLabel.adjustsFontForContentSizeCategory = true
 
         addSubview(overlayView)
         checkbox.addSubview(checkboxImageView)

--- a/Sources/Charcoal/Filters/Map/SearchLocationViewController.swift
+++ b/Sources/Charcoal/Filters/Map/SearchLocationViewController.swift
@@ -301,7 +301,7 @@ private extension SearchLocationViewController {
 private class SearchLocationSearchBar: UISearchBar {
     // Makes sure to setup appearance proxy one time and one time only
     private static let setupSearchBarAppereanceOnce: () = {
-        let textFieldAppearanceInSearch = UITextField.appearance(whenContainedInInstancesOf: [MapFilterView.self, SearchLocationSearchBar.self])
+        let textFieldAppearanceInSearch = UITextField.appearance(whenContainedInInstancesOf: [SearchLocationSearchBar.self])
         textFieldAppearanceInSearch.defaultTextAttributes = [
             NSAttributedString.Key.foregroundColor: UIColor.licorice,
             NSAttributedString.Key.font: UIFont.bodyRegular,

--- a/Sources/Charcoal/Filters/Map/SliderView/ValueSliderWithLabelView.swift
+++ b/Sources/Charcoal/Filters/Map/SliderView/ValueSliderWithLabelView.swift
@@ -17,6 +17,7 @@ class ValueSliderWithLabelView: UIView {
     private lazy var valueLabel: UILabel = {
         let label = UILabel(frame: .zero)
         label.font = .title2
+        label.adjustsFontForContentSizeCategory = true
         label.textColor = .licorice
         label.translatesAutoresizingMaskIntoConstraints = false
         label.textAlignment = .center

--- a/Sources/Charcoal/Filters/Range/Input/NumberInputView.swift
+++ b/Sources/Charcoal/Filters/Range/Input/NumberInputView.swift
@@ -23,6 +23,7 @@ final class NumberInputView: UIView {
         let textField = UITextField(withAutoLayout: true)
         textField.textColor = Style.textColor
         textField.font = Style.normalFont(size: fontSize)
+        textField.adjustsFontForContentSizeCategory = true
         textField.keyboardType = .numberPad
         textField.textAlignment = .right
         textField.delegate = self
@@ -34,6 +35,7 @@ final class NumberInputView: UIView {
         label.attributedText = attributedUnitText(withFont: Style.normalFont(size: fontSize), from: unit)
         label.textColor = Style.textColor
         label.font = Style.normalFont(size: fontSize)
+        label.adjustsFontForContentSizeCategory = true
         label.isUserInteractionEnabled = true
         label.isAccessibilityElement = false
         label.addGestureRecognizer(makeGestureRecognizer())
@@ -44,6 +46,7 @@ final class NumberInputView: UIView {
         let label = UILabel(withAutoLayout: true)
         label.text = unit.lowerBoundText
         label.font = Style.hintNormalFont
+        label.adjustsFontForContentSizeCategory = true
         label.textColor = Style.textColor
         label.isAccessibilityElement = false
         return label

--- a/Sources/Charcoal/Filters/Range/Input/RangeNumberInputView.swift
+++ b/Sources/Charcoal/Filters/Range/Input/RangeNumberInputView.swift
@@ -48,6 +48,7 @@ final class RangeNumberInputView: UIView {
         label.text = "-"
         label.textColor = .licorice
         label.font = UIFont.body(withSize: fontSize.rawValue)
+        label.adjustsFontForContentSizeCategory = true
         label.isAccessibilityElement = false
         return label
     }()

--- a/Sources/Charcoal/Filters/Range/Slider/SliderReferenceValueView.swift
+++ b/Sources/Charcoal/Filters/Range/Slider/SliderReferenceValueView.swift
@@ -24,6 +24,7 @@ final class SliderReferenceValueView: UIView {
         let label = UILabel(frame: .zero)
         label.translatesAutoresizingMaskIntoConstraints = false
         label.font = UIFont.caption.withSize(12).scaledFont(forTextStyle: .footnote)
+        label.adjustsFontForContentSizeCategory = true
         label.textColor = .licorice
         label.textAlignment = .center
         label.text = displayText

--- a/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
+++ b/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
@@ -109,6 +109,15 @@ final class RootFilterViewController: FilterViewController {
         updateResetButtonAvailability()
     }
 
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        if previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory {
+            configureInlineFilter()
+            inlineFilterView?.resetContentOffset()
+            updateNavigationTitleView()
+            updateBottomButtonTitle()
+        }
+    }
+
     // MARK: - Public
 
     func reloadFilters() {

--- a/Sources/Charcoal/Filters/Root/Views/FilterBottomButtonView.swift
+++ b/Sources/Charcoal/Filters/Root/Views/FilterBottomButtonView.swift
@@ -13,6 +13,7 @@ class FilterBottomButtonView: UIView {
 
     private lazy var button: Button = {
         let button = Button(style: .callToAction)
+        button.titleLabel?.adjustsFontForContentSizeCategory = true
         button.addTarget(self, action: #selector(didTapButton), for: .touchUpInside)
         button.translatesAutoresizingMaskIntoConstraints = false
         return button

--- a/Sources/Charcoal/Filters/Root/Views/RootFilterCell.swift
+++ b/Sources/Charcoal/Filters/Root/Views/RootFilterCell.swift
@@ -106,6 +106,7 @@ final class RootFilterCell: BasicTableViewCell {
 
     private func setup() {
         titleLabel.font = .bodyRegular
+        titleLabel.adjustsFontForContentSizeCategory = true
         titleLabel.textColor = .licorice
 
         setContextMarkBackground()

--- a/Sources/Charcoal/Filters/Root/Views/VerticalSelectorView.swift
+++ b/Sources/Charcoal/Filters/Root/Views/VerticalSelectorView.swift
@@ -32,6 +32,7 @@ final class VerticalSelectorView: UIView {
     private lazy var titleLabel: UILabel = {
         let label = UILabel(withAutoLayout: true)
         label.font = UIFont.captionStrong.withSize(12).scaledFont(forTextStyle: .footnote)
+        label.adjustsFontForContentSizeCategory = true
         label.textColor = .spaceGray
         label.textAlignment = .center
         return label
@@ -40,6 +41,7 @@ final class VerticalSelectorView: UIView {
     private lazy var button: UIButton = {
         let button = UIButton(withAutoLayout: true)
         button.titleLabel?.font = UIFont.bodyStrong(withSize: 17, textStyle: .footnote)
+        button.titleLabel?.adjustsFontForContentSizeCategory = true
 
         button.setTitleColor(.primaryBlue, for: .normal)
         button.setTitleColor(.callToActionButtonHighlightedBodyColor, for: .highlighted)

--- a/Sources/Charcoal/Filters/Stepper/StepperFilterView.swift
+++ b/Sources/Charcoal/Filters/Stepper/StepperFilterView.swift
@@ -27,6 +27,7 @@ final class StepperFilterView: UIControl {
         let label = UILabel(frame: .zero)
         label.text = "\(value)+ \(unit)"
         label.font = .title2
+        label.adjustsFontForContentSizeCategory = true
         label.textColor = .licorice
         label.numberOfLines = 0
         label.translatesAutoresizingMaskIntoConstraints = false

--- a/Sources/Charcoal/Selection/Views/SelectionTagViewCell.swift
+++ b/Sources/Charcoal/Selection/Views/SelectionTagViewCell.swift
@@ -16,6 +16,7 @@ final class SelectionTagViewCell: UICollectionViewCell {
     private lazy var titleLabel: UILabel = {
         let label = UILabel(withAutoLayout: true)
         label.font = SelectionTagViewCell.titleFont
+        label.adjustsFontForContentSizeCategory = true
         label.textColor = .milk
         label.textAlignment = .center
         return label

--- a/Sources/Charcoal/Vertical/VerticalCell.swift
+++ b/Sources/Charcoal/Vertical/VerticalCell.swift
@@ -71,10 +71,14 @@ final class VerticalCell: UITableViewCell {
         self.selectedBackgroundView = selectedBackgroundView
 
         separatorInset = .leadingInset(56)
+
         textLabel?.font = .bodyRegular
         textLabel?.textColor = .licorice
+        textLabel?.adjustsFontForContentSizeCategory = true
+
         detailTextLabel?.font = .detail
         detailTextLabel?.textColor = .stone
+        detailTextLabel?.adjustsFontForContentSizeCategory = true
 
         addSubview(radioButton)
 


### PR DESCRIPTION
# Why?

Because before you had to restart the app in order to see updated fonts after setting larger accessibility sizes in settings.

# What?

- Set `adjustsFontForContentSizeCategory` to `true` where it's needed
- Reload navigation bar title and inline filters when `preferredContentSizeCategory` changes

# Show me

![dynamic](https://user-images.githubusercontent.com/10529867/57628729-c6121d00-759a-11e9-9de5-0ea2051e7689.gif)
