### PR TITLE
Add support for showing info callout about region reform

### DIFF
--- a/Demo/DataSource.swift
+++ b/Demo/DataSource.swift
@@ -21,6 +21,7 @@ class DataSource: NSObject {
         Row(title: "Torget", setup: .bap, usingBottomSheet: true),
         Row(title: "Torget (iPad)", type: DrawerPresentationViewController.self, setup: .bap),
         Row(title: "Bil", setup: .car, usingBottomSheet: true),
+        Row(title: "Bil with region callout", setup: .carWithRegionReformCallout, usingBottomSheet: true),
         Row(title: "Eiendom", setup: .realestate, usingBottomSheet: true),
         Row(title: "Jobb", setup: .job, usingBottomSheet: true),
         Row(title: "Båt", setup: .boat, usingBottomSheet: true),

--- a/Demo/Setup.swift
+++ b/Demo/Setup.swift
@@ -15,13 +15,14 @@ class Setup {
         }
     }
 
-    private init(markets: [DemoVertical]) {
+    private init(markets: [DemoVertical], includeRegionReformCallout: Bool = false) {
         self.markets = markets
         current = markets.first
 
         if let current = current {
             filterContainer = Setup.filterContainer(name: current.name)
             filterContainer?.verticals = markets
+            filterContainer?.regionReformCalloutText = includeRegionReformCallout ? "Obs! Vi har oppdatert områdevalg til å passe til de nye kommunene i Norge" : nil
         }
     }
 
@@ -74,6 +75,18 @@ extension Setup {
             DemoVertical(name: "mobile-home", title: "Bobil"),
             DemoVertical(name: "caravan", title: "Campingvogn"),
         ])
