### PR TITLE
Fix compile errors in Xcode 12.5

### DIFF
--- a/Sources/FINNSetup/BackendModel/PolygonData.swift
+++ b/Sources/FINNSetup/BackendModel/PolygonData.swift
@@ -62,7 +62,7 @@ public struct PolygonData {
     }
 
     static func createBBoxQuery(for coordinates: [CLLocationCoordinate2D]) -> String? {
-        let bboxCoordinates = [
+        let bboxCoordinates: [CLLocationDegrees] = [
             coordinates.map { $0.longitude }.min() ?? 0,
             coordinates.map { $0.latitude }.min() ?? 0,
             coordinates.map { $0.longitude }.max() ?? 0,


### PR DESCRIPTION
# Why?

I guess it has something to do with Swift 5.4

<img width="1546" alt="Screenshot 2021-04-30 at 12 13 10" src="https://user-images.githubusercontent.com/10529867/116681968-f0d72500-a9ad-11eb-9acd-de13c8c03ddd.png">

# What?

Specify the type for `bboxCoordinates` in `PolygonData.swift`

# Show me

No UI changes.