### PR TITLE
WIP: Feature toggle support suggestion/discussion

### DIFF
--- a/Charcoal.xcodeproj/project.pbxproj
+++ b/Charcoal.xcodeproj/project.pbxproj
@@ -74,6 +74,8 @@
 		55F97D1220AC4FD5002BABC9 /* VerticalListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55F97D1120AC4FD5002BABC9 /* VerticalListViewController.swift */; };
 		55F97D1720B4432C002BABC9 /* RangeSliderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55F97D1620B4432C002BABC9 /* RangeSliderView.swift */; };
 		91E6C09F230D8649009EDE12 /* DrawerPresentationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91E6C09E230D8649009EDE12 /* DrawerPresentationViewController.swift */; };
+		9B05271723C8A17B000E888A /* CharcoalFeatureConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B05271623C8A17B000E888A /* CharcoalFeatureConfig.swift */; };
+		9B05271923C8A1C7000E888A /* FeatureConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B05271823C8A1C7000E888A /* FeatureConfig.swift */; };
 		9B2931E323477A6B006469B5 /* AppCenterDistribute.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9B2931E223477A6B006469B5 /* AppCenterDistribute.framework */; };
 		9B2931E723477AF5006469B5 /* AppCenterCrashes.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9B2931E523477AF5006469B5 /* AppCenterCrashes.framework */; };
 		9B2931F52347815B006469B5 /* AppCenter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9B2931F42347815B006469B5 /* AppCenter.framework */; };
@@ -357,6 +359,8 @@
 		55F97D1120AC4FD5002BABC9 /* VerticalListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerticalListViewController.swift; sourceTree = "<group>"; };
 		55F97D1620B4432C002BABC9 /* RangeSliderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RangeSliderView.swift; sourceTree = "<group>"; };
 		91E6C09E230D8649009EDE12 /* DrawerPresentationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawerPresentationViewController.swift; sourceTree = "<group>"; };
+		9B05271623C8A17B000E888A /* CharcoalFeatureConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CharcoalFeatureConfig.swift; sourceTree = "<group>"; };
+		9B05271823C8A1C7000E888A /* FeatureConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureConfig.swift; sourceTree = "<group>"; };
 		9B2931E223477A6B006469B5 /* AppCenterDistribute.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppCenterDistribute.framework; path = Carthage/Build/iOS/AppCenterDistribute.framework; sourceTree = "<group>"; };
 		9B2931E523477AF5006469B5 /* AppCenterCrashes.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppCenterCrashes.framework; path = Carthage/Build/iOS/AppCenterCrashes.framework; sourceTree = "<group>"; };
 		9B2931F42347815B006469B5 /* AppCenter.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppCenter.framework; path = Carthage/Build/iOS/AppCenter.framework; sourceTree = "<group>"; };
@@ -821,6 +825,7 @@
 			children = (
 				CFEDCDFA2232B756008FCDB1 /* FINNSetup.h */,
 				CFEDCE172232BDF2008FCDB1 /* Info.plist */,
+				9B05271823C8A1C7000E888A /* FeatureConfig.swift */,
 				08716B3621F76424003180D8 /* FilterKey.swift */,
 				55BDA76E20DBC46800331FFC /* FilterMarket.swift */,
 				CF81E10C221C515800D00423 /* FINNFilterConfiguration.swift */,
@@ -954,6 +959,7 @@
 				44ECE661208F7FA20017AC82 /* Charcoal.h */,
 				44ECE662208F7FA20017AC82 /* Info.plist */,
 				44ECE698208F80320017AC82 /* Charcoal.swift */,
+				9B05271623C8A17B000E888A /* CharcoalFeatureConfig.swift */,
 				DA39FA1C220B17DB00608AC4 /* CharcoalViewController.swift */,
 				DA3EA340228983AC00B05E92 /* ScrollViewController.swift */,
 				9BABD26A236AE54100860EB5 /* Theme.swift */,
@@ -1644,6 +1650,7 @@
 				9BB827A6216C9CD40014028C /* RangeFilterConfiguration.swift in Sources */,
 				DA643FB7220C720A001ED360 /* StepperViewController.swift in Sources */,
 				CF7C46112226F415001FB92C /* ListFilterCell.swift in Sources */,
