### PR TITLE
Bump charcoal to 6.4.0

### DIFF
--- a/Charcoal.podspec
+++ b/Charcoal.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = 'Charcoal'
   s.summary          = 'A library that simplifies the creation of modern filtering experiences'
-  s.version          = '6.3.0'
+  s.version          = '6.4.0'
   s.author           = 'FINN.no'
   s.homepage         = 'https://github.com/finn-no/charcoal-ios'
   s.social_media_url = 'https://twitter.com/FINN_tech'


### PR DESCRIPTION
# Why?

Want to have the realestate digital viewing filter in the next patch. 