### PR TITLE
Fix: Move christmas filter to top of list for BAP

### DIFF
--- a/Sources/FINNSetup/FilterMarkets/FilterMarketBap.swift
+++ b/Sources/FINNSetup/FilterMarkets/FilterMarketBap.swift
@@ -17,6 +17,7 @@ extension FilterMarketBap: FilterConfiguration {
 
     public var rootLevelFilterKeys: [FilterKey] {
         return [
+            .christmas,
             .coronaAid,
             .category,
             .bikesType,
@@ -37,7 +38,6 @@ extension FilterMarketBap: FilterConfiguration {
             .map,
             .location,
             .price,
-            .christmas,
         ]
     }
 


### PR DESCRIPTION
# Why?
Torget wants us to move the christmas filter to the top of the list.

# What?
- Moved it🎅

# Show me
<img width="320" alt="Screenshot 2020-11-26 at 10 28 08" src="https://user-images.githubusercontent.com/1901556/100333077-75261600-2fd2-11eb-9d73-c2f4d839f2ec.png">

