### PR TITLE
Digital viewing search filter in realestate

### DIFF
--- a/Sources/FINNSetup/FilterKey.swift
+++ b/Sources/FINNSetup/FilterKey.swift
@@ -107,4 +107,5 @@ public enum FilterKey: String, CodingKey {
     case drivingRange = "driving_range"
     case maxTrailerWeight = "max_trailer_weight"
     case coronaAid = "corona_aid"
+    case digitalViewing = "video_type"
 }

--- a/Sources/FINNSetup/FilterMarkets/FilterMarketRealestate.swift
+++ b/Sources/FINNSetup/FilterMarkets/FilterMarketRealestate.swift
@@ -47,6 +47,7 @@ extension FilterMarketRealestate: FilterConfiguration {
                 .propertyType,
                 .ownershipType,
                 .facilities,
+                .digitalViewing,
                 .viewing,
                 .floorNavigator,
                 .energyLabel,
@@ -81,6 +82,7 @@ extension FilterMarketRealestate: FilterConfiguration {
                 .priceCollective,
                 .area,
                 .noOfBedrooms,
+                .digitalViewing,
                 .viewing,
                 .leisureSituation,
                 .propertyType,
@@ -109,6 +111,7 @@ extension FilterMarketRealestate: FilterConfiguration {
                 .furnished,
                 .rentFrom,
                 .facilities,
+                .digitalViewing,
                 .viewing,
                 .floorNavigator,
             ]


### PR DESCRIPTION
# Why?

We want to display the new digital viewings filter that was added to the proxy. The video filter is helpful in these corona times. 

# What?

Added the new filter `digitalViewing`, that is displayed for all realestate submarkets with the viewing filter; homes, letting and leisure sale. 

# Show me

| Filters | Subfilter |
| --- | --- |
| ![IMG_1455](https://user-images.githubusercontent.com/17450858/77314970-012ac400-6d07-11ea-9885-f61d3944ba3e.PNG) | ![IMG_1456](https://user-images.githubusercontent.com/17450858/77314977-038d1e00-6d07-11ea-86d7-31a75980d84e.PNG) |