### PR TITLE
Center OnboardingCell content in contentView

### DIFF
--- a/Sources/Charcoal/Onboarding/OnboardingCell.swift
+++ b/Sources/Charcoal/Onboarding/OnboardingCell.swift
@@ -7,16 +7,23 @@ import UIKit
 final class OnboardingCell: UICollectionViewCell {
     // MARK: - Private properties
 
-    private static let imageHeight: CGFloat = 200
+    private lazy var stackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [imageView, textLabel])
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .vertical
+        stackView.alignment = .center
+        stackView.spacing = .largeSpacing
+        return stackView
+    }()
 
     private lazy var imageView: UIImageView = {
-        let imageView = UIImageView(withAutoLayout: true)
+        let imageView = UIImageView()
         imageView.contentMode = .center
         return imageView
     }()
 
     private lazy var textLabel: UILabel = {
-        let label = UILabel(withAutoLayout: true)
+        let label = UILabel()
         label.numberOfLines = 0
         return label
     }()
@@ -49,18 +56,13 @@ final class OnboardingCell: UICollectionViewCell {
     // MARK: - Private methods
 
     private func setup() {
-        contentView.addSubview(imageView)
-        contentView.addSubview(textLabel)
+        contentView.addSubview(stackView)
 
         NSLayoutConstraint.activate([
-            imageView.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
-            imageView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor, constant: -OnboardingCell.imageHeight / 4),
-            imageView.widthAnchor.constraint(equalToConstant: 320),
+            stackView.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
+            stackView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            stackView.widthAnchor.constraint(equalToConstant: 320),
             imageView.heightAnchor.constraint(equalToConstant: 200),
-
-            textLabel.leadingAnchor.constraint(equalTo: imageView.leadingAnchor, constant: .mediumSpacing),
-            textLabel.trailingAnchor.constraint(equalTo: imageView.trailingAnchor, constant: -.mediumSpacing),
-            textLabel.topAnchor.constraint(equalTo: imageView.bottomAnchor, constant: .largeSpacing),
         ])
     }
 }

--- a/Sources/Charcoal/Onboarding/OnboardingCell.swift
+++ b/Sources/Charcoal/Onboarding/OnboardingCell.swift
@@ -7,6 +7,8 @@ import UIKit
 final class OnboardingCell: UICollectionViewCell {
     // MARK: - Private properties
 
+    private static let imageHeight: CGFloat = 200
+
     private lazy var imageView: UIImageView = {
         let imageView = UIImageView(withAutoLayout: true)
         imageView.contentMode = .center
@@ -52,7 +54,7 @@ final class OnboardingCell: UICollectionViewCell {
 
         NSLayoutConstraint.activate([
             imageView.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
-            imageView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 52),
+            imageView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor, constant: -OnboardingCell.imageHeight / 4),
             imageView.widthAnchor.constraint(equalToConstant: 320),
             imageView.heightAnchor.constraint(equalToConstant: 200),
 

--- a/Sources/Charcoal/Onboarding/OnboardingViewController.swift
+++ b/Sources/Charcoal/Onboarding/OnboardingViewController.swift
@@ -254,7 +254,7 @@ private extension OnboardingViewController {
             collectionView.bottomAnchor.constraint(equalTo: previousButton.topAnchor, constant: -.largeSpacing),
 
             skipButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -.mediumSpacing),
-            skipButton.topAnchor.constraint(equalTo: view.topAnchor, constant: .mediumSpacing),
+            skipButton.topAnchor.constraint(equalTo: view.topAnchor, constant: -.mediumSpacing),
 
             pageControl.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             pageControl.centerYAnchor.constraint(equalTo: collectionView.bottomAnchor),

--- a/Sources/Charcoal/Onboarding/OnboardingViewController.swift
+++ b/Sources/Charcoal/Onboarding/OnboardingViewController.swift
@@ -254,7 +254,7 @@ private extension OnboardingViewController {
             collectionView.bottomAnchor.constraint(equalTo: previousButton.topAnchor, constant: -.largeSpacing),
 
             skipButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -.mediumSpacing),
-            skipButton.topAnchor.constraint(equalTo: view.topAnchor, constant: -.mediumSpacing),
+            skipButton.topAnchor.constraint(equalTo: view.topAnchor, constant: .mediumSpacing),
 
             pageControl.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             pageControl.centerYAnchor.constraint(equalTo: collectionView.bottomAnchor),


### PR DESCRIPTION
# Why?

Since Charcoal is being enabled on iPad the `OnboardingCell` content should be centered within the `contentView`, not anchored to the top.

# What?

Moved the two existing views into a `UIStackView` that's centered within the `contentView`

# Show me

### Before

![Simulator Screen Shot - iPhone Xs - 2019-08-15 at 14 03 01](https://user-images.githubusercontent.com/3852639/63093704-86c2e600-bf66-11e9-8426-9f70ff917e3b.png)
![Simulator Screen Shot - iPhone Xs - 2019-08-15 at 14 03 03](https://user-images.githubusercontent.com/3852639/63093705-86c2e600-bf66-11e9-964b-30d2ac3f88ba.png)

### After

![Simulator Screen Shot - iPhone Xs - 2019-08-15 at 14 06 43](https://user-images.githubusercontent.com/3852639/63093696-80346e80-bf66-11e9-87a8-a04c31944590.png)
![Simulator Screen Shot - iPhone Xs - 2019-08-15 at 14 06 45](https://user-images.githubusercontent.com/3852639/63093697-80346e80-bf66-11e9-96c7-717bc5868ed3.png)

