### PR TITLE
Replace "is_sold" filter with "lifecycle"

### DIFF
--- a/Demo/Resources/realestate/realestate-homes.json
+++ b/Demo/Resources/realestate/realestate-homes.json
@@ -9,7 +9,7 @@
                 "q",
                 "published",
                 "location",
-                "is_sold",
+                "lifecycle",
                 "is_new_property",
                 "price",
                 "price_collective",
@@ -358,9 +358,9 @@
                         }
                         ]
         },
-        "is_sold": {
+        "lifecycle": {
             "title": "Type søk",
-            "name": "is_sold",
+            "name": "lifecycle",
             "queries": [
                         {
                         "title": "Til salgs",
@@ -368,9 +368,14 @@
                         "total-results": 38202
                         },
                         {
-                        "title": "Solgt",
+                        "title": "Solgt siste 3 dager",
                         "value": "true",
                         "total-results": 464
+                        },
+                        {
+                        "title": "Kommer for salg",
+                        "value": "true",
+                        "total-results": 11
                         }
                         ]
         },

--- a/Sources/FINNSetup/FilterKey.swift
+++ b/Sources/FINNSetup/FilterKey.swift
@@ -44,7 +44,7 @@ public enum FilterKey: String, CodingKey {
     case industry
     case isNewProperty = "is_new_property"
     case isPrivateBroker = "is_private_broker"
-    case isSold = "is_sold"
+    case lifecycle
     case jobDuration = "job_duration"
     case jobSector = "job_sector"
     case laptopsBrand = "laptops_brand"

--- a/Sources/FINNSetup/FilterMarkets/FilterMarketRealestate.swift
+++ b/Sources/FINNSetup/FilterMarkets/FilterMarketRealestate.swift
@@ -27,7 +27,7 @@ extension FilterMarketRealestate: FilterConfiguration {
         let defaultFilter: [FilterKey] = [.published]
         switch self {
         case .homes:
-            return defaultFilter + [.isSold, .isNewProperty, .isPrivateBroker]
+            return defaultFilter + [.lifecycle, .isNewProperty, .isPrivateBroker]
         default: return defaultFilter
         }
     }


### PR DESCRIPTION
# Why?
Because the filter has been changed.

# What?
Replaced "is_sold" with "lifecycle".

# Show me
![Simulator Screen Shot - iPhone 11 Pro - 2020-01-15 at 14 05 27](https://user-images.githubusercontent.com/3169203/72436187-23044980-37a0-11ea-9af8-0809dec42e13.png)
