### PR TITLE
Callout overlay dark mode fix

### DIFF
--- a/Sources/Charcoal/Filters/Root/Views/CalloutOverlay.swift
+++ b/Sources/Charcoal/Filters/Root/Views/CalloutOverlay.swift
@@ -37,7 +37,7 @@ final class CalloutOverlay: UIView {
         let view = UIView(withAutoLayout: true)
         if #available(iOS 13, *),
             traitCollection.userInterfaceStyle == .dark {
-            view.backgroundColor = UIColor.bgSecondary.withAlphaComponent(0.8)
+            view.backgroundColor = UIColor.bgSecondary.withAlphaComponent(0.6)
         } else {
             view.backgroundColor = UIColor(white: 1, alpha: 0.8)
         }

--- a/Sources/Charcoal/Filters/Root/Views/CalloutOverlay.swift
+++ b/Sources/Charcoal/Filters/Root/Views/CalloutOverlay.swift
@@ -35,12 +35,7 @@ final class CalloutOverlay: UIView {
 
     private lazy var bodyView: UIView = {
         let view = UIView(withAutoLayout: true)
-        var alphaComponent: CGFloat = 0.8
-        if #available(iOS 13, *),
-            traitCollection.userInterfaceStyle == .dark {
-            alphaComponent = 0.6
-        }
-        view.backgroundColor = UIColor.overlayBackground.withAlphaComponent(alphaComponent)
+        view.backgroundColor = .overlayBackground
         return view
     }()
 
@@ -128,6 +123,6 @@ final class CalloutOverlay: UIView {
 
 private extension UIColor {
     class var overlayBackground: UIColor {
-        dynamicColorIfAvailable(defaultColor: .milk, darkModeColor: .darkIce)
+        dynamicColorIfAvailable(defaultColor: milk.withAlphaComponent(0.8), darkModeColor: darkIce.withAlphaComponent(0.6))
     }
 }

--- a/Sources/Charcoal/Filters/Root/Views/CalloutOverlay.swift
+++ b/Sources/Charcoal/Filters/Root/Views/CalloutOverlay.swift
@@ -35,12 +35,12 @@ final class CalloutOverlay: UIView {
 
     private lazy var bodyView: UIView = {
         let view = UIView(withAutoLayout: true)
+        var alphaComponent: CGFloat = 0.8
         if #available(iOS 13, *),
             traitCollection.userInterfaceStyle == .dark {
-            view.backgroundColor = UIColor.bgSecondary.withAlphaComponent(0.6)
-        } else {
-            view.backgroundColor = UIColor(white: 1, alpha: 0.8)
+            alphaComponent = 0.6
         }
+        view.backgroundColor = UIColor.overlayBackground.withAlphaComponent(alphaComponent)
         return view
     }()
 
@@ -123,5 +123,11 @@ final class CalloutOverlay: UIView {
 
     @objc private func handleTap() {
         delegate?.calloutOverlayDidTapInside(self)
+    }
+}
+
+private extension UIColor {
+    class var overlayBackground: UIColor {
+        dynamicColorIfAvailable(defaultColor: .milk, darkModeColor: .darkIce)
     }
 }

--- a/Sources/Charcoal/Filters/Root/Views/CalloutOverlay.swift
+++ b/Sources/Charcoal/Filters/Root/Views/CalloutOverlay.swift
@@ -35,7 +35,12 @@ final class CalloutOverlay: UIView {
 
     private lazy var bodyView: UIView = {
         let view = UIView(withAutoLayout: true)
-        view.backgroundColor = UIColor(white: 1, alpha: 0.8)
+        if #available(iOS 13, *),
+            traitCollection.userInterfaceStyle == .dark {
+            view.backgroundColor = UIColor.bgSecondary.withAlphaComponent(0.8)
+        } else {
+            view.backgroundColor = UIColor(white: 1, alpha: 0.8)
+        }
         return view
     }()
 


### PR DESCRIPTION
# Why?

A little dark mode bug sneaked into the polygon search. 

# What?

Callouts had a white background color. Now it has `bgPrimary` if dark mode, just like the bottom sheet.

# Show me

| Before | After |
| --- | --- |
| ![Image from iOS (1)](https://user-images.githubusercontent.com/17450858/81901488-e6662480-95be-11ea-9015-e87f625c348d.png) | ![IMG_1807](https://user-images.githubusercontent.com/17450858/81902043-ca16b780-95bf-11ea-8a21-278b4eafbdf7.PNG) |
