### PR TITLE
Nettbil promotion callout

### DIFF
--- a/Sources/Charcoal/CharcoalViewController.swift
+++ b/Sources/Charcoal/CharcoalViewController.swift
@@ -81,6 +81,9 @@ public final class CharcoalViewController: UINavigationController {
         if let text = filterContainer?.regionReformCalloutText, !userDefaults.regionReformCalloutShown {
             showCalloutOverlay(withText: text, andDirection: .down, constrainedToTopAnchor: navigationBar.bottomAnchor)
             userDefaults.regionReformCalloutShown = true
+        } else if let nettbilCalloutText = filterContainer?.nettbilCalloutText, !userDefaults.nettbilCalloutShown {
+            showCalloutOverlay(withText: nettbilCalloutText, andDirection: .up, constrainedToTopAnchor: navigationBar.bottomAnchor)
+            userDefaults.nettbilCalloutShown = true
         }
     }
 
@@ -380,6 +383,11 @@ private extension UserDefaults {
     }
 
     var polygonSearchCalloutShown: Bool {
+        get { return bool(forKey: "Charcoal." + #function) }
+        set { set(newValue, forKey: "Charcoal." + #function) }
+    }
+
+    var nettbilCalloutShown: Bool {
         get { return bool(forKey: "Charcoal." + #function) }
         set { set(newValue, forKey: "Charcoal." + #function) }
     }

--- a/Sources/Charcoal/Models/FilterContainer.swift
+++ b/Sources/Charcoal/Models/FilterContainer.swift
@@ -9,6 +9,7 @@ public class FilterContainer {
 
     public var verticals: [Vertical]?
     public var regionReformCalloutText: String?
+    public var nettbilCalloutText: String?
 
     // MARK: - Internal properties
 

--- a/Sources/Charcoal/Vertical/VerticalCell.swift
+++ b/Sources/Charcoal/Vertical/VerticalCell.swift
@@ -12,6 +12,13 @@ final class VerticalCell: UITableViewCell {
         return radioButton
     }()
 
+    private lazy var externalVerticalIcon: UIImageView = {
+        let imageView = UIImageView(image: UIImage(named: .webview).withRenderingMode(.alwaysTemplate))
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.tintColor = .chevron
+        return imageView
+    }()
+
     // MARK: - Init
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
@@ -48,19 +55,11 @@ final class VerticalCell: UITableViewCell {
         textLabel?.text = vertical.title
         radioButton.isHighlighted = vertical.isCurrent
 
-        if vertical.isExternal {
-            detailTextLabel?.text = "browserText".localized()
-
-            let accessoryView = UIImageView(image: UIImage(named: .webview).withRenderingMode(.alwaysTemplate))
-            accessoryView.tintColor = .chevron
-            self.accessoryView = accessoryView
-        } else {
-            accessoryView = nil
-            detailTextLabel?.text = nil
-        }
+        radioButton.isHidden = vertical.isExternal
+        externalVerticalIcon.isHidden = !radioButton.isHidden
 
         let accessibilityPrefix = vertical.isCurrent ? "selected".localized() + ", " : ""
-        let accessibilitySuffix = detailTextLabel?.text.map { ", \($0) " } ?? ""
+        let accessibilitySuffix = vertical.isExternal ? ", " + "browserText".localized() + " " : ""
 
         accessibilityLabel = accessibilityPrefix + vertical.title + accessibilitySuffix
     }
@@ -76,15 +75,16 @@ final class VerticalCell: UITableViewCell {
         textLabel?.textColor = .textPrimary
         textLabel?.adjustsFontForContentSizeCategory = true
 
-        detailTextLabel?.font = .detail
-        detailTextLabel?.textColor = .textSecondary
-        detailTextLabel?.adjustsFontForContentSizeCategory = true
-
         addSubview(radioButton)
+        addSubview(externalVerticalIcon)
+        externalVerticalIcon.isHidden = true
 
         NSLayoutConstraint.activate([
             radioButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: .spacingM),
             radioButton.centerYAnchor.constraint(equalTo: centerYAnchor),
+
+            externalVerticalIcon.leadingAnchor.constraint(equalTo: leadingAnchor, constant: .spacingM + .spacingXS),
+            externalVerticalIcon.centerYAnchor.constraint(equalTo: centerYAnchor),
         ])
     }
 }


### PR DESCRIPTION
# Why?

We want to gain more attention for Nettbil, and promote it with callouts. 

# What?

- Add support for nettbil callout pointing to verticals menu. Make sure it's only shown once.
- Remove radio button and replace it with the open in browser icon.
This was done for two reasons: 
1) It doesn't make sense to have a radio button UX wise, since it's not selectable in the menu anyways. 
2) We are going to change vertical name in the proxy from "Nettbil" to "Nettbil - selg uten reklamasjonsansvar", which requires more space.

# Show me

![nettbil-callout](https://user-images.githubusercontent.com/17450858/90112951-f2de5280-dd50-11ea-97ff-c7137ecdc294.png)

| Before | After |
| --- | --- |
| ![nettbil-before](https://user-images.githubusercontent.com/17450858/90112924-ece87180-dd50-11ea-8769-b81477f6a322.PNG) | ![IMG_2925](https://user-images.githubusercontent.com/17450858/90113073-1b664c80-dd51-11ea-9ea8-0d1b84762772.PNG) |
