### PR TITLE
Use a gregorian calendar for current year in year range filters

### DIFF
--- a/Sources/FINNSetup/Extensions/RangeFilterConfiguration+FINNSetup.swift
+++ b/Sources/FINNSetup/Extensions/RangeFilterConfiguration+FINNSetup.swift
@@ -18,9 +18,11 @@ extension RangeFilterConfiguration {
     }
 
     static func yearConfiguration(minimumValue: Int) -> RangeFilterConfiguration {
+        let gregorianCalendar = Calendar(identifier: .gregorian)
+        let currentYear = gregorianCalendar.component(.year, from: Date())
         return .configuration(
             minimumValue: minimumValue,
-            maximumValue: Calendar.current.component(.year, from: Date()),
+            maximumValue: currentYear,
             increment: 1,
             unit: .year
         )


### PR DESCRIPTION
# Why?
If a user has, for instance, Japanese calendar the year part of current date can come back as 31, which will not work well for a year filter with minimum date 1900... Probably the cause of some of our crashes.

# What?
Use a gregorian calendar for current year in year range filters since minimum value (and backend) already assumes gregorian.

The other option would be to change minimum year to also be using the users calendar, but that would also need to be handled when communicating with backend. Since this is part of the FINN setup I believe it is fine to use (and show) Gregorian year.