+    }
+
+    static var carWithRegionReformCallout: Setup {
+        return Setup(
+            markets: [
+                DemoVertical(name: "car-norway", title: "Biler i Norge", isCurrent: true),
+                DemoVertical(name: "car-abroad", title: "Biler i utlandet"),
+                DemoVertical(name: "mobile-home", title: "Bobil"),
+                DemoVertical(name: "caravan", title: "Campingvogn"),
+            ],
+            includeRegionReformCallout: true
+        )
     }
 
     static var realestate: Setup {

--- a/Sources/Charcoal/CharcoalViewController.swift
+++ b/Sources/Charcoal/CharcoalViewController.swift
@@ -75,7 +75,7 @@ public final class CharcoalViewController: UINavigationController {
 
         if let text = filterContainer?.regionReformCalloutText, !userDefaults.regionReformCalloutShown {
             showCalloutOverlay(withText: text, andDirection: .down, constrainedToTopAnchor: navigationBar.bottomAnchor)
-            // TODO: userDefaults.regionReformCalloutShown = true
+            userDefaults.regionReformCalloutShown = true
         }
     }
 

--- a/Sources/Charcoal/CharcoalViewController.swift
+++ b/Sources/Charcoal/CharcoalViewController.swift
@@ -43,6 +43,8 @@ public final class CharcoalViewController: UINavigationController {
         didSet { rootFilterViewController?.showLoadingIndicator(isLoading) }
     }
 
+    public var canShowRegionReformCallout = false
+
     // MARK: - Private properties
 
     private var selectionHasChanged = false
@@ -71,9 +73,9 @@ public final class CharcoalViewController: UINavigationController {
 
         let userDefaults = UserDefaults.standard
 
-        if let text = filterContainer?.locationChangesCalloutText, !userDefaults.locationChangesCalloutShown {
+        if let text = filterContainer?.regionReformCalloutText, !userDefaults.regionReformCalloutShown {
             showCalloutOverlay(withText: text, andDirection: .down, constrainedToTopAnchor: navigationBar.bottomAnchor)
-            // TODO: userDefaults.locationChangesCalloutShown = true
+            // TODO: userDefaults.regionReformCalloutShown = true
         }
     }
 
@@ -333,7 +335,7 @@ extension CharcoalViewController: CalloutOverlayDelegate {
 // MARK: - UserDefaults
 
 private extension UserDefaults {
-    var locationChangesCalloutShown: Bool {
+    var regionReformCalloutShown: Bool {
         get { return bool(forKey: "Charcoal." + #function) }
         set { set(newValue, forKey: "Charcoal." + #function) }
     }

--- a/Sources/Charcoal/CharcoalViewController.swift
+++ b/Sources/Charcoal/CharcoalViewController.swift
@@ -71,9 +71,9 @@ public final class CharcoalViewController: UINavigationController {
 
         let userDefaults = UserDefaults.standard
 
-        if let text = filterContainer?.verticalsCalloutText, !userDefaults.verticalCalloutShown {
-            showCalloutOverlay(withText: text, andDirection: .up, constrainedToAnchor: navigationBar.bottomAnchor)
-            userDefaults.verticalCalloutShown = true
+        if let text = filterContainer?.locationChangesCalloutText, !userDefaults.locationChangesCalloutShown {
+            showCalloutOverlay(withText: text, andDirection: .down, constrainedToTopAnchor: navigationBar.bottomAnchor)
+            // TODO: userDefaults.locationChangesCalloutShown = true
         }
     }
 
@@ -181,7 +181,7 @@ extension CharcoalViewController: FilterViewControllerDelegate {
                 viewController is StepperFilterViewController ||
                 viewController is GridFilterViewController {
                 UserDefaults.standard.bottomButtomCalloutShown = true
-                showCalloutOverlay(withText: "callout.bottomButton".localized(), andDirection: .down, constrainedToAnchor: viewController.bottomButton.topAnchor)
+                showCalloutOverlay(withText: "callout.bottomButton".localized(), andDirection: .down, constrainedToDirectionalAnchor: viewController.bottomButton.topAnchor)
             }
         }
     }
@@ -305,7 +305,7 @@ extension CharcoalViewController: CalloutOverlayDelegate {
         })
     }
 
-    private func showCalloutOverlay(withText text: String, andDirection direction: CalloutView.Direction, constrainedToAnchor anchor: NSLayoutYAxisAnchor) {
+    private func showCalloutOverlay(withText text: String, andDirection direction: CalloutView.Direction, constrainedToDirectionalAnchor directionalAnchor: NSLayoutYAxisAnchor? = nil, constrainedToTopAnchor topAnchor: NSLayoutYAxisAnchor? = nil) {
         calloutOverlay = CalloutOverlay(direction: direction)
 
         if let calloutOverlay = calloutOverlay {
@@ -315,7 +315,12 @@ extension CharcoalViewController: CalloutOverlayDelegate {
 
             view.addSubview(calloutOverlay)
 
-            calloutOverlay.configure(withText: text, calloutAnchor: anchor)
+            if let topAnchor = topAnchor {
+                calloutOverlay.configure(withText: text, calloutTopAnchor: topAnchor)
+            } else if let directionalAnchor = directionalAnchor {
+                calloutOverlay.configure(withText: text, calloutAnchor: directionalAnchor)
+            }
+
             calloutOverlay.fillInSuperview()
 
             UIView.animate(withDuration: 0.3, delay: 0.5, options: [], animations: { [weak self] in
@@ -328,9 +333,9 @@ extension CharcoalViewController: CalloutOverlayDelegate {
 // MARK: - UserDefaults
 
 private extension UserDefaults {
-    var verticalCalloutShown: Bool {
-        get { return bool(forKey: #function) }
-        set { set(newValue, forKey: #function) }
+    var locationChangesCalloutShown: Bool {
+        get { return bool(forKey: "Charcoal." + #function) }
+        set { set(newValue, forKey: "Charcoal." + #function) }
     }
 
     var bottomButtomCalloutShown: Bool {

--- a/Sources/Charcoal/CharcoalViewController.swift
+++ b/Sources/Charcoal/CharcoalViewController.swift
@@ -43,8 +43,6 @@ public final class CharcoalViewController: UINavigationController {
         didSet { rootFilterViewController?.showLoadingIndicator(isLoading) }
     }
 
-    public var canShowRegionReformCallout = false
-
     // MARK: - Private properties
 
     private var selectionHasChanged = false

--- a/Sources/Charcoal/Filters/Root/Views/CalloutOverlay.swift
+++ b/Sources/Charcoal/Filters/Root/Views/CalloutOverlay.swift
@@ -24,20 +24,7 @@ final class CalloutOverlay: UIView {
         }
     }
 
-    private var directionalConstraints: [NSLayoutConstraint] {
-        switch direction {
-        case .up:
-            return [
-                bodyView.topAnchor.constraint(equalTo: calloutView.topAnchor),
-                bodyView.bottomAnchor.constraint(equalTo: bottomAnchor),
-            ]
-        case .down:
-            return [
-                bodyView.topAnchor.constraint(equalTo: topAnchor),
-                bodyView.bottomAnchor.constraint(equalTo: calloutView.bottomAnchor),
-            ]
-        }
-    }
+    private var directionalConstraints: [NSLayoutConstraint]?
 
     private lazy var calloutView: CalloutView = {
         let view = CalloutView(direction: direction)
@@ -68,6 +55,24 @@ final class CalloutOverlay: UIView {
     func configure(withText text: String, calloutAnchor: NSLayoutYAxisAnchor) {
         calloutView.show(withText: text)
         calloutViewDirectionalAnchor.constraint(equalTo: calloutAnchor).isActive = true
+        switch direction {
+        case .up:
+            directionalConstraints = [
+                bodyView.topAnchor.constraint(equalTo: calloutView.topAnchor),
+                bodyView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            ]
+        case .down:
+            directionalConstraints = [
+                bodyView.topAnchor.constraint(equalTo: topAnchor),
+                bodyView.bottomAnchor.constraint(equalTo: calloutView.bottomAnchor),
+            ]
+        }
+    }
+
+    func configure(withText text: String, calloutTopAnchor: NSLayoutYAxisAnchor) {
+        calloutView.show(withText: text)
+        calloutView.topAnchor.constraint(equalTo: calloutTopAnchor).isActive = true
+        directionalConstraints = nil
     }
 
     private func setup() {
@@ -79,13 +84,22 @@ final class CalloutOverlay: UIView {
         let gestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(handleTap))
         addGestureRecognizer(gestureRecognizer)
 
-        let constraints = directionalConstraints + [
+        var constraints = [
             calloutView.centerXAnchor.constraint(equalTo: centerXAnchor),
             calloutView.widthAnchor.constraint(equalToConstant: 250),
 
             bodyView.leadingAnchor.constraint(equalTo: leadingAnchor),
             bodyView.trailingAnchor.constraint(equalTo: trailingAnchor),
         ]
+
+        if let directionalConstraints = directionalConstraints {
+            constraints += directionalConstraints
+        } else {
+            constraints += [
+                bodyView.topAnchor.constraint(equalTo: topAnchor),
+                bodyView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            ]
+        }
 
         NSLayoutConstraint.activate(constraints)
     }

--- a/Sources/Charcoal/Models/FilterContainer.swift
+++ b/Sources/Charcoal/Models/FilterContainer.swift
@@ -8,7 +8,7 @@ public class FilterContainer {
     // MARK: - Public properties
 
     public var verticals: [Vertical]?
-    public var locationChangesCalloutText: String?
+    public var regionReformCalloutText: String?
 
     // MARK: - Internal properties
 

--- a/Sources/Charcoal/Models/FilterContainer.swift
+++ b/Sources/Charcoal/Models/FilterContainer.swift
@@ -8,7 +8,7 @@ public class FilterContainer {
     // MARK: - Public properties
 
     public var verticals: [Vertical]?
-    public var verticalsCalloutText: String?
+    public var locationChangesCalloutText: String?
 
     // MARK: - Internal properties
 

--- a/Sources/Charcoal/Resources/en.lproj/Localizable.strings
+++ b/Sources/Charcoal/Resources/en.lproj/Localizable.strings
@@ -87,5 +87,3 @@
 
 "alert.reset.message" = "Er du sikker på at du vil nullstille\nog fjerne alle dine filtervalg?";
 "alert.action.reset" = "Nullstill filteret";
-
-"callout.locationChanges" = "Obs! Vi har oppdatert områdevalg til å passe til de nye kommunene i Norge";

--- a/Sources/Charcoal/Resources/en.lproj/Localizable.strings
+++ b/Sources/Charcoal/Resources/en.lproj/Localizable.strings
@@ -83,14 +83,9 @@
 "onboarding.content.2.title" = "Full kontroll";
 "onboarding.content.2.highlight" = "bedre oversikt";
 
-"callout.realestate" = "Trykk her i toppen for å se andre kategorier som Bolig til leie, Fritidsboliger, Tomter etc.";
-"callout.car" = "Trykk her i toppen for å se andre kategorier som Bobil, Campingvogn og Biler i utlandet";
-"callout.mc" = "Trykk her i toppen for å se andre kategorier som Scootere og mopeder, Snøscootere og ATV’er";
-"callout.boat" = "Trykk her i toppen for å se andre kategorier som Båter til leie, Båtmotorer til salgs etc.";
-"callout.b2b" = "Trykk her i toppen for å se andre kategorier som Buss og minibuss, Bygg og anlegg, Traktor etc.";
-"callout.job" = "Trykk her i toppen for å se annonser for Deltidsstillinger og Lederstillinger";
-
 "callout.bottomButton" = "Trykk på Bruk-knappen for å gå videre.";
 
 "alert.reset.message" = "Er du sikker på at du vil nullstille\nog fjerne alle dine filtervalg?";
 "alert.action.reset" = "Nullstill filteret";
+
+"callout.locationChanges" = "Obs! Vi har oppdatert områdevalg til å passe til de nye kommunene i Norge";

--- a/Sources/FINNSetup/BackendModel/FilterSetup.swift
+++ b/Sources/FINNSetup/BackendModel/FilterSetup.swift
@@ -72,7 +72,7 @@ public struct FilterSetup: Decodable {
             inlineFilter: Filter.inline(title: "", key: FilterKey.preferences.rawValue, subfilters: preferenceFilters),
             numberOfResults: objectCount ?? hits
         )
-        
+
         return container
     }
 

--- a/Sources/FINNSetup/BackendModel/FilterSetup.swift
+++ b/Sources/FINNSetup/BackendModel/FilterSetup.swift
@@ -73,7 +73,7 @@ public struct FilterSetup: Decodable {
             numberOfResults: objectCount ?? hits
         )
 
-        container.verticalsCalloutText = config.verticalsCalloutText
+        container.locationChangesCalloutText = config.locationChangesCalloutText
 
         return container
     }

--- a/Sources/FINNSetup/BackendModel/FilterSetup.swift
+++ b/Sources/FINNSetup/BackendModel/FilterSetup.swift
@@ -72,9 +72,7 @@ public struct FilterSetup: Decodable {
             inlineFilter: Filter.inline(title: "", key: FilterKey.preferences.rawValue, subfilters: preferenceFilters),
             numberOfResults: objectCount ?? hits
         )
-
-        container.locationChangesCalloutText = config.locationChangesCalloutText
-
+        
         return container
     }
 

--- a/Sources/FINNSetup/FINNFilterConfiguration.swift
+++ b/Sources/FINNSetup/FINNFilterConfiguration.swift
@@ -9,7 +9,7 @@ public protocol FilterConfiguration {
     var rootLevelFilterKeys: [FilterKey] { get }
     var contextFilterKeys: Set<FilterKey> { get }
     var mutuallyExclusiveFilterKeys: Set<FilterKey> { get }
-    var verticalsCalloutText: String? { get }
+    var locationChangesCalloutText: String? { get }
 
     func handlesVerticalId(_ vertical: String) -> Bool
     func rangeConfiguration(forKey key: FilterKey) -> RangeFilterConfiguration?
@@ -23,5 +23,9 @@ public extension FilterConfiguration {
         }
 
         return mutuallyExclusiveFilterKeys.filter { $0 != key }
+    }
+
+    var locationChangesCalloutText: String? {
+        return "callout.locationChanges".localized()
     }
 }

--- a/Sources/FINNSetup/FINNFilterConfiguration.swift
+++ b/Sources/FINNSetup/FINNFilterConfiguration.swift
@@ -9,7 +9,6 @@ public protocol FilterConfiguration {
     var rootLevelFilterKeys: [FilterKey] { get }
     var contextFilterKeys: Set<FilterKey> { get }
     var mutuallyExclusiveFilterKeys: Set<FilterKey> { get }
-    var locationChangesCalloutText: String? { get }
 
     func handlesVerticalId(_ vertical: String) -> Bool
     func rangeConfiguration(forKey key: FilterKey) -> RangeFilterConfiguration?
@@ -23,9 +22,5 @@ public extension FilterConfiguration {
         }
 
         return mutuallyExclusiveFilterKeys.filter { $0 != key }
-    }
-
-    var locationChangesCalloutText: String? {
-        return "callout.locationChanges".localized()
     }
 }

--- a/Sources/FINNSetup/FilterMarket.swift
+++ b/Sources/FINNSetup/FilterMarket.swift
@@ -60,10 +60,6 @@ extension FilterMarket: FilterConfiguration {
         return currentFilterConfig.mutuallyExclusiveFilterKeys
     }
 
-    public var locationChangesCalloutText: String? {
-        return currentFilterConfig.locationChangesCalloutText
-    }
-
     public func handlesVerticalId(_ vertical: String) -> Bool {
         return currentFilterConfig.handlesVerticalId(vertical)
     }

--- a/Sources/FINNSetup/FilterMarket.swift
+++ b/Sources/FINNSetup/FilterMarket.swift
@@ -60,8 +60,8 @@ extension FilterMarket: FilterConfiguration {
         return currentFilterConfig.mutuallyExclusiveFilterKeys
     }
 
-    public var verticalsCalloutText: String? {
-        return currentFilterConfig.verticalsCalloutText
+    public var locationChangesCalloutText: String? {
+        return currentFilterConfig.locationChangesCalloutText
     }
 
     public func handlesVerticalId(_ vertical: String) -> Bool {

--- a/Sources/FINNSetup/FilterMarkets/FilterMarketB2B.swift
+++ b/Sources/FINNSetup/FilterMarkets/FilterMarketB2B.swift
@@ -104,10 +104,6 @@ extension FilterMarketB2B: FilterConfiguration {
         return [.location, .map]
     }
 
-    public var verticalsCalloutText: String? {
-        return "callout.b2b".localized()
-    }
-
     public func handlesVerticalId(_ vertical: String) -> Bool {
         return rawValue == vertical
     }

--- a/Sources/FINNSetup/FilterMarkets/FilterMarketBap.swift
+++ b/Sources/FINNSetup/FilterMarkets/FilterMarketBap.swift
@@ -64,10 +64,6 @@ extension FilterMarketBap: FilterConfiguration {
         return [.location, .map]
     }
 
-    public var verticalsCalloutText: String? {
-        return nil
-    }
-
     public func handlesVerticalId(_ vertical: String) -> Bool {
         return rawValue == vertical || vertical.hasPrefix(rawValue + "-")
     }

--- a/Sources/FINNSetup/FilterMarkets/FilterMarketBoat.swift
+++ b/Sources/FINNSetup/FilterMarkets/FilterMarketBoat.swift
@@ -95,10 +95,6 @@ extension FilterMarketBoat: FilterConfiguration {
         return [.location, .map]
     }
 
-    public var verticalsCalloutText: String? {
-        return "callout.boat".localized()
-    }
-
     public func handlesVerticalId(_ vertical: String) -> Bool {
         return rawValue == vertical
     }

--- a/Sources/FINNSetup/FilterMarkets/FilterMarketCar.swift
+++ b/Sources/FINNSetup/FilterMarkets/FilterMarketCar.swift
@@ -127,10 +127,6 @@ extension FilterMarketCar: FilterConfiguration {
         return [.location, .map]
     }
 
-    public var verticalsCalloutText: String? {
-        return "callout.car".localized()
-    }
-
     public func handlesVerticalId(_ vertical: String) -> Bool {
         return rawValue == vertical
     }

--- a/Sources/FINNSetup/FilterMarkets/FilterMarketJob.swift
+++ b/Sources/FINNSetup/FilterMarkets/FilterMarketJob.swift
@@ -52,10 +52,6 @@ extension FilterMarketJob: FilterConfiguration {
         return [.location, .map]
     }
 
-    public var verticalsCalloutText: String? {
-        return "callout.job".localized()
-    }
-
     public func handlesVerticalId(_ vertical: String) -> Bool {
         return rawValue == vertical
     }

--- a/Sources/FINNSetup/FilterMarkets/FilterMarketMC.swift
+++ b/Sources/FINNSetup/FilterMarkets/FilterMarketMC.swift
@@ -59,10 +59,6 @@ extension FilterMarketMC: FilterConfiguration {
         return [.location, .map]
     }
 
-    public var verticalsCalloutText: String? {
-        return "callout.mc".localized()
-    }
-
     public func handlesVerticalId(_ vertical: String) -> Bool {
         return rawValue == vertical
     }

--- a/Sources/FINNSetup/FilterMarkets/FilterMarketRealestate.swift
+++ b/Sources/FINNSetup/FilterMarkets/FilterMarketRealestate.swift
@@ -162,10 +162,6 @@ extension FilterMarketRealestate: FilterConfiguration {
         return [.location, .map]
     }
 
-    public var verticalsCalloutText: String? {
-        return "callout.realestate".localized()
-    }
-
     public func handlesVerticalId(_ vertical: String) -> Bool {
         return rawValue == vertical
     }

--- a/UITests/Core/UITestCase.swift
+++ b/UITests/Core/UITestCase.swift
@@ -14,7 +14,7 @@ class UITestCase: XCTestCase {
 
         app = XCUIApplication()
         app.launchArguments.append("--uitesting")
-        app.launchArguments += ["-verticalCalloutShown", "YES"]
+        app.launchArguments += ["-Charcoal.regionReformCalloutShown", "YES"]
         app.launchArguments += ["-bottomButtomCalloutShown", "YES"]
     }
 }

--- a/UITests/FilterSelectionUITests.swift
+++ b/UITests/FilterSelectionUITests.swift
@@ -9,7 +9,7 @@ final class FilterSelectionUITests: UITestCase {
         app.launch()
 
         // 1. Open real estate market
-        app.tables.element(boundBy: 0).cells.element(boundBy: 8).tap()
+        app.tables.element(boundBy: 0).cells.element(boundBy: 9).tap()
         sleep(1)
         XCTAssertTrue(app.hasNavigationTitle("Filtrer søket"))
 


### PR DESCRIPTION
# Why?
Norwegian regions will change in 2020 and to align with that our filter regions will change too. Some users might be surprised by this so this is a one time callout to inform about the change.

# What?
If a region reform text has been set on the FilterConfiguration a callout will be shown (unless it has been shown before).

Unfortunately the callout does not point to the actual "Område" cell, this would be ideal, but since we are stressed on time this might have to do. If someone has an idea how to easily solve this that doesn't break the boundary between "Charcoal general" and "FINN Charcoal" (and doesn't risk introducing bugs) please let me know! 😄 

This also removes the callout about where to find submarkets. It has been there a long time now so it should not be needed anymore.

# Show me
![Simulator Screen Shot - iPhone 11 Pro Max - 2019-12-16 at 17 16 46](https://user-images.githubusercontent.com/3169203/70928909-3f428880-2032-11ea-8a25-4c6684682859.png)
