### PR TITLE
Turn off smart quotes for searchbars

### DIFF
--- a/Demo/Components/MapFilterDemoViewController.swift
+++ b/Demo/Components/MapFilterDemoViewController.swift
@@ -16,6 +16,8 @@ class MapFilterDemoViewController: DemoViewController {
         searchBar.placeholder = "Søk etter sted eller adresse"
         searchBar.searchBarStyle = .minimal
         searchBar.backgroundColor = Theme.mainBackground
+        searchBar.smartQuotesType = .no
+        searchBar.smartDashesType = .no
         view.searchBar = searchBar
         view.translatesAutoresizingMaskIntoConstraints = false
         return view

--- a/Sources/Charcoal/Filters/FreeText/FreeTextFilterSearchBar.swift
+++ b/Sources/Charcoal/Filters/FreeText/FreeTextFilterSearchBar.swift
@@ -29,10 +29,14 @@ class FreeTextFilterSearchBar: UISearchBar {
     override init(frame: CGRect) {
         _ = FreeTextFilterSearchBar.setupSearchQuerySearchBarAppereanceOnce
         super.init(frame: frame)
+        smartQuotesType = .no
+        smartDashesType = .no
     }
 
     required init?(coder aDecoder: NSCoder) {
         _ = FreeTextFilterSearchBar.setupSearchQuerySearchBarAppereanceOnce
         super.init(coder: aDecoder)
+        smartQuotesType = .no
+        smartDashesType = .no
     }
 }

--- a/Sources/Charcoal/Filters/Map/SearchLocationViewController.swift
+++ b/Sources/Charcoal/Filters/Map/SearchLocationViewController.swift
@@ -318,11 +318,15 @@ private class SearchLocationSearchBar: UISearchBar {
     override init(frame: CGRect) {
         _ = SearchLocationSearchBar.setupSearchBarAppereanceOnce
         super.init(frame: frame)
+        smartQuotesType = .no
+        smartDashesType = .no
     }
 
     required init?(coder aDecoder: NSCoder) {
         _ = SearchLocationSearchBar.setupSearchBarAppereanceOnce
         super.init(coder: aDecoder)
+        smartQuotesType = .no
+        smartDashesType = .no
     }
 }
 


### PR DESCRIPTION
# Why?
Smart quotes are not so good when searching since quotes have special meaning, but « » doesn't.

# What?
No smart quotes on searchbars.
