### PR TITLE
Filter for knots (boat)

### DIFF
--- a/Sources/Charcoal/Models/FilterUnit.swift
+++ b/Sources/Charcoal/Models/FilterUnit.swift
@@ -17,6 +17,7 @@ public enum FilterUnit: Equatable {
     case squareMeters
     case year
     case kiloWattHour
+    case knots
     case custom(
         value: String,
         accessibilityValue: String,
@@ -49,6 +50,8 @@ public enum FilterUnit: Equatable {
             return ""
         case .kiloWattHour:
             return "unit.kiloWattHour.value".localized()
+        case .knots:
+            return "unit.knots.value".localized()
         case let .custom(value, _, _):
             return value
         }
@@ -80,6 +83,8 @@ public enum FilterUnit: Equatable {
             return "unit.years.accessibilityValue".localized()
         case .kiloWattHour:
             return "unit.kiloWattHour.accessibilityValue".localized()
+        case .knots:
+            return "unit.knots.accessibilityValue".localized()
         case let .custom(_, accessibilityValue, _):
             return accessibilityValue
         }

--- a/Sources/Charcoal/Resources/en.lproj/Localizable.strings
+++ b/Sources/Charcoal/Resources/en.lproj/Localizable.strings
@@ -50,6 +50,7 @@
 "unit.seats.value" = "seter";
 "unit.squareMeters.value" = "m²";
 "unit.kiloWattHour.value" = "kWh";
+"unit.knots.value" = "knop";
 
 "unit.centimeters.accessibilityValue" = "centimeter";
 "unit.cubicCentimeters.accessibilityValue" = "kubikkcentimeter";
@@ -63,6 +64,7 @@
 "unit.squareMeters.accessibilityValue" = "kvadratmeter";
 "unit.years.accessibilityValue" = "år";
 "unit.kiloWattHour.accessibilityValue" = "kilowattime";
+"unit.knots.accessibilityValue" = "knop";
 
 "map.title" = "Område i kart";
 "map.radiusSearch.toggleButton.title" = "Avstand";

--- a/Sources/FINNSetup/FilterKey.swift
+++ b/Sources/FINNSetup/FilterKey.swift
@@ -101,6 +101,7 @@ public enum FilterKey: String, CodingKey {
     case searchType = "search_type"
     case segment
     case shoeSize = "shoe_size"
+    case speed
     case transmission
     case truckSegment = "truck_segment"
     case type

--- a/Sources/FINNSetup/FilterMarkets/FilterMarketBoat.swift
+++ b/Sources/FINNSetup/FilterMarkets/FilterMarketBoat.swift
@@ -40,6 +40,7 @@ extension FilterMarketBoat: FilterConfiguration {
                 .lengthFeet,
                 .width,
                 .year,
+                .speed,
                 .motorIncluded,
                 .motorType,
                 .material,
@@ -128,6 +129,8 @@ extension FilterMarketBoat: FilterConfiguration {
             return .configuration(minimumValue: 0, maximumValue: 60, increment: 1, unit: .feet)
         case .year:
             return .yearConfiguration(minimumValue: 1985)
+        case .speed:
+            return .configuration(minimumValue: 0, maximumValue: 100, increment: 2, unit: .knots)
         case .motorSize, .engineEffect:
             return .horsePowerConfiguration(minimumValue: 0, maximumValue: 500)
         case .noOfSeats:


### PR DESCRIPTION
# Why?
There's been added a speed filter for the boat market. The unit for this filter should be knop/knots.

# What?
- Added the filter and localized strings.

# Show me
<img width="320" alt="Screenshot 2020-09-02 at 15 05 28" src="https://user-images.githubusercontent.com/1901556/91987027-c6a16a80-ed2d-11ea-9de3-0c88916e2c83.png">
