### PR TITLE
Filter-as-you-type: Dismiss keyboard on search button press

### DIFF
--- a/Sources/Charcoal/Filters/List/ListFilterViewController.swift
+++ b/Sources/Charcoal/Filters/List/ListFilterViewController.swift
@@ -245,4 +245,8 @@ extension ListFilterViewController: UISearchBarDelegate {
 
         tableView.reloadData()
     }
+
+    public func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
+        searchBar.endEditing(true)
+    }
 }


### PR DESCRIPTION
# Why?
In #340 I forgot to add logic to dismiss keyboard when the search button is pressed.

# Show me
![Kapture 2020-05-29 at 10 34 46](https://user-images.githubusercontent.com/1901556/83239420-20771f00-a198-11ea-8a0e-5a9bd47cddcf.gif)
