### PR TITLE
Fix vertical selector on iOS10

### DIFF
--- a/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
+++ b/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
@@ -30,7 +30,7 @@ final class RootFilterViewController: FilterViewController {
 
     // MARK: - Private properties
 
-    private lazy var verticalSelectorView = VerticalSelectorView()
+    private lazy var verticalSelectorView = VerticalSelectorView(withAutoLayout: true)
 
     private lazy var tableView: UITableView = {
         let tableView = UITableView(frame: .zero, style: .plain)


### PR DESCRIPTION
# Why?

Because there was something wrong with using auto-layout in navigation bar title view.

# What?

It seems like we should explicitly set `translatesautoresizingmaskintoconstraints` to `false` on iOS10.

# Show me

### Before

![before](https://user-images.githubusercontent.com/10529867/57768102-32ac2980-770b-11e9-839e-542659337038.png)

### After

![after](https://user-images.githubusercontent.com/10529867/57768110-3770dd80-770b-11e9-9bdf-195659439479.png)