### PR TITLE
Feature: Filter-as-you-type for filtering subfilters

### DIFF
--- a/Charcoal.xcodeproj/project.pbxproj
+++ b/Charcoal.xcodeproj/project.pbxproj
@@ -85,6 +85,7 @@
 		55BDA76620DB7FC000331FFC /* TestDataDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55BDA76520DB7FC000331FFC /* TestDataDecoder.swift */; };
 		55F97D1220AC4FD5002BABC9 /* VerticalListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55F97D1120AC4FD5002BABC9 /* VerticalListViewController.swift */; };
 		55F97D1720B4432C002BABC9 /* RangeSliderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55F97D1620B4432C002BABC9 /* RangeSliderView.swift */; };
+		8D6800979EDCAFB591D588CC /* FreeTextFilterSearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D680AD29F6FD45E8F683EE6 /* FreeTextFilterSearchBar.swift */; };
 		91E6C09F230D8649009EDE12 /* DrawerPresentationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91E6C09E230D8649009EDE12 /* DrawerPresentationViewController.swift */; };
 		9B2931E323477A6B006469B5 /* AppCenterDistribute.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9B2931E223477A6B006469B5 /* AppCenterDistribute.framework */; };
 		9B2931E723477AF5006469B5 /* AppCenterCrashes.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9B2931E523477AF5006469B5 /* AppCenterCrashes.framework */; };
@@ -375,6 +376,7 @@
 		55BDC0FD20BFFB8D0038C83A /* FilterSetup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterSetup.swift; sourceTree = "<group>"; };
 		55F97D1120AC4FD5002BABC9 /* VerticalListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerticalListViewController.swift; sourceTree = "<group>"; };
 		55F97D1620B4432C002BABC9 /* RangeSliderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RangeSliderView.swift; sourceTree = "<group>"; };
+		8D680AD29F6FD45E8F683EE6 /* FreeTextFilterSearchBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FreeTextFilterSearchBar.swift; sourceTree = "<group>"; };
 		91E6C09E230D8649009EDE12 /* DrawerPresentationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawerPresentationViewController.swift; sourceTree = "<group>"; };
 		9B2931E223477A6B006469B5 /* AppCenterDistribute.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppCenterDistribute.framework; path = Carthage/Build/iOS/AppCenterDistribute.framework; sourceTree = "<group>"; };
 		9B2931E523477AF5006469B5 /* AppCenterCrashes.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppCenterCrashes.framework; path = Carthage/Build/iOS/AppCenterCrashes.framework; sourceTree = "<group>"; };
@@ -1066,6 +1068,7 @@
 			children = (
 				DAEB179621A6986500D9AAD6 /* FreeTextFilterViewController.swift */,
 				DA1C346F222534C700FB22A5 /* ViewModels */,
+				8D680AD29F6FD45E8F683EE6 /* FreeTextFilterSearchBar.swift */,
 			);
 			path = FreeText;
 			sourceTree = "<group>";
@@ -1746,6 +1749,7 @@
 				CFE255D7225B929B00052077 /* GridFilterCell.swift in Sources */,
 				CFCB36012237DE06004E6EB3 /* SelectionChangeOrigin.swift in Sources */,
 				4978F74624474B9E00D9D6C2 /* PolygonEdge.swift in Sources */,