+				9B05271723C8A17B000E888A /* CharcoalFeatureConfig.swift in Sources */,
 				9BE0A04F2091C2E90000632B /* ArrayExtensions.swift in Sources */,
 				DADF2DD22253761300567C78 /* OnboardingCell.swift in Sources */,
 				46774F3B21BFF57F00ECFED8 /* MapDistanceValueFormatter.swift in Sources */,
@@ -1755,6 +1762,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9B05271923C8A1C7000E888A /* FeatureConfig.swift in Sources */,
 				CFEDCE0C2232B7A8008FCDB1 /* FilterMarketCar.swift in Sources */,
 				CFEDCE102232B7A8008FCDB1 /* FilterMarketBoat.swift in Sources */,
 				CFEDCE052232B7A8008FCDB1 /* FilterKey.swift in Sources */,

--- a/Demo/Setup.swift
+++ b/Demo/Setup.swift
@@ -5,6 +5,25 @@
 import FINNSetup
 import UIKit
 
+struct FeatureSetup: FeatureInfo {
+    var isEnabled: Bool
+    var text: String?
+    func didShow() {}
+}
+
+class DemoFeatureConfig: FeatureConfig {
+    var features = [FINNFeature: FeatureSetup]()
+    var coreFeatures = [CharcoalFeature: FeatureSetup]()
+
+    func featureConfig(_ feature: FINNFeature) -> FeatureInfo? {
+        return features[feature]
+    }
+
+    func featureConfig(_ feature: CharcoalFeature) -> FeatureInfo? {
+        return coreFeatures[feature]
+    }
+}
+
 class Setup {
     var filterContainer: FilterContainer?
     let markets: [DemoVertical]
@@ -22,7 +41,9 @@ class Setup {
         if let current = current {
             filterContainer = Setup.filterContainer(name: current.name)
             filterContainer?.verticals = markets
-            filterContainer?.regionReformCalloutText = includeRegionReformCallout ? "Obs! Vi har oppdatert områdevalg til å passe til de nye kommunene i Norge" : nil
+            let demoFeatureConfig = DemoFeatureConfig()
+            demoFeatureConfig.coreFeatures[.regionReformCallout] = FeatureSetup(isEnabled: includeRegionReformCallout, text: "Obs! Vi har oppdatert områdevalg til å passe til de nye kommunene i Norge")
+            filterContainer?.featureConfig = demoFeatureConfig
         }
     }
 

--- a/Sources/Charcoal/CharcoalFeatureConfig.swift
+++ b/Sources/Charcoal/CharcoalFeatureConfig.swift
@@ -1,0 +1,20 @@
+//
+//  Copyright © FINN.no AS, Inc. All rights reserved.
+//
+
+import Foundation
+
+public protocol FeatureInfo {
+    var isEnabled: Bool { get }
+    var text: String? { get }
+    func didShow()
+}
+
+public enum CharcoalFeature {
+    case bottomButtonCallout
+    case regionReformCallout
+}
+
+public protocol CharcoalFeatureConfig {
+    func featureConfig(_ feature: CharcoalFeature) -> FeatureInfo?
+}

--- a/Sources/Charcoal/CharcoalViewController.swift
+++ b/Sources/Charcoal/CharcoalViewController.swift
@@ -69,11 +69,11 @@ public final class CharcoalViewController: UINavigationController {
     public override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
-        let userDefaults = UserDefaults.standard
-
-        if let text = filterContainer?.regionReformCalloutText, !userDefaults.regionReformCalloutShown {
+        if let regionReformFeature = filterContainer?.featureConfig?.featureConfig(.regionReformCallout),
+            regionReformFeature.isEnabled,
+            let text = regionReformFeature.text {
             showCalloutOverlay(withText: text, andDirection: .down, constrainedToTopAnchor: navigationBar.bottomAnchor)
-            userDefaults.regionReformCalloutShown = true
+            regionReformFeature.didShow()
         }
     }
 
@@ -333,11 +333,6 @@ extension CharcoalViewController: CalloutOverlayDelegate {
 // MARK: - UserDefaults
 
 private extension UserDefaults {
-    var regionReformCalloutShown: Bool {
-        get { return bool(forKey: "Charcoal." + #function) }
-        set { set(newValue, forKey: "Charcoal." + #function) }
-    }
-
     var bottomButtomCalloutShown: Bool {
         get { return bool(forKey: #function) }
         set { set(newValue, forKey: #function) }

--- a/Sources/Charcoal/Models/FilterContainer.swift
+++ b/Sources/Charcoal/Models/FilterContainer.swift
@@ -7,6 +7,7 @@ import Foundation
 public class FilterContainer {
     // MARK: - Public properties
 
+    public var featureConfig: CharcoalFeatureConfig?
     public var verticals: [Vertical]?
     public var regionReformCalloutText: String?
 

--- a/Sources/Charcoal/Models/FilterContainer.swift
+++ b/Sources/Charcoal/Models/FilterContainer.swift
@@ -9,7 +9,6 @@ public class FilterContainer {
 
     public var featureConfig: CharcoalFeatureConfig?
     public var verticals: [Vertical]?
-    public var regionReformCalloutText: String?
 
     // MARK: - Internal properties
 

--- a/Sources/FINNSetup/BackendModel/FilterSetup.swift
+++ b/Sources/FINNSetup/BackendModel/FilterSetup.swift
@@ -82,6 +82,10 @@ public struct FilterSetup: Decodable {
     private func makeRootLevelFilter(withKey key: FilterKey, using config: FilterConfiguration) -> Filter? {
         let style: Filter.Style = config.contextFilterKeys.contains(key) ? .context : .normal
 
+        if key == .christmas, !isChristmasFilterEnabled() {
+            return nil
+        }
+
         switch key {
         case .map:
             return makeMapFilter(withKey: key)
@@ -170,6 +174,13 @@ public struct FilterSetup: Decodable {
                 subfilters: subfilters ?? []
             )
         }
+    }
+
+    private func isChristmasFilterEnabled() -> Bool {
+        guard let isEnabled = featureConfig?.featureConfig(.christmasFilter)?.isEnabled else {
+            return false
+        }
+        return isEnabled
     }
 
     public static func decode(from dict: [AnyHashable: Any]?) -> FilterSetup? {

--- a/Sources/FINNSetup/BackendModel/FilterSetup.swift
+++ b/Sources/FINNSetup/BackendModel/FilterSetup.swift
@@ -9,6 +9,7 @@ public struct FilterSetup: Decodable {
     public let filterTitle: String
     public let hits: Int
     public let objectCount: Int?
+    public var featureConfig: FeatureConfig?
 
     let filters: [FilterData]
 
@@ -72,6 +73,8 @@ public struct FilterSetup: Decodable {
             inlineFilter: Filter.inline(title: "", key: FilterKey.preferences.rawValue, subfilters: preferenceFilters),
             numberOfResults: objectCount ?? hits
         )
+
+        container.featureConfig = featureConfig
 
         return container
     }

--- a/Sources/FINNSetup/FeatureConfig.swift
+++ b/Sources/FINNSetup/FeatureConfig.swift
@@ -1,0 +1,14 @@
+//
+//  Copyright © FINN.no AS, Inc. All rights reserved.
+//
+
+import Charcoal
+import Foundation
+
+public enum FINNFeature {
+    case christmasFilter
+}
+
+public protocol FeatureConfig: CharcoalFeatureConfig {
+    func featureConfig(_ feature: FINNFeature) -> FeatureInfo?
+}


### PR DESCRIPTION
# Why?
We have had a couple of situations now where we want to toggle some feature based on unleash, but since we do not want to access unleash from within Charcoal it has been a bit complicated.

# What?
This is a suggestion for how we could have a feature toggle solution for Charcoal. It is a bit extra complicated since we have uses for it both in Charcoal core and our FINN setup part. I did not find a natural place to "hand it over" to Charcoal either but put it as a property in `FilterSetup` for now.

Free to come with better (or just different) suggestions for how to solve this. What I implemented probably needs at least some refactoring (and renaming) before it is ready to use (for instance `bottomButtonCallout` "feature" is not implemented yet).

If we where to do it this way the main app needs to have implementations for `FeatureConfig` and `FeatureInfo` that connects to unleash toggles (and supplies text for region reform callout). It would also need to add writing to `UserDefaults` for those things that are to be shown only once.
