### PR TITLE
NavigationBar appearance

### DIFF
--- a/Sources/Charcoal/CharcoalViewController.swift
+++ b/Sources/Charcoal/CharcoalViewController.swift
@@ -115,7 +115,7 @@ public final class CharcoalViewController: UINavigationController {
         navigationBar.setBackgroundImage(UIImage(), for: .default)
 
         if #available(iOS 13.0, *) {
-            let appearance = UINavigationBarAppearance()
+            let appearance = UINavigationBar.appearance().standardAppearance.copy()
             appearance.configureWithTransparentBackground()
             appearance.backgroundColor = .bgPrimary
 

--- a/Sources/Charcoal/CharcoalViewController.swift
+++ b/Sources/Charcoal/CharcoalViewController.swift
@@ -113,7 +113,18 @@ public final class CharcoalViewController: UINavigationController {
     private func setupNavigationBar() {
         navigationBar.isTranslucent = false
         navigationBar.setBackgroundImage(UIImage(), for: .default)
-        navigationBar.shadowImage = UIImage()
+
+        if #available(iOS 13.0, *) {
+            let appearance = UINavigationBarAppearance()
+            appearance.configureWithTransparentBackground()
+            appearance.backgroundColor = .bgPrimary
+
+            navigationBar.standardAppearance = appearance
+            navigationBar.compactAppearance = appearance
+            navigationBar.scrollEdgeAppearance = appearance
+        } else {
+            navigationBar.shadowImage = UIImage()
+        }
     }
 }
 


### PR DESCRIPTION
# Why?
On iOS 13+ we need to set the appearance for `UINavigationBar` with `UINavigationBarAppearance`.

Currently we've tried to remove the shadow image by using `navigationBar.shadowImage = UIImage()`, but this doesn't seem to work anymore.

These changes fetches the default appearance for `UINavigationBar` and overrides it for this specific navigationBar.

# What?
- Use `UINavigationBarAppearance` to set appearance if iOS 13+.

# Show me
| Before | After |
| --- | --- |
| ![Image from iOS (10)](https://user-images.githubusercontent.com/1901556/67958351-5864b680-fbf7-11e9-803f-dcd91b0686ca.png) | ![Image from iOS (11)](https://user-images.githubusercontent.com/1901556/67959540-3409d980-fbf9-11e9-830a-7c3612c9d27d.png) |