### PR TITLE
Fix unit label on iOS10

### DIFF
--- a/Sources/Charcoal/Filters/Range/Input/NumberInputView.swift
+++ b/Sources/Charcoal/Filters/Range/Input/NumberInputView.swift
@@ -173,7 +173,7 @@ final class NumberInputView: UIView {
             textField.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -.mediumSpacing),
 
             unitLabel.topAnchor.constraint(equalTo: textField.topAnchor),
-            unitLabel.leadingAnchor.constraint(equalTo: textField.trailingAnchor),
+            unitLabel.leadingAnchor.constraint(equalTo: textField.trailingAnchor, constant: .mediumSpacing),
             unitLabel.bottomAnchor.constraint(equalTo: textField.bottomAnchor),
             unitLabel.trailingAnchor.constraint(equalTo: trailingAnchor),
 
@@ -192,7 +192,6 @@ final class NumberInputView: UIView {
     private func attributedUnitText(withFont font: UIFont?, from unit: FilterUnit) -> NSAttributedString {
         let style = NSMutableParagraphStyle()
         style.alignment = .justified
-        style.firstLineHeadIndent = .mediumSpacing
         style.headIndent = .mediumSpacing
         style.tailIndent = -.mediumSpacing
         style.lineBreakMode = .byCharWrapping


### PR DESCRIPTION
# Why?

Because the unit label in ranges had incorrect width on iOS10.

# What?

Replace `firstLineHeadIndent` with anchor constant, which works well both on iOS10 and above.

# Show me

### Before

![before](https://user-images.githubusercontent.com/10529867/58020502-9a49e680-7b08-11e9-9488-ef0aa9b960e1.png)

### After

![after](https://user-images.githubusercontent.com/10529867/58020524-a9309900-7b08-11e9-9294-176ce7487c01.png)
