### PR TITLE
Internal: Add "squash" strategy setting for charcoal

### DIFF
--- a/.pr_changelog.json
+++ b/.pr_changelog.json
@@ -1,0 +1,3 @@
+{
+  "strategy": "squash"
+}

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'fastlane', '2.133.0'
+gem 'pr_changelog', '~> 0.4.0'
 
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
 eval_gemfile(plugins_path) if File.exist?(plugins_path)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,7 @@ GEM
     naturally (2.2.0)
     os (1.0.1)
     plist (3.5.0)
+    pr_changelog (0.4.0)
     public_suffix (2.0.5)
     representable (3.0.4)
       declarative (< 0.1.0)
@@ -156,6 +157,7 @@ PLATFORMS
 DEPENDENCIES
   fastlane (= 2.133.0)
   fastlane-plugin-appcenter
+  pr_changelog (~> 0.4.0)
 
 BUNDLED WITH
    2.0.2

--- a/README.md
+++ b/README.md
@@ -144,6 +144,24 @@ let selection = Set([
 viewController.set(selection: selection)
 ```
 
+## Changelogs
+
+This project has a `Gemfile` that specify some development dependencies, one of those is `pr_changelog` which is a tool that helps you to generate changelogs from the Git history of the repo. You install this by running `bundle install`.
+
+To get the changes that have not been released yet just run:
+
+```
+$ pr_changelog
+```
+
+If you want to see what changes were released in the last version, run:
+
+```
+$ pr_changelog --last-release
+```
+
+You can always run the command with the `--help` flag when needed.
+
 ## Dependencies
 
 Some of the UI elements in **Charcoal** are taken from [FinniversKit](https://github.com/finn-no/FinniversKit),


### PR DESCRIPTION
for the `pr_changelog` command utility

# Why?

To generate changelogs for this repo more easily

# What?

- Add changelog instructions in the README
- Add `pr_changelog` to the Gemfile
- Add the configuration file `.pr_changelog.json`, so then to generate a list of
unreleased changes for this repo you can just run

```
pr_changelog
```