### PR TITLE
Dark mode fix: Vertical selector

### DIFF
--- a/Sources/Charcoal/Vertical/VerticalCell.swift
+++ b/Sources/Charcoal/Vertical/VerticalCell.swift
@@ -68,6 +68,7 @@ final class VerticalCell: UITableViewCell {
         let selectedBackgroundView = UIView()
         selectedBackgroundView.backgroundColor = .defaultCellSelectedBackgroundColor
         self.selectedBackgroundView = selectedBackgroundView
+        backgroundColor = .clear
 
         separatorInset = .leadingInset(56)
 

--- a/Sources/Charcoal/Vertical/VerticalListViewController.swift
+++ b/Sources/Charcoal/Vertical/VerticalListViewController.swift
@@ -17,6 +17,7 @@ final class VerticalListViewController: ScrollViewController {
         tableView.dataSource = self
         tableView.delegate = self
         tableView.allowsSelection = true
+        tableView.backgroundColor = Theme.mainBackground
         tableView.removeLastCellSeparator()
         registerCells(for: tableView)
         return tableView


### PR DESCRIPTION
# Why?

Noticed background color for selecting vertical in charcoal was a little off. 

# What?

Make sure to use `Theme.mainBackground` for the tableView. The cells are `.clear`, so they will have the same color as tableView.

# Show me

| Before | After |
| --- | --- |
| ![Skjermbilde 2020-12-08 kl  09 38 10](https://user-images.githubusercontent.com/17450858/101461218-dcc95300-393a-11eb-8fa2-0e308f417e7a.png) | ![Skjermbilde 2020-12-08 kl  09 46 26](https://user-images.githubusercontent.com/17450858/101461213-daff8f80-393a-11eb-811f-b7a6ca604222.png) |


