### PR TITLE
Don't show root filter with no selectable values

### DIFF
--- a/Sources/FINNSetup/BackendModel/FilterSetup.swift
+++ b/Sources/FINNSetup/BackendModel/FilterSetup.swift
@@ -97,6 +97,10 @@ public struct FilterSetup: Decodable {
                     return nil
                 }
             } else {
+                guard data.queries.count > 0 else {
+                    // No need to show a root filter that has no selectable values
+                    return nil
+                }
                 return makeFilter(from: data, withKind: .standard, style: style)
             }
         }

--- a/Sources/FINNSetup/BackendModel/FilterSetup.swift
+++ b/Sources/FINNSetup/BackendModel/FilterSetup.swift
@@ -97,8 +97,7 @@ public struct FilterSetup: Decodable {
                     return nil
                 }
             } else {
-                guard data.queries.count > 0 else {
-                    // No need to show a root filter that has no selectable values
+                guard !data.queries.isEmpty else {
                     return nil
                 }
                 return makeFilter(from: data, withKind: .standard, style: style)

--- a/UnitTests/Charcoal/Models/FilterTests.swift
+++ b/UnitTests/Charcoal/Models/FilterTests.swift
@@ -192,9 +192,15 @@ extension FilterTests: TestDataDecoder {
         guard let config = FilterMarket(market: "bap-sale") else { return }
         let filterSetup = filterDataFromJSONFile(named: "ContextFilterTestData")
         let filter = filterSetup?.filterContainer(using: config)
-        let categoryFilter = filter?.rootFilters.first(where: { $0.key == "category" })
         let shoeSizeFilter = filter?.rootFilters.first(where: { $0.key == "shoe_size" })
-        XCTAssertEqual(categoryFilter?.style, .normal)
         XCTAssertEqual(shoeSizeFilter?.style, .context)
+    }
+
+    func testRootFilterWithoutSubfiltersShouldNotShow() {
+        guard let config = FilterMarket(market: "bap-sale") else { return }
+        let filterSetup = filterDataFromJSONFile(named: "ContextFilterTestData")
+        let filter = filterSetup?.filterContainer(using: config)
+        let categoryFilter = filter?.rootFilters.first(where: { $0.key == "category" })
+        XCTAssertNil(categoryFilter)
     }
 }


### PR DESCRIPTION
# Why?
A root filter is not useful if it has no subfilters.
 
# What?
Removed root filters without queries (that are not `map`, `shoeSize` or a range).

# Show me
This is how it effects the main app, look at "Juleglede"

### Before
![Simulator Screen Shot - iPhone 11 Pro - 2020-01-10 at 11 16 23](https://user-images.githubusercontent.com/3169203/72145357-ab4aaf00-339a-11ea-972d-cd146bfe5c40.png)

### After
![Simulator Screen Shot - iPhone 11 Pro - 2020-01-10 at 11 11 47](https://user-images.githubusercontent.com/3169203/72145310-881fff80-339a-11ea-9ec9-d925c63b8d52.png)
