### PR TITLE
Remove text about the bottom button always being visible

### DIFF
--- a/Sources/Charcoal/Resources/en.lproj/Localizable.strings
+++ b/Sources/Charcoal/Resources/en.lproj/Localizable.strings
@@ -90,7 +90,7 @@
 "callout.b2b" = "Trykk her i toppen for å se andre kategorier som Buss og minibuss, Bygg og anlegg, Traktor etc.";
 "callout.job" = "Trykk her i toppen for å se annonser for Deltidsstillinger og Lederstillinger";
 
-"callout.bottomButton" = "Trykk på Bruk-knappen her i bunnen for å gå videre med valget ditt. Denne vil alltid dukke opp her i slutten av en kategori.";
+"callout.bottomButton" = "Trykk på Bruk-knappen for å gå videre.";
 
 "alert.reset.message" = "Er du sikker på at du vil nullstille\nog fjerne alle dine filtervalg?";
 "alert.action.reset" = "Nullstill filteret";


### PR DESCRIPTION
# Why?

Need to remove the last part of the string, stating that the "Bruk"-button always will be visible, since it is not true. 

# What?

Removed the unwanted part

# Show me

### Before

![Simulator Screen Shot - iPad Air - 2019-08-22 at 08 36 39](https://user-images.githubusercontent.com/3852639/65154594-12c7a200-da2c-11e9-9337-f2358a2d01b6.png)


### After

![Simulator Screen Shot - iPad Air - 2019-09-18 at 15 48 14](https://user-images.githubusercontent.com/3852639/65154615-19eeb000-da2c-11e9-81b0-5e3692895731.png)
