### PR TITLE
Fix: avoid automatic re-centering on the filter map after scrolling

### DIFF
--- a/Sources/Charcoal/Filters/Map/MapFilterViewController.swift
+++ b/Sources/Charcoal/Filters/Map/MapFilterViewController.swift
@@ -31,6 +31,7 @@ final class MapFilterViewController: FilterViewController {
     private let radiusFilter: Filter
     private let locationNameFilter: Filter
     private let locationManager = CLLocationManager()
+    private var hasRequestedLocationAuthorization = false
     private var nextRegionChangeIsFromUserInteraction = false
     private var hasChanges = false
     private var isMapLoaded = false
@@ -132,6 +133,7 @@ final class MapFilterViewController: FilterViewController {
 
     private func attemptToActivateUserLocationSupport() {
         if CLLocationManager.locationServicesEnabled(), CLLocationManager.authorizationStatus() == .notDetermined {
+            hasRequestedLocationAuthorization = true
             locationManager.requestWhenInUseAuthorization()
         } else {
             // Not authorized
@@ -213,7 +215,10 @@ extension MapFilterViewController: MKMapViewDelegate {
     }
 
     func mapView(_ mapView: MKMapView, didUpdate userLocation: MKUserLocation) {
-        mapFilterView.centerOnInitialCoordinate()
+        if hasRequestedLocationAuthorization {
+            mapFilterView.centerOnInitialCoordinate()
+            hasRequestedLocationAuthorization = false
+        }
     }
 }
 


### PR DESCRIPTION
# Why?

@hakloev reported a bug about this https://sch-chat.slack.com/archives/G0903G630/p1574771877180300

The functionality was removed in #310 and caused that the map would re-center on the user
location after scrolling away. Curiously enough, this only seem to happen on device, not on the simulator

# What?

- Restore `hasRequestedLocationAuthorization`