### PR TITLE
Corona aid

### DIFF
--- a/Sources/FINNSetup/BackendModel/FilterSetup.swift
+++ b/Sources/FINNSetup/BackendModel/FilterSetup.swift
@@ -55,15 +55,21 @@ public struct FilterSetup: Decodable {
 
     // MARK: - Factory
 
-    public func filterContainer(using config: FilterConfiguration) -> FilterContainer {
+    public func filterContainer(using config: FilterConfiguration, excludedFilters: [FilterKey] = []) -> FilterContainer {
         let rootFilters = config.rootLevelFilterKeys.compactMap { key -> Filter? in
+            if excludedFilters.contains(key) {
+                return nil
+            }
             let filter = makeRootLevelFilter(withKey: key, using: config)
             filter?.mutuallyExclusiveFilterKeys = Set(config.mutuallyExclusiveFilters(for: key).map { $0.rawValue })
             return filter
         }
 
-        let preferenceFilters = config.preferenceFilterKeys.compactMap {
-            filterData(forKey: $0).flatMap { makeFilter(from: $0, withKind: .standard, style: .normal) }
+        let preferenceFilters = config.preferenceFilterKeys.compactMap { key -> Filter? in
+            if excludedFilters.contains(key) {
+                return nil
+            }
+            return filterData(forKey: key).flatMap { makeFilter(from: $0, withKind: .standard, style: .normal) }
         }
 
         let container = FilterContainer(

--- a/Sources/FINNSetup/FilterKey.swift
+++ b/Sources/FINNSetup/FilterKey.swift
@@ -106,4 +106,5 @@ public enum FilterKey: String, CodingKey {
     case batteryCapacity = "battery_capacity"
     case drivingRange = "driving_range"
     case maxTrailerWeight = "max_trailer_weight"
+    case coronaAid = "corona_aid"
 }

--- a/Sources/FINNSetup/FilterMarkets/FilterMarketBap.swift
+++ b/Sources/FINNSetup/FilterMarkets/FilterMarketBap.swift
@@ -17,6 +17,7 @@ extension FilterMarketBap: FilterConfiguration {
 
     public var rootLevelFilterKeys: [FilterKey] {
         return [
+            .coronaAid,
             .category,
             .bikesType,
             .carPartsBrand,


### PR DESCRIPTION
# Why?
To make it possible to have corona aid as a separate filter on root level.

# What?
- Whitelisted "corona-aid".
- Added possibility to exclude some filters from root level when building a FilterContainer. So main app can use unleash to decide if this is to be at root level or not.

# Show me
Have a look at PR in main app.
