### PR TITLE
Fix allQueryItems function in selection store

### DIFF
--- a/Sources/Charcoal/Selection/FilterSelectionStore.swift
+++ b/Sources/Charcoal/Selection/FilterSelectionStore.swift
@@ -147,7 +147,7 @@ public extension FilterSelectionStore {
     }
 
     func allQueryItems(for filterContainer: FilterContainer) -> [URLQueryItem] {
-        filterContainer.allFilters.reduce([]) { $0 + queryItems(for: $1) }
+        filterContainer.allFilters.reduce([]) { $0 + allQueryItems(for: $1) }
     }
 
     func allQueryItems(for filter: Filter) -> [URLQueryItem] {


### PR DESCRIPTION
# Why?

There was a bug in the functions that I introduced in https://github.com/finn-no/charcoal-ios/pull/327

# What?

Fix `allQueryItems` function in `FilterSelectionStore` not calling the correct method.

# Show me

No UI changes.