### PR TITLE
Filter container: make filter properties public

### DIFF
--- a/Demo/DataSource.swift
+++ b/Demo/DataSource.swift
@@ -13,7 +13,7 @@ class DataSource: NSObject {
         Row(title: "Inline Filter", type: InlineFilterDemoViewController.self),
         Row(title: "Range Filter", type: RangeFilterDemoViewController.self),
         Row(title: "Stepper Filter", type: StepperFilterDemoViewController.self),
-        Row(title: "Område i kart", type: MapFilterDemoViewController.self)
+        Row(title: "Område i kart", type: MapFilterDemoViewController.self),
     ]
 
     private let markets = [

--- a/Sources/Charcoal/Models/FilterContainer.swift
+++ b/Sources/Charcoal/Models/FilterContainer.swift
@@ -12,12 +12,12 @@ public class FilterContainer {
 
     // MARK: - Internal properties
 
-    private(set) var rootFilters: [Filter]
-    private(set) var inlineFilter: Filter?
-    private(set) var freeTextFilter: Filter?
-    private(set) var numberOfResults: Int
+    public private(set) var rootFilters: [Filter]
+    public private(set) var inlineFilter: Filter?
+    public private(set) var freeTextFilter: Filter?
+    public private(set) var numberOfResults: Int
 
-    var allFilters: [Filter] {
+    public var allFilters: [Filter] {
         return [freeTextFilter, inlineFilter].compactMap { $0 } + rootFilters
     }
 


### PR DESCRIPTION
# Why?

In my experiments I want to use filters from `FilterContainer` directly.

# What?

Make some of the properties in `FilterContainer` public. Shouldn't be a problem if we expose these.

# Show me

No UI changes.