### PR TITLE
Fix: Filter tag spacing

### DIFF
--- a/Sources/Charcoal/Filters/Root/Views/RootFilterCell.swift
+++ b/Sources/Charcoal/Filters/Root/Views/RootFilterCell.swift
@@ -119,6 +119,11 @@ final class RootFilterCell: BasicTableViewCell {
         stackViewTopAnchorConstraint.constant = .mediumLargeSpacing
         stackViewBottomAnchorConstraint.constant = -.mediumLargeSpacing
 
+        var selectionTagsContainerTrailingConstant: CGFloat = .smallSpacing
+        if #available(iOS 13, *) {
+            selectionTagsContainerTrailingConstant -= .mediumSpacing
+        }
+
         NSLayoutConstraint.activate([
             contextMark.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: .mediumLargeSpacing + .mediumSpacing),
             contextMark.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
@@ -127,7 +132,7 @@ final class RootFilterCell: BasicTableViewCell {
 
             selectionTagsContainerView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
             selectionTagsContainerView.leadingAnchor.constraint(equalTo: titleLabel.trailingAnchor, constant: .mediumLargeSpacing),
-            selectionTagsContainerView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: .smallSpacing),
+            selectionTagsContainerView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: selectionTagsContainerTrailingConstant),
 
             hairLine.heightAnchor.constraint(equalToConstant: 1.0 / UIScreen.main.scale),
             hairLine.bottomAnchor.constraint(equalTo: bottomAnchor),


### PR DESCRIPTION
# Why?
Because of the changes in chevron spacing in iOS 13, the filter tags were being pushed onto the chevron.

# What?
- Subtract `.mediumSpacing` if iOS 13.

# Show me

| iOS version | Before | After |
| --- | --- | --- |
| iOS 13 | <img width="545" alt="Screenshot 2019-10-23 at 12 35 30" src="https://user-images.githubusercontent.com/1901556/67384762-15209d00-f592-11e9-996c-0cbeca990496.png"> | <img width="545" alt="Screenshot 2019-10-23 at 12 36 03" src="https://user-images.githubusercontent.com/1901556/67384771-1651ca00-f592-11e9-99c2-735a6c48b447.png"> |
| iOS 11.4 | <img width="545" alt="Screenshot 2019-10-23 at 12 36 54" src="https://user-images.githubusercontent.com/1901556/67384795-2073c880-f592-11e9-9c15-796f2a1eb5cb.png"> | 👈 Same as before |