+				8D6800979EDCAFB591D588CC /* FreeTextFilterSearchBar.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/Charcoal/Filters/FilterViewController.swift
+++ b/Sources/Charcoal/Filters/FilterViewController.swift
@@ -19,6 +19,7 @@ public class FilterViewController: ScrollViewController, FilterBottomButtonViewD
     // MARK: - Private properties
 
     lazy var bottomButtonBottomConstraint = bottomButton.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+    private(set) lazy var topShadowViewBottomAnchor = topShadowView.bottomAnchor.constraint(equalTo: view.topAnchor)
 
     private(set) lazy var bottomButton: FilterBottomButtonView = {
         let view = FilterBottomButtonView()
@@ -111,7 +112,7 @@ public class FilterViewController: ScrollViewController, FilterBottomButtonViewD
             bottomButton.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             bottomButton.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             bottomButton.topAnchor.constraint(lessThanOrEqualTo: view.bottomAnchor),
-            topShadowView.bottomAnchor.constraint(equalTo: view.topAnchor),
+            topShadowViewBottomAnchor,
         ])
     }
 

--- a/Sources/Charcoal/Filters/FreeText/FreeTextFilterSearchBar.swift
+++ b/Sources/Charcoal/Filters/FreeText/FreeTextFilterSearchBar.swift
@@ -1,0 +1,34 @@
+import FinniversKit
+
+class FreeTextFilterSearchBar: UISearchBar {
+    // Makes sure to setup appearance proxy one time and one time only
+    private static let setupSearchQuerySearchBarAppereanceOnce: () = {
+        let textFieldAppearanceInRoot = UITextField.appearance(whenContainedInInstancesOf: [AppearanceColoredTableView.self])
+        textFieldAppearanceInRoot.adjustsFontForContentSizeCategory = true
+        textFieldAppearanceInRoot.defaultTextAttributes = [
+            NSAttributedString.Key.foregroundColor: UIColor.textAction,
+            NSAttributedString.Key.font: UIFont.bodyRegular,
+        ]
+
+        let textFieldAppearanceInSearch = UITextField.appearance(whenContainedInInstancesOf: [FreeTextFilterSearchBar.self])
+        textFieldAppearanceInRoot.adjustsFontForContentSizeCategory = true
+        textFieldAppearanceInSearch.defaultTextAttributes = [
+            NSAttributedString.Key.foregroundColor: UIColor.textPrimary,
+            NSAttributedString.Key.font: UIFont.bodyRegular,
+        ]
+
+        let barButtondAppearance = UIBarButtonItem.appearance(whenContainedInInstancesOf: [FreeTextFilterSearchBar.self])
+        barButtondAppearance.setTitleTextAttributes([.font: UIFont.bodyRegular])
+        barButtondAppearance.title = "cancel".localized()
+    }()
+
+    override init(frame: CGRect) {
+        _ = FreeTextFilterSearchBar.setupSearchQuerySearchBarAppereanceOnce
+        super.init(frame: frame)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        _ = FreeTextFilterSearchBar.setupSearchQuerySearchBarAppereanceOnce
+        super.init(coder: aDecoder)
+    }
+}

--- a/Sources/Charcoal/Filters/FreeText/FreeTextFilterSearchBar.swift
+++ b/Sources/Charcoal/Filters/FreeText/FreeTextFilterSearchBar.swift
@@ -10,15 +10,15 @@ class FreeTextFilterSearchBar: UISearchBar {
         let textFieldAppearanceInRoot = UITextField.appearance(whenContainedInInstancesOf: [AppearanceColoredTableView.self])
         textFieldAppearanceInRoot.adjustsFontForContentSizeCategory = true
         textFieldAppearanceInRoot.defaultTextAttributes = [
-            NSAttributedString.Key.foregroundColor: UIColor.textAction,
-            NSAttributedString.Key.font: UIFont.bodyRegular,
+            .foregroundColor: UIColor.textAction,
+            .font: UIFont.bodyRegular,
         ]
 
         let textFieldAppearanceInSearch = UITextField.appearance(whenContainedInInstancesOf: [FreeTextFilterSearchBar.self])
         textFieldAppearanceInRoot.adjustsFontForContentSizeCategory = true
         textFieldAppearanceInSearch.defaultTextAttributes = [
-            NSAttributedString.Key.foregroundColor: UIColor.textPrimary,
-            NSAttributedString.Key.font: UIFont.bodyRegular,
+            .foregroundColor: UIColor.textPrimary,
+            .font: UIFont.bodyRegular,
         ]
 
         let barButtondAppearance = UIBarButtonItem.appearance(whenContainedInInstancesOf: [FreeTextFilterSearchBar.self])

--- a/Sources/Charcoal/Filters/FreeText/FreeTextFilterSearchBar.swift
+++ b/Sources/Charcoal/Filters/FreeText/FreeTextFilterSearchBar.swift
@@ -1,3 +1,7 @@
+//
+//  Copyright © FINN.no AS, Inc. All rights reserved.
+//
+
 import FinniversKit
 
 class FreeTextFilterSearchBar: UISearchBar {

--- a/Sources/Charcoal/Filters/FreeText/FreeTextFilterViewController.swift
+++ b/Sources/Charcoal/Filters/FreeText/FreeTextFilterViewController.swift
@@ -246,36 +246,3 @@ private extension FreeTextFilterViewController {
         ])
     }
 }
-
-private class FreeTextFilterSearchBar: UISearchBar {
-    // Makes sure to setup appearance proxy one time and one time only
-    private static let setupSearchQuerySearchBarAppereanceOnce: () = {
-        let textFieldAppearanceInRoot = UITextField.appearance(whenContainedInInstancesOf: [AppearanceColoredTableView.self])
-        textFieldAppearanceInRoot.adjustsFontForContentSizeCategory = true
-        textFieldAppearanceInRoot.defaultTextAttributes = [
-            NSAttributedString.Key.foregroundColor: UIColor.textAction,
-            NSAttributedString.Key.font: UIFont.bodyRegular,
-        ]
-
-        let textFieldAppearanceInSearch = UITextField.appearance(whenContainedInInstancesOf: [FreeTextFilterSearchBar.self])
-        textFieldAppearanceInRoot.adjustsFontForContentSizeCategory = true
-        textFieldAppearanceInSearch.defaultTextAttributes = [
-            NSAttributedString.Key.foregroundColor: UIColor.textPrimary,
-            NSAttributedString.Key.font: UIFont.bodyRegular,
-        ]
-
-        let barButtondAppearance = UIBarButtonItem.appearance(whenContainedInInstancesOf: [FreeTextFilterSearchBar.self])
-        barButtondAppearance.setTitleTextAttributes([.font: UIFont.bodyRegular])
-        barButtondAppearance.title = "cancel".localized()
-    }()
-
-    override init(frame: CGRect) {
-        _ = FreeTextFilterSearchBar.setupSearchQuerySearchBarAppereanceOnce
-        super.init(frame: frame)
-    }
-
-    required init?(coder aDecoder: NSCoder) {
-        _ = FreeTextFilterSearchBar.setupSearchQuerySearchBarAppereanceOnce
-        super.init(coder: aDecoder)
-    }
-}

--- a/Sources/Charcoal/Filters/FreeText/FreeTextFilterViewController.swift
+++ b/Sources/Charcoal/Filters/FreeText/FreeTextFilterViewController.swift
@@ -103,10 +103,7 @@ public class FreeTextFilterViewController: ScrollViewController {
         guard let keyboardValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else { return }
 
         var keyboardHeight = view.convert(keyboardValue.cgRectValue, from: view.window).height
-
-        if #available(iOS 11.0, *) {
-            keyboardHeight -= view.window?.safeAreaInsets.bottom ?? 0
-        }
+        keyboardHeight -= view.window?.safeAreaInsets.bottom ?? 0
 
         if notification.name == UIResponder.keyboardWillHideNotification {
             tableView.contentInset = .zero

--- a/Sources/Charcoal/Filters/List/ListFilterViewController.swift
+++ b/Sources/Charcoal/Filters/List/ListFilterViewController.swift
@@ -23,6 +23,12 @@ public final class ListFilterViewController: FilterViewController {
         return tableView
     }()
 
+    private lazy var searchBar: UISearchBar = {
+        let searchBar = UISearchBar(withAutoLayout: true)
+        searchBar.placeholder = "Placeholder"
+        return searchBar
+    }()
+
     private let filter: Filter
 
     private var canSelectAll: Bool {

--- a/Sources/Charcoal/Filters/List/ListFilterViewController.swift
+++ b/Sources/Charcoal/Filters/List/ListFilterViewController.swift
@@ -233,7 +233,14 @@ extension ListFilterViewController: UISearchBarDelegate {
             scopedSubfilters = filter.subfilters
         } else {
             let searchTextLowercased = searchText.lowercased()
-            scopedSubfilters = filter.subfilters.filter { $0.title.lowercased().contains(searchTextLowercased) }
+            // Find subfilters matching the query and make those who are prefixed with the query appear at the top.
+            scopedSubfilters = filter.subfilters
+                .filter { $0.title.lowercased().contains(searchTextLowercased) }
+                .sorted {
+                    let first = $0.title.lowercased().hasPrefix(searchTextLowercased) ? 0 : 1
+                    let second = $1.title.lowercased().hasPrefix(searchTextLowercased) ? 0 : 1
+                    return first < second
+                }
         }
 
         tableView.reloadData()

--- a/Sources/Charcoal/Filters/List/ListFilterViewController.swift
+++ b/Sources/Charcoal/Filters/List/ListFilterViewController.swift
@@ -30,6 +30,7 @@ public final class ListFilterViewController: FilterViewController {
     }()
 
     private let filter: Filter
+    private var filteredSubfilters: [Filter]
 
     private var canSelectAll: Bool {
         return filter.value != nil
@@ -39,6 +40,7 @@ public final class ListFilterViewController: FilterViewController {
 
     public init(filter: Filter, selectionStore: FilterSelectionStore) {
         self.filter = filter
+        filteredSubfilters = filter.subfilters
         super.init(title: filter.title, selectionStore: selectionStore)
     }
 
@@ -114,7 +116,7 @@ extension ListFilterViewController: UITableViewDataSource {
         case .all:
             return canSelectAll ? 1 : 0
         case .subfilters:
-            return filter.subfilters.count
+            return filteredSubfilters.count
         }
     }
 
@@ -130,7 +132,7 @@ extension ListFilterViewController: UITableViewDataSource {
         case .all:
             viewModel = .selectAll(from: filter, isSelected: isAllSelected)
         case .subfilters:
-            let subfilter = filter.subfilters[indexPath.row]
+            let subfilter = filteredSubfilters[indexPath.row]
 
             switch subfilter.kind {
             case .external:
@@ -164,7 +166,7 @@ extension ListFilterViewController: UITableViewDelegate {
             tableView.reloadSections(IndexSet(integer: Section.subfilters.rawValue), with: .fade)
             showBottomButton(true, animated: true)
         case .subfilters:
-            let subfilter = filter.subfilters[indexPath.row]
+            let subfilter = filteredSubfilters[indexPath.row]
 
             switch subfilter.kind {
             case _ where !subfilter.subfilters.isEmpty, .external:

--- a/Sources/Charcoal/Filters/List/ListFilterViewController.swift
+++ b/Sources/Charcoal/Filters/List/ListFilterViewController.swift
@@ -197,4 +197,14 @@ extension ListFilterViewController: UITableViewDelegate {
 // MARK: - UISearchBarDelegate
 
 extension ListFilterViewController: UISearchBarDelegate {
+    public func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
+        if searchText.isEmpty {
+            filteredSubfilters = filter.subfilters
+        } else {
+            let searchTextLowercased = searchText.lowercased()
+            filteredSubfilters = filter.subfilters.filter { $0.title.lowercased().contains(searchTextLowercased) }
+        }
+
+        tableView.reloadData()
+    }
 }

--- a/Sources/Charcoal/Filters/List/ListFilterViewController.swift
+++ b/Sources/Charcoal/Filters/List/ListFilterViewController.swift
@@ -34,7 +34,7 @@ public final class ListFilterViewController: FilterViewController {
     }()
 
     private let filter: Filter
-    private var filteredSubfilters: [Filter]
+    private var scopedSubfilters: [Filter]
     private let notificationCenter: NotificationCenter
     private let searchbarSubfilterThreshold: Int
 
@@ -46,7 +46,7 @@ public final class ListFilterViewController: FilterViewController {
 
     public init(filter: Filter, selectionStore: FilterSelectionStore, searchbarSubfilterThreshold: Int = 20, notificationCenter: NotificationCenter = .default) {
         self.filter = filter
-        filteredSubfilters = filter.subfilters
+        scopedSubfilters = filter.subfilters
         self.searchbarSubfilterThreshold = searchbarSubfilterThreshold
         self.notificationCenter = notificationCenter
         super.init(title: filter.title, selectionStore: selectionStore)
@@ -151,7 +151,7 @@ extension ListFilterViewController: UITableViewDataSource {
         case .all:
             return canSelectAll ? 1 : 0
         case .subfilters:
-            return filteredSubfilters.count
+            return scopedSubfilters.count
         }
     }
 
@@ -167,7 +167,7 @@ extension ListFilterViewController: UITableViewDataSource {
         case .all:
             viewModel = .selectAll(from: filter, isSelected: isAllSelected)
         case .subfilters:
-            let subfilter = filteredSubfilters[indexPath.row]
+            let subfilter = scopedSubfilters[indexPath.row]
 
             switch subfilter.kind {
             case .external:
@@ -201,7 +201,7 @@ extension ListFilterViewController: UITableViewDelegate {
             tableView.reloadSections(IndexSet(integer: Section.subfilters.rawValue), with: .fade)
             showBottomButton(true, animated: true)
         case .subfilters:
-            let subfilter = filteredSubfilters[indexPath.row]
+            let subfilter = scopedSubfilters[indexPath.row]
 
             switch subfilter.kind {
             case _ where !subfilter.subfilters.isEmpty, .external:
@@ -230,10 +230,10 @@ extension ListFilterViewController: UITableViewDelegate {
 extension ListFilterViewController: UISearchBarDelegate {
     public func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
         if searchText.isEmpty {
-            filteredSubfilters = filter.subfilters
+            scopedSubfilters = filter.subfilters
         } else {
             let searchTextLowercased = searchText.lowercased()
-            filteredSubfilters = filter.subfilters.filter { $0.title.lowercased().contains(searchTextLowercased) }
+            scopedSubfilters = filter.subfilters.filter { $0.title.lowercased().contains(searchTextLowercased) }
         }
 
         tableView.reloadData()

--- a/Sources/Charcoal/Filters/List/ListFilterViewController.swift
+++ b/Sources/Charcoal/Filters/List/ListFilterViewController.swift
@@ -125,10 +125,7 @@ public final class ListFilterViewController: FilterViewController {
         guard let keyboardValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else { return }
 
         var keyboardHeight = view.convert(keyboardValue.cgRectValue, from: view.window).height
-
-        if #available(iOS 11.0, *) {
-            keyboardHeight -= view.window?.safeAreaInsets.bottom ?? 0
-        }
+        keyboardHeight -= view.window?.safeAreaInsets.bottom ?? 0
 
         if notification.name == UIResponder.keyboardWillHideNotification {
             tableView.contentInset = .zero

--- a/Sources/Charcoal/Filters/List/ListFilterViewController.swift
+++ b/Sources/Charcoal/Filters/List/ListFilterViewController.swift
@@ -69,12 +69,34 @@ public final class ListFilterViewController: FilterViewController {
     private func setup() {
         view.insertSubview(tableView, belowSubview: bottomButton)
 
-        NSLayoutConstraint.activate([
+        let sharedTableViewConstraints = [
             tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            tableView.topAnchor.constraint(equalTo: view.topAnchor),
             tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             tableView.bottomAnchor.constraint(equalTo: bottomButton.topAnchor),
-        ])
+        ]
+
+        if filter.subfilters.count >= 20 {
+            view.addSubview(searchBar)
+
+            topShadowViewBottomAnchor.isActive = false
+
+            NSLayoutConstraint.activate(
+                sharedTableViewConstraints +
+                [
+                    searchBar.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: .spacingS),
+                    searchBar.topAnchor.constraint(equalTo: view.topAnchor),
+                    searchBar.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -.spacingS),
+
+                    topShadowView.bottomAnchor.constraint(equalTo: searchBar.bottomAnchor),
+                    tableView.topAnchor.constraint(equalTo: searchBar.bottomAnchor),
+                ]
+            )
+        } else {
+            NSLayoutConstraint.activate(
+                sharedTableViewConstraints +
+                [tableView.topAnchor.constraint(equalTo: view.topAnchor)]
+            )
+        }
     }
 }
 

--- a/Sources/Charcoal/Filters/List/ListFilterViewController.swift
+++ b/Sources/Charcoal/Filters/List/ListFilterViewController.swift
@@ -24,8 +24,12 @@ public final class ListFilterViewController: FilterViewController {
     }()
 
     private lazy var searchBar: UISearchBar = {
-        let searchBar = UISearchBar(withAutoLayout: true)
-        searchBar.placeholder = "Placeholder"
+        let searchBar = FreeTextFilterSearchBar(frame: .zero)
+        searchBar.searchBarStyle = .minimal
+        searchBar.delegate = self
+        searchBar.backgroundColor = Theme.mainBackground
+        searchBar.placeholder = "Avgrens søket"
+        searchBar.translatesAutoresizingMaskIntoConstraints = false
         return searchBar
     }()
 
@@ -188,4 +192,9 @@ extension ListFilterViewController: UITableViewDelegate {
             cell.animateSelection(isSelected: isSelected)
         }
     }
+}
+
+// MARK: - UISearchBarDelegate
+
+extension ListFilterViewController: UISearchBarDelegate {
 }

--- a/Sources/Charcoal/Filters/List/ListFilterViewController.swift
+++ b/Sources/Charcoal/Filters/List/ListFilterViewController.swift
@@ -36,6 +36,7 @@ public final class ListFilterViewController: FilterViewController {
     private let filter: Filter
     private var filteredSubfilters: [Filter]
     private let notificationCenter: NotificationCenter
+    private let searchbarSubfilterThreshold: Int
 
     private var canSelectAll: Bool {
         return filter.value != nil
@@ -43,9 +44,10 @@ public final class ListFilterViewController: FilterViewController {
 
     // MARK: - Init
 
-    public init(filter: Filter, selectionStore: FilterSelectionStore, notificationCenter: NotificationCenter = .default) {
+    public init(filter: Filter, selectionStore: FilterSelectionStore, searchbarSubfilterThreshold: Int = 20, notificationCenter: NotificationCenter = .default) {
         self.filter = filter
         filteredSubfilters = filter.subfilters
+        self.searchbarSubfilterThreshold = searchbarSubfilterThreshold
         self.notificationCenter = notificationCenter
         super.init(title: filter.title, selectionStore: selectionStore)
     }
@@ -90,7 +92,7 @@ public final class ListFilterViewController: FilterViewController {
             tableView.bottomAnchor.constraint(equalTo: bottomButton.topAnchor),
         ]
 
-        if filter.subfilters.count >= 20 {
+        if filter.subfilters.count >= searchbarSubfilterThreshold {
             view.addSubview(searchBar)
 
             topShadowViewBottomAnchor.isActive = false

--- a/Sources/Charcoal/Filters/List/ListFilterViewController.swift
+++ b/Sources/Charcoal/Filters/List/ListFilterViewController.swift
@@ -86,22 +86,18 @@ public final class ListFilterViewController: FilterViewController {
 
             topShadowViewBottomAnchor.isActive = false
 
-            NSLayoutConstraint.activate(
-                sharedTableViewConstraints +
-                [
-                    searchBar.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: .spacingS),
-                    searchBar.topAnchor.constraint(equalTo: view.topAnchor),
-                    searchBar.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -.spacingS),
+            let searchBarConstraints = [
+                searchBar.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: .spacingS),
+                searchBar.topAnchor.constraint(equalTo: view.topAnchor),
+                searchBar.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -.spacingS),
 
-                    topShadowView.bottomAnchor.constraint(equalTo: searchBar.bottomAnchor),
-                    tableView.topAnchor.constraint(equalTo: searchBar.bottomAnchor),
-                ]
-            )
+                topShadowView.bottomAnchor.constraint(equalTo: searchBar.bottomAnchor),
+                tableView.topAnchor.constraint(equalTo: searchBar.bottomAnchor),
+            ]
+
+            NSLayoutConstraint.activate(sharedTableViewConstraints + searchBarConstraints)
         } else {
-            NSLayoutConstraint.activate(
-                sharedTableViewConstraints +
-                [tableView.topAnchor.constraint(equalTo: view.topAnchor)]
-            )
+            NSLayoutConstraint.activate(sharedTableViewConstraints + [tableView.topAnchor.constraint(equalTo: view.topAnchor)])
         }
     }
 }

--- a/Sources/Charcoal/Filters/List/ListFilterViewController.swift
+++ b/Sources/Charcoal/Filters/List/ListFilterViewController.swift
@@ -28,7 +28,7 @@ public final class ListFilterViewController: FilterViewController {
         searchBar.searchBarStyle = .minimal
         searchBar.delegate = self
         searchBar.backgroundColor = Theme.mainBackground
-        searchBar.placeholder = "Avgrens søket"
+        searchBar.placeholder = "filterAsYouType.placeholder".localized()
         searchBar.translatesAutoresizingMaskIntoConstraints = false
         return searchBar
     }()

--- a/Sources/Charcoal/Filters/List/ListFilterViewController.swift
+++ b/Sources/Charcoal/Filters/List/ListFilterViewController.swift
@@ -100,6 +100,13 @@ public final class ListFilterViewController: FilterViewController {
             NSLayoutConstraint.activate(sharedTableViewConstraints + [tableView.topAnchor.constraint(equalTo: view.topAnchor)])
         }
     }
+
+    // MARK: - Overrides
+
+    public func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+        super.scrollViewDidScroll(scrollView)
+        searchBar.endEditing(true)
+    }
 }
 
 // MARK: - UITableViewDataSource

--- a/Sources/Charcoal/Resources/en.lproj/Localizable.strings
+++ b/Sources/Charcoal/Resources/en.lproj/Localizable.strings
@@ -29,6 +29,7 @@
 "next" = "Neste";
 "skip" = "Hopp over";
 "noValue" = "Ingen verdi";
+"filterAsYouType.placeholder" = "Avgrens søket";
 
 "root.title" = "Filtrer søket";
 "root.verticalSelector.title" = "Flere kategorier";


### PR DESCRIPTION
# Why?
We want to implement a similar feature to what Android implemented in one of their hackdays. Some lists contains a lot items, like car/boat brand, and instead of scrolling endlessly the user should be able to narrow down the list with a query.

**Functionality**:
- The searchbar will be visible for filters with a subfilter count higher than what's defined through the constructor argument `searchbarSubfilterThreshold`.
- The keyboard will dismiss on drag within the tableview.
- Subfilters matching the query, or all if searchbar is empty, are copied into `scopedSubfilters`.
  - Subfilters prefixed with the query are prioritized to the top of the list.
- The list `scopedSubfilters` is used to populate the tableView.


# What?
- Add searchbar to top of view, if subfilters exceed the threshold.
- Pull out private class `FreeTextFilterSearchBar` into separate file and use this one.
  - It already has styling we need configured.
- Pull constraint for `topShadowView.bottomAnchor` into separate variable.

# Show me
![Kapture 2020-05-28 at 14 01 54](https://user-images.githubusercontent.com/1901556/83139251-56f76000-a0ec-11ea-827e-44a8c5d21f9f.gif)
