### PR TITLE
Expose list, range, stepper and grid filters

### DIFF
--- a/Sources/Charcoal/CharcoalViewController.swift
+++ b/Sources/Charcoal/CharcoalViewController.swift
@@ -166,15 +166,15 @@ extension CharcoalViewController: RootFilterViewControllerDelegate {
 // MARK: - FilterViewControllerDelegate
 
 extension CharcoalViewController: FilterViewControllerDelegate {
-    func filterViewControllerWillBeginTextEditing(_ viewController: FilterViewController) {
+    public func filterViewControllerWillBeginTextEditing(_ viewController: FilterViewController) {
         textEditingDelegate?.charcoalViewControllerWillBeginTextEditing(self)
     }
 
-    func filterViewControllerWillEndTextEditing(_ viewController: FilterViewController) {
+    public func filterViewControllerWillEndTextEditing(_ viewController: FilterViewController) {
         textEditingDelegate?.charcoalViewControllerWillEndTextEditing(self)
     }
 
-    func filterViewControllerWillPresentBottomButton(_ viewController: FilterViewController) {
+    public func filterViewControllerWillPresentBottomButton(_ viewController: FilterViewController) {
         if UIDevice.current.userInterfaceIdiom == .pad, !UserDefaults.standard.bottomButtomCalloutShown {
             if viewController is ListFilterViewController ||
                 viewController is RangeFilterViewController ||
@@ -186,7 +186,7 @@ extension CharcoalViewController: FilterViewControllerDelegate {
         }
     }
 
-    func filterViewControllerDidPressBottomButton(_ viewController: FilterViewController) {
+    public func filterViewControllerDidPressBottomButton(_ viewController: FilterViewController) {
         if viewController === rootFilterViewController {
             selectionDelegate?.charcoalViewControllerDidPressShowResults(self)
         } else {
@@ -195,7 +195,7 @@ extension CharcoalViewController: FilterViewControllerDelegate {
         }
     }
 
-    func filterViewController(_ viewController: FilterViewController, didSelectFilter filter: Filter) {
+    public func filterViewController(_ viewController: FilterViewController, didSelectFilter filter: Filter) {
         switch filter.kind {
         case .standard:
             guard !filter.subfilters.isEmpty else { break }

--- a/Sources/Charcoal/Filters/FilterViewController.swift
+++ b/Sources/Charcoal/Filters/FilterViewController.swift
@@ -4,7 +4,7 @@
 
 import UIKit
 
-protocol FilterViewControllerDelegate: AnyObject {
+public protocol FilterViewControllerDelegate: AnyObject {
     func filterViewController(_ viewController: FilterViewController, didSelectFilter filter: Filter)
     func filterViewControllerWillPresentBottomButton(_ viewController: FilterViewController)
     func filterViewControllerDidPressBottomButton(_ viewController: FilterViewController)
@@ -12,8 +12,8 @@ protocol FilterViewControllerDelegate: AnyObject {
     func filterViewControllerWillEndTextEditing(_ viewController: FilterViewController)
 }
 
-class FilterViewController: ScrollViewController, FilterBottomButtonViewDelegate {
-    weak var delegate: FilterViewControllerDelegate?
+public class FilterViewController: ScrollViewController, FilterBottomButtonViewDelegate {
+    public weak var delegate: FilterViewControllerDelegate?
     let selectionStore: FilterSelectionStore
 
     // MARK: - Private properties
@@ -43,7 +43,7 @@ class FilterViewController: ScrollViewController, FilterBottomButtonViewDelegate
 
     // MARK: - Lifecycle
 
-    override func viewDidLoad() {
+    public override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = Theme.mainBackground
         setup()
@@ -54,24 +54,22 @@ class FilterViewController: ScrollViewController, FilterBottomButtonViewDelegate
         view.addGestureRecognizer(gestureRecognizer)
     }
 
-    override func viewWillAppear(_ animated: Bool) {
+    public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         enableSwipeBack(true)
     }
 
-    override func viewWillDisappear(_ animated: Bool) {
+    public override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         enableSwipeBack(true)
     }
 
-    override func scrollViewDidScroll(_ scrollView: UIScrollView) {
+    public override func scrollViewDidScroll(_ scrollView: UIScrollView) {
         super.scrollViewDidScroll(scrollView)
         bottomButton.update(with: scrollView)
     }
 
-    // MARK: - Internal functions
-
-    func showBottomButton(_ show: Bool, animated: Bool) {
+    public func showBottomButton(_ show: Bool, animated: Bool) {
         if viewIfLoaded?.window != nil {
             view.layoutIfNeeded()
         }
@@ -93,6 +91,8 @@ class FilterViewController: ScrollViewController, FilterBottomButtonViewDelegate
             self?.bottomButton.isHidden = !show
         })
     }
+
+    // MARK: - Internal functions
 
     func enableSwipeBack(_ isEnabled: Bool) {
         let gestureRecognizer = navigationController?.interactivePopGestureRecognizer
@@ -124,7 +124,7 @@ class FilterViewController: ScrollViewController, FilterBottomButtonViewDelegate
 }
 
 extension FilterViewController: UIGestureRecognizerDelegate {
-    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
+    public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
         enableSwipeBack(!(touch.view is UISlider))
         return false
     }

--- a/Sources/Charcoal/Filters/FilterViewController.swift
+++ b/Sources/Charcoal/Filters/FilterViewController.swift
@@ -27,7 +27,7 @@ public class FilterViewController: ScrollViewController, FilterBottomButtonViewD
         return view
     }()
 
-    private(set) var isShowingBottomButton = false
+    public private(set) var isShowingBottomButton = false
 
     // MARK: - Init
 

--- a/Sources/Charcoal/Filters/Grid/GridFilterViewController.swift
+++ b/Sources/Charcoal/Filters/Grid/GridFilterViewController.swift
@@ -4,7 +4,7 @@
 
 import FinniversKit
 
-final class GridFilterViewController: FilterViewController {
+public final class GridFilterViewController: FilterViewController {
     private lazy var collectionView: UICollectionView = {
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
         collectionView.translatesAutoresizingMaskIntoConstraints = false
@@ -22,25 +22,25 @@ final class GridFilterViewController: FilterViewController {
 
     // MARK: - Init
 
-    init(filter: Filter, selectionStore: FilterSelectionStore) {
+    public init(filter: Filter, selectionStore: FilterSelectionStore) {
         self.filter = filter
         super.init(title: filter.title, selectionStore: selectionStore)
     }
 
-    required init?(coder aDecoder: NSCoder) {
+    public required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
     // MARK: - Overrides
 
-    override func viewDidLoad() {
+    public override func viewDidLoad() {
         super.viewDidLoad()
         bottomButton.buttonTitle = "applyButton".localized()
         showBottomButton(false, animated: false)
         setup()
     }
 
-    override func viewWillAppear(_ animated: Bool) {
+    public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         collectionView.reloadData()
 
@@ -66,11 +66,11 @@ final class GridFilterViewController: FilterViewController {
 // MARK: - UICollectionViewDataSource
 
 extension GridFilterViewController: UICollectionViewDataSource {
-    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+    public func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return filter.subfilters.count
     }
 
-    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+    public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeue(GridFilterCell.self, for: indexPath)
         let currentFilter = filter.subfilters[indexPath.row]
         cell.configure(withTitle: currentFilter.title, accessibilityPrefix: filter.title)
@@ -81,22 +81,22 @@ extension GridFilterViewController: UICollectionViewDataSource {
 // MARK: - UICollectionViewDelegateFlowLayout
 
 extension GridFilterViewController: UICollectionViewDelegateFlowLayout {
-    func collectionView(_ collectionView: UICollectionView,
-                        layout collectionViewLayout: UICollectionViewLayout,
-                        sizeForItemAt indexPath: IndexPath) -> CGSize {
+    public func collectionView(_ collectionView: UICollectionView,
+                               layout collectionViewLayout: UICollectionViewLayout,
+                               sizeForItemAt indexPath: IndexPath) -> CGSize {
         let numberOfItemsPerRow: CGFloat = 5
         let side = ((collectionView.frame.width - edgeInset * 2) / numberOfItemsPerRow) - .spacingS
 
         return CGSize(width: side, height: side)
     }
 
-    func collectionView(_ collectionView: UICollectionView,
-                        layout collectionViewLayout: UICollectionViewLayout,
-                        minimumLineSpacingForSectionAt section: Int) -> CGFloat {
+    public func collectionView(_ collectionView: UICollectionView,
+                               layout collectionViewLayout: UICollectionViewLayout,
+                               minimumLineSpacingForSectionAt section: Int) -> CGFloat {
         return .spacingS
     }
 
-    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+    public func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let currentFilter = filter.subfilters[indexPath.row]
 
         UISelectionFeedbackGenerator().selectionChanged()
@@ -104,7 +104,7 @@ extension GridFilterViewController: UICollectionViewDelegateFlowLayout {
         showBottomButtonIfNeeded()
     }
 
-    func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
+    public func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
         let currentFilter = filter.subfilters[indexPath.row]
 
         UISelectionFeedbackGenerator().selectionChanged()

--- a/Sources/Charcoal/Filters/List/ListFilterViewController.swift
+++ b/Sources/Charcoal/Filters/List/ListFilterViewController.swift
@@ -4,7 +4,7 @@
 
 import FinniversKit
 
-final class ListFilterViewController: FilterViewController {
+public final class ListFilterViewController: FilterViewController {
     private enum Section: Int {
         case all, subfilters
     }
@@ -31,29 +31,29 @@ final class ListFilterViewController: FilterViewController {
 
     // MARK: - Init
 
-    init(filter: Filter, selectionStore: FilterSelectionStore) {
+    public init(filter: Filter, selectionStore: FilterSelectionStore) {
         self.filter = filter
         super.init(title: filter.title, selectionStore: selectionStore)
     }
 
-    required init?(coder aDecoder: NSCoder) {
+    public required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
     // MARK: - Overrides
 
-    override func viewDidLoad() {
+    public override func viewDidLoad() {
         super.viewDidLoad()
         bottomButton.buttonTitle = "applyButton".localized()
         setup()
     }
 
-    override func viewWillAppear(_ animated: Bool) {
+    public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         tableView.reloadData()
     }
 
-    override func showBottomButton(_ show: Bool, animated: Bool) {
+    public override func showBottomButton(_ show: Bool, animated: Bool) {
         super.showBottomButton(show, animated: animated)
         bottomButton.update(with: tableView)
     }
@@ -75,11 +75,11 @@ final class ListFilterViewController: FilterViewController {
 // MARK: - UITableViewDataSource
 
 extension ListFilterViewController: UITableViewDataSource {
-    func numberOfSections(in tableView: UITableView) -> Int {
+    public func numberOfSections(in tableView: UITableView) -> Int {
         return 2
     }
 
-    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         guard let section = Section(rawValue: section) else { return 0 }
 
         switch section {
@@ -90,7 +90,7 @@ extension ListFilterViewController: UITableViewDataSource {
         }
     }
 
-    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+    public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let section = Section(rawValue: indexPath.section) else { fatalError("Apple screwed up!") }
 
         let cell = tableView.dequeue(ListFilterCell.self, for: indexPath)
@@ -123,7 +123,7 @@ extension ListFilterViewController: UITableViewDataSource {
 // MARK: - UITableViewDelegate
 
 extension ListFilterViewController: UITableViewDelegate {
-    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+    public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         guard let section = Section(rawValue: indexPath.section) else { return }
 
         tableView.deselectRow(at: indexPath, animated: false)

--- a/Sources/Charcoal/Filters/Range/RangeFilterViewController.swift
+++ b/Sources/Charcoal/Filters/Range/RangeFilterViewController.swift
@@ -4,7 +4,7 @@
 
 import UIKit
 
-final class RangeFilterViewController: FilterViewController {
+public final class RangeFilterViewController: FilterViewController {
     // MARK: - Private properties
 
     private let lowValueFilter: Filter
@@ -20,8 +20,8 @@ final class RangeFilterViewController: FilterViewController {
 
     // MARK: - Init
 
-    init(title: String, lowValueFilter: Filter, highValueFilter: Filter,
-         filterConfig: RangeFilterConfiguration, selectionStore: FilterSelectionStore) {
+    public init(title: String, lowValueFilter: Filter, highValueFilter: Filter,
+                filterConfig: RangeFilterConfiguration, selectionStore: FilterSelectionStore) {
         self.lowValueFilter = lowValueFilter
         self.highValueFilter = highValueFilter
         self.filterConfig = filterConfig
@@ -29,13 +29,13 @@ final class RangeFilterViewController: FilterViewController {
         setup()
     }
 
-    required init?(coder aDecoder: NSCoder) {
+    public required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
     // MARK: - Lifecycle
 
-    override func viewDidLoad() {
+    public override func viewDidLoad() {
         super.viewDidLoad()
         setup()
     }

--- a/Sources/Charcoal/Filters/Stepper/StepperViewController.swift
+++ b/Sources/Charcoal/Filters/Stepper/StepperViewController.swift
@@ -5,7 +5,7 @@
 import FinniversKit
 import UIKit
 
-final class StepperFilterViewController: FilterViewController {
+public final class StepperFilterViewController: FilterViewController {
     private let filter: Filter
     private let filterConfig: StepperFilterConfiguration
     private lazy var topConstraint = stepperFilterView.centerYAnchor.constraint(lessThanOrEqualTo: view.topAnchor)
@@ -23,19 +23,19 @@ final class StepperFilterViewController: FilterViewController {
 
     // MARK: - Init
 
-    init(filter: Filter, selectionStore: FilterSelectionStore, filterConfig: StepperFilterConfiguration) {
+    public init(filter: Filter, selectionStore: FilterSelectionStore, filterConfig: StepperFilterConfiguration) {
         self.filter = filter
         self.filterConfig = filterConfig
         super.init(title: filter.title, selectionStore: selectionStore)
     }
 
-    required init?(coder aDecoder: NSCoder) {
+    public required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
     // MARK: - Lifecycle
 
-    override func viewDidLoad() {
+    public override func viewDidLoad() {
         super.viewDidLoad()
         bottomButton.buttonTitle = "applyButton".localized()
 
@@ -51,7 +51,7 @@ final class StepperFilterViewController: FilterViewController {
         ])
     }
 
-    override func viewWillAppear(_ animated: Bool) {
+    public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         topConstraint.constant = (view.frame.height - bottomButton.intrinsicContentSize.height) / 2
     }

--- a/Sources/Charcoal/Selection/FilterSelectionStore.swift
+++ b/Sources/Charcoal/Selection/FilterSelectionStore.swift
@@ -146,6 +146,15 @@ public extension FilterSelectionStore {
         return filters.reduce([]) { $0 + queryItems(for: $1) }
     }
 
+    func allQueryItems(for filterContainer: FilterContainer) -> [URLQueryItem] {
+        filterContainer.allFilters.reduce([]) { $0 + queryItems(for: $1) }
+    }
+
+    func allQueryItems(for filter: Filter) -> [URLQueryItem] {
+        let queryItems = queryItem(for: filter).flatMap { [$0] } ?? []
+        return filter.subfilters.reduce(queryItems) { $0 + allQueryItems(for: $1) }
+    }
+
     func titles(for filter: Filter) -> [SelectionTitle] {
         switch filter.kind {
         case let .range(lowValueFilter, highValueFilter, config):

--- a/Sources/Charcoal/Selection/SelectionTitle.swift
+++ b/Sources/Charcoal/Selection/SelectionTitle.swift
@@ -5,16 +5,16 @@
 import Foundation
 
 public struct SelectionTitle: Equatable {
-    let value: String
-    let accessibilityLabel: String
+    public let value: String
+    public let accessibilityLabel: String
 
     // MARK: - Init
 
-    init(value: String) {
+    public init(value: String) {
         self.init(value: value, accessibilityLabel: value)
     }
 
-    init(value: String, accessibilityLabel: String) {
+    public init(value: String, accessibilityLabel: String) {
         self.value = value
         self.accessibilityLabel = accessibilityLabel
     }


### PR DESCRIPTION
# Why?

In my experiments I want to use some of the filters separately.

# What?

- Make list, grid, stepper and range filters public
- Add new method to `FilterSelectionStore` to get all query items for the given filter including its sub-filters.

# Show me

No UI changes.