### PR TITLE
Fix map + bottom sheet animation crashes - iPad orientation change fix

### DIFF
--- a/Sources/Charcoal/Filters/Map/Polygon/Views/MapPolygonFilterView.swift
+++ b/Sources/Charcoal/Filters/Map/Polygon/Views/MapPolygonFilterView.swift
@@ -35,7 +35,11 @@ final class MapPolygonFilterView: UIView {
 
     private var polygon: MKPolygon?
 
-    private var updateViewDispatchWorkItem: DispatchWorkItem?
+    private var updateViewDispatchWorkItem: DispatchWorkItem? {
+        willSet {
+            updateViewDispatchWorkItem?.cancel()
+        }
+    }
 
     // MARK: - Internal properties
 
@@ -216,8 +220,6 @@ final class MapPolygonFilterView: UIView {
     override func layoutSubviews() {
         super.layoutSubviews()
 
-        guard updateViewDispatchWorkItem == nil else { return }
-
         let updateViewWorkItem = DispatchWorkItem { [weak self] in
             guard let self = self else { return }
             self.mapContainerView.isHidden = false
@@ -228,7 +230,7 @@ final class MapPolygonFilterView: UIView {
         updateViewDispatchWorkItem = updateViewWorkItem
 
         // Use a delay incase the view is being resized
-        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(500), execute: updateViewWorkItem)
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(400), execute: updateViewWorkItem)
     }
 
     // MARK: - API


### PR DESCRIPTION
# Why?
The map height was not changed on orientation changes.

# What?
Update map height on each layoutSubviews to also handle orientation changes. 

MapRadiusFilterView: map view height and setting region moved to separate work items since otherwise the region sometimes gets set incorrectly.
