### PR TITLE
Bug/grid view constraints

### DIFF
--- a/Sources/Charcoal/CharcoalViewController.swift
+++ b/Sources/Charcoal/CharcoalViewController.swift
@@ -189,7 +189,6 @@ extension CharcoalViewController: FilterViewControllerDelegate {
             guard !filter.subfilters.isEmpty else { break }
 
             let gridViewController = GridFilterViewController(filter: filter, selectionStore: selectionStore)
-//            gridViewController.showBottomButton(viewController.isShowingBottomButton, animated: false)
 
             pushViewController(gridViewController)
         case let .range(lowValueFilter, highValueFilter, filterConfig):

--- a/Sources/Charcoal/CharcoalViewController.swift
+++ b/Sources/Charcoal/CharcoalViewController.swift
@@ -189,7 +189,7 @@ extension CharcoalViewController: FilterViewControllerDelegate {
             guard !filter.subfilters.isEmpty else { break }
 
             let gridViewController = GridFilterViewController(filter: filter, selectionStore: selectionStore)
-            gridViewController.showBottomButton(viewController.isShowingBottomButton, animated: false)
+//            gridViewController.showBottomButton(viewController.isShowingBottomButton, animated: false)
 
             pushViewController(gridViewController)
         case let .range(lowValueFilter, highValueFilter, filterConfig):

--- a/Sources/Charcoal/Filters/Grid/GridFilterViewController.swift
+++ b/Sources/Charcoal/Filters/Grid/GridFilterViewController.swift
@@ -12,11 +12,12 @@ final class GridFilterViewController: FilterViewController {
         collectionView.allowsMultipleSelection = true
         collectionView.dataSource = self
         collectionView.delegate = self
-        collectionView.contentInset = UIEdgeInsets(top: .mediumLargeSpacing, left: 27, bottom: 0, right: 27)
+        collectionView.contentInset = UIEdgeInsets(top: .mediumLargeSpacing, left: edgeInset, bottom: 0, right: edgeInset)
         collectionView.register(GridFilterCell.self)
         return collectionView
     }()
 
+    private let edgeInset: CGFloat = 27
     private let filter: Filter
 
     // MARK: - Init
@@ -84,7 +85,7 @@ extension GridFilterViewController: UICollectionViewDelegateFlowLayout {
                         layout collectionViewLayout: UICollectionViewLayout,
                         sizeForItemAt indexPath: IndexPath) -> CGSize {
         let numberOfItemsPerRow: CGFloat = 5
-        let side = (collectionView.frame.width / numberOfItemsPerRow) - .mediumSpacing
+        let side = ((collectionView.frame.width - edgeInset * 2) / numberOfItemsPerRow) - .mediumSpacing
 
         return CGSize(width: side, height: side)
     }

--- a/Sources/Charcoal/Filters/Grid/GridFilterViewController.swift
+++ b/Sources/Charcoal/Filters/Grid/GridFilterViewController.swift
@@ -12,6 +12,7 @@ final class GridFilterViewController: FilterViewController {
         collectionView.allowsMultipleSelection = true
         collectionView.dataSource = self
         collectionView.delegate = self
+        collectionView.contentInset = UIEdgeInsets(top: .mediumLargeSpacing, left: 27, bottom: 0, right: 27)
         collectionView.register(GridFilterCell.self)
         return collectionView
     }()
@@ -34,6 +35,7 @@ final class GridFilterViewController: FilterViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         bottomButton.buttonTitle = "applyButton".localized()
+        showBottomButton(false, animated: false)
         setup()
     }
 
@@ -49,8 +51,14 @@ final class GridFilterViewController: FilterViewController {
     // MARK: - Setup
 
     private func setup() {
-        view.addSubview(collectionView)
-        collectionView.fillInSuperview(insets: UIEdgeInsets(top: .mediumLargeSpacing, left: 27, bottom: 0, right: -27))
+        view.insertSubview(collectionView, belowSubview: bottomButton)
+
+        NSLayoutConstraint.activate([
+            collectionView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            collectionView.topAnchor.constraint(equalTo: view.topAnchor),
+            collectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            collectionView.bottomAnchor.constraint(equalTo: bottomButton.topAnchor),
+        ])
     }
 }
 


### PR DESCRIPTION
# Why?

There was a bug where the apply button was covered by the grid filter.

# What?

- Made sure collection view was added under the bottom button
- Constrained the collection view to bottom button top anchor
- Replace constraint constants with content inset
- Add edge insets to item size calculation
- Not show bottom button when entering grid filter.

# Show me

### Before

![Simulator Screen Shot - iPhone Xs - 2019-06-25 at 13 45 33](https://user-images.githubusercontent.com/19956175/60096331-f24fba80-9750-11e9-9650-09cacca0e134.png)

### After

![Simulator Screen Shot - iPhone Xs - 2019-06-25 at 13 50 58](https://user-images.githubusercontent.com/19956175/60096347-f976c880-9750-11e9-8de7-98cc9b1469b6.png)
