### PR TITLE
Add anchor for popoverPresentationController on iPad

### DIFF
--- a/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
+++ b/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
@@ -232,6 +232,10 @@ final class RootFilterViewController: FilterViewController {
         alertController.addAction(resetAction)
         alertController.addAction(cancelAction)
 
+        if let popoverController = alertController.popoverPresentationController {
+            popoverController.barButtonItem = resetButton
+        }
+
         present(alertController, animated: true)
     }
 }


### PR DESCRIPTION
# Why?

Need to be able to present the `UIAlertController` for clearing the filter on iPad.

# What?

Anchored the `popoverPresentationController` to the `UIBarButtonItem` `resetButton` if it's present.

# Show me

### Before

Was not available on the iPad

### After

![Simulator Screen Shot - iPad Air - 2019-08-14 at 10 05 53](https://user-images.githubusercontent.com/3852639/63004998-f4461800-be7b-11e9-85d9-0e370f587ce7.png)
