### PR TITLE
Fix bug where map centers on random coordinates in location search

### DIFF
--- a/Sources/Charcoal/Filters/Map/Radius/MapRadiusFilterViewController.swift
+++ b/Sources/Charcoal/Filters/Map/Radius/MapRadiusFilterViewController.swift
@@ -227,7 +227,7 @@ extension MapRadiusFilterViewController: SearchLocationViewControllerDelegate {
             locationName = location.name
             self.coordinate = coordinate
 
-            mapRadiusFilterView.centerOnCoordinate(coordinate, animated: true)
+            mapRadiusFilterView.centerOnCoordinate(coordinate, animated: false)
         }
     }
 }


### PR DESCRIPTION
# Why?

We got a bug report from a user searching for Vadsø, where the map sometimes would center on a random location in Finland.

# What?

We recently did a bug fix, #371 , which hides the map when centring on a location (the height is 0). 
I suspect this causes the map to center wrongly while animating. 
Doing it without animation fixes the issue. 
We don't really need this to be animated, because you can barely see the animation anyways (the map is hidden while it happens).

We can enable animations again when we have found a more permanent fix for #371 (start using iOS 15+ bottom sheet instead of our own)

# Show me

| Before | After |
| --- | --- |
| ![Skjermopptak 2022-02-07 kl  12 42 07](https://user-images.githubusercontent.com/17450858/152819210-8f8022a8-ca22-4477-97d9-54e69bc8b8e3.gif) | ![Skjermopptak 2022-02-07 kl  12 43 57](https://user-images.githubusercontent.com/17450858/152819262-4fc0caba-87ff-423b-a6df-ed69d16fa511.gif) |

