### PR TITLE
Fix: RangeSlider bounds placement

### DIFF
--- a/Sources/Charcoal/Filters/Range/Slider/RangeSliderView.swift
+++ b/Sources/Charcoal/Filters/Range/Slider/RangeSliderView.swift
@@ -220,9 +220,9 @@ extension RangeSliderView: StepSliderDelegate {
 
     func stepSlider(_ stepSlider: StepSlider, canChangeToStep step: Step) -> Bool {
         if stepSlider == highValueSlider {
-            return step >= lowValueSlider.step
+            return step != .lowerBound && step >= lowValueSlider.step
         } else if stepSlider == lowValueSlider {
-            return step <= highValueSlider.step
+            return step != .upperBound && step <= highValueSlider.step
         } else {
             return true
         }


### PR DESCRIPTION
# Why?
We've had some complaints that it's possible to place both sliders in the `RangeSlider` in either the upper or lower bounds. These bounds have a value of `nil`, and won't set a value.

These changes makes sure that the `highValueSlider` isn't able to be placed in `lowerBound`, and `lowValueSlider` in `upperBound`.

# What?
- Add check for upper/lower bound placement for sliders.

# Show me

| Before | After |
| --- | --- |
| ![charcoal-slider-minmax-before](https://user-images.githubusercontent.com/1901556/68193522-75143c00-ffb3-11e9-8727-cdfa49f6130f.gif) | ![charcoal-slider-minmax-after](https://user-images.githubusercontent.com/1901556/68193525-76456900-ffb3-11e9-85fb-5e0431fa5e21.gif) |