### PR TITLE
Ensure we center on user location when loading MapFilterView

### DIFF
--- a/Sources/Charcoal/Filters/Map/MapFilterViewController.swift
+++ b/Sources/Charcoal/Filters/Map/MapFilterViewController.swift
@@ -32,7 +32,6 @@ final class MapFilterViewController: FilterViewController {
     private let locationNameFilter: Filter
     private let locationManager = CLLocationManager()
     private var nextRegionChangeIsFromUserInteraction = false
-    private var hasRequestedLocationAuthorization = false
     private var hasChanges = false
     private var isMapLoaded = false
 
@@ -133,7 +132,6 @@ final class MapFilterViewController: FilterViewController {
 
     private func attemptToActivateUserLocationSupport() {
         if CLLocationManager.locationServicesEnabled(), CLLocationManager.authorizationStatus() == .notDetermined {
-            hasRequestedLocationAuthorization = true
             locationManager.requestWhenInUseAuthorization()
         } else {
             // Not authorized

--- a/Sources/Charcoal/Filters/Map/MapFilterViewController.swift
+++ b/Sources/Charcoal/Filters/Map/MapFilterViewController.swift
@@ -215,10 +215,7 @@ extension MapFilterViewController: MKMapViewDelegate {
     }
 
     func mapView(_ mapView: MKMapView, didUpdate userLocation: MKUserLocation) {
-        if hasRequestedLocationAuthorization {
-            centerOnUserLocation()
-            hasRequestedLocationAuthorization = false
-        }
+        mapFilterView.centerOnInitialCoordinate()
     }
 }
 


### PR DESCRIPTION
# Why

Given the issue "Område i kart does not always open at users current
location, but in center of Oslo"
https://sch-chat.slack.com/archives/C049P0P78/p1564999530014900


# In detail

I added some logs while developing and I found the following two
scenarios:

Scenario 1:
```
>>>>> viewDidLoad()
>>>>> init(radius:centerCoordinate:)
>>>>> centerOnInitialCoordinate() nil
>>>>> set deleage
>>>>> initialize mapFilterView and set delegate
>>>>> mapView(_:didUpdate:) false Location(60.392104, 5.321791)
>>>>> mapViewDidFinishLoadingMap(_:) Optional(<+60.39210400,+5.32179100> +/- 5.00m (speed -1.00 mps / course -1.00) @ 11/6/19, 10:36:09 AM Central European Standard Time)
>>>>> centerOnInitialCoordinate() Optional(<+60.39210400,+5.32179100> +/- 5.00m (speed -1.00 mps / course -1.00) @ 11/6/19, 10:36:09 AM Central European Standard Time)
```

Scenario 2:
```
>>>>> viewDidLoad()
>>>>> init(radius:centerCoordinate:)
>>>>> centerOnInitialCoordinate() nil
>>>>> set deleage
>>>>> initialize mapFilterView and set delegate
>>>>> mapViewDidFinishLoadingMap(_:) nil
>>>>> centerOnInitialCoordinate() nil
>>>>> mapView(_:didUpdate:) false Location(60.392104, 5.321791)
```

In the first scenario `mapView(_:didUpdate:)` returns before
`mapViewDidFinishLoadingMap`. That means the user location is available when
calling `centerOnInitialCoordinate()`.

In the second one, since `mapView(_:didUpdate:)` returns **After**
`mapViewDidFinishLoadingMap`, then the location was not yet available
when calling `centerOnInitialCoordinate`.

Finally the fix is to allow `mapView(_:didUpdate:)` to call
`centerOnInitialCoordinate` when called, since that means the user location
was requested and its available if there was not a previous search
location, avoiding the race condition there.