### PR TITLE
Add support for næringstorget callout and general vertical callout

### DIFF
--- a/CharcoalDemo/CharcoalDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CharcoalDemo/CharcoalDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/finn-no/FinniversKit.git",
         "state": {
           "branch": null,
-          "revision": "6c1cece9a0d9b9150414eef3b5ebdbe0709be1a9",
-          "version": "85.1.1"
+          "revision": "fde0a61ad119361e86fc5514dd32b1af9f8510da",
+          "version": "90.3.0"
         }
       },
       {

--- a/CharcoalDemo/CharcoalDemo/Models/DemoVertical.swift
+++ b/CharcoalDemo/CharcoalDemo/Models/DemoVertical.swift
@@ -10,6 +10,7 @@ class DemoVertical: Vertical {
     let title: String
     var isCurrent: Bool
     let isExternal: Bool
+    let calloutText: String? = nil
 
     init(title: String, isCurrent: Bool = false, isExternal: Bool = false) {
         self.title = title

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/finn-no/FinniversKit.git",
         "state": {
           "branch": null,
-          "revision": "6c1cece9a0d9b9150414eef3b5ebdbe0709be1a9",
-          "version": "85.1.1"
+          "revision": "fde0a61ad119361e86fc5514dd32b1af9f8510da",
+          "version": "90.3.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(name: "FinniversKit", url: "https://github.com/finn-no/FinniversKit.git", from: "85.1.1")
+        .package(name: "FinniversKit", url: "https://github.com/finn-no/FinniversKit.git", from: "90.3.0")
     ],
     targets: [
         .target(

--- a/Sources/Charcoal/CharcoalViewController.swift
+++ b/Sources/Charcoal/CharcoalViewController.swift
@@ -88,9 +88,9 @@ public final class CharcoalViewController: UINavigationController {
 
         let userDefaults = UserDefaults.standard
 
-        if let nettbilCalloutText = filterContainer?.nettbilCalloutText, !userDefaults.nettbilCalloutShown {
-            showCalloutOverlay(withText: nettbilCalloutText, andDirection: .up, constrainedToTopAnchor: navigationBar.bottomAnchor)
-            userDefaults.nettbilCalloutShown = true
+        if let naeringsTorgetCalloutText = filterContainer?.naeringsTorgetCalloutText, !userDefaults.naeringsTorgetCalloutShown {
+            showCalloutOverlay(withText: naeringsTorgetCalloutText, andDirection: .up, constrainedToTopAnchor: navigationBar.bottomAnchor)
+            userDefaults.naeringsTorgetCalloutShown = true
         }
     }
 
@@ -434,7 +434,7 @@ private extension UserDefaults {
         set { set(newValue, forKey: #function) }
     }
 
-    var nettbilCalloutShown: Bool {
+    var naeringsTorgetCalloutShown: Bool {
         get { return bool(forKey: "Charcoal." + #function) }
         set { set(newValue, forKey: "Charcoal." + #function) }
     }

--- a/Sources/Charcoal/Models/FilterContainer.swift
+++ b/Sources/Charcoal/Models/FilterContainer.swift
@@ -8,7 +8,7 @@ public class FilterContainer {
     // MARK: - Public properties
 
     public var verticals: [Vertical]?
-    public var nettbilCalloutText: String?
+    public var naeringsTorgetCalloutText: String?
 
     // MARK: - Internal properties
 

--- a/Sources/Charcoal/Models/Vertical.swift
+++ b/Sources/Charcoal/Models/Vertical.swift
@@ -6,4 +6,5 @@ public protocol Vertical {
     var title: String { get }
     var isCurrent: Bool { get }
     var isExternal: Bool { get }
+    var calloutText: String? { get }
 }

--- a/Sources/Charcoal/Vertical/VerticalCell.swift
+++ b/Sources/Charcoal/Vertical/VerticalCell.swift
@@ -19,6 +19,12 @@ final class VerticalCell: UITableViewCell {
         return imageView
     }()
 
+    private lazy var calloutView: DetailCalloutView = {
+        let calloutView = DetailCalloutView(direction: .left, numberOfLines: 1)
+        calloutView.translatesAutoresizingMaskIntoConstraints = false
+        return calloutView
+    }()
+
     // MARK: - Init
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
@@ -49,6 +55,11 @@ final class VerticalCell: UITableViewCell {
         radioButton.isHighlighted = isRadioButtonHighlighted
     }
 
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        calloutView.removeFromSuperview()
+    }
+
     // MARK: - Setup
 
     func configure(for vertical: Vertical) {
@@ -62,6 +73,18 @@ final class VerticalCell: UITableViewCell {
         let accessibilitySuffix = vertical.isExternal ? ", " + "browserText".localized() + " " : ""
 
         accessibilityLabel = accessibilityPrefix + vertical.title + accessibilitySuffix
+
+        if let calloutText = vertical.calloutText, let textLabel = textLabel {
+            addSubview(calloutView)
+            NSLayoutConstraint.activate([
+                calloutView.leadingAnchor.constraint(equalTo: textLabel.trailingAnchor, constant: .spacingM),
+                calloutView.centerYAnchor.constraint(equalTo: centerYAnchor),
+                calloutView.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor),
+            ])
+            calloutView.configure(withText: calloutText)
+        } else {
+            calloutView.removeFromSuperview()
+        }
     }
 
     private func setup() {


### PR DESCRIPTION
# Why?

We should promote a new market: Næringstorget! 🚜 

# What?

We used to have a nettbil callout showing _once_ for all users when opening the filters for the car market. Now we're using this space for a næringstorget callout instead. 

Also adding support to display a specific callout for each market vertical. At the moment, it will be used to show a "Nyhet" tag for næringstorget, but it can be used for whatever we want in the future.

Bumping FinniversKit to 90.3.0 where `DetailCalloutView` was introduced.

# Show me

| Global callout | Vertical callout |
| --- | --- |
| ![Simulator Screen Shot - iPhone 13 Pro - 2022-02-11 at 13 10 20](https://user-images.githubusercontent.com/17450858/154225294-01388338-65db-42ca-a77c-52f445e1da9d.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2022-02-16 at 09 39 59](https://user-images.githubusercontent.com/17450858/154227014-a9ff868d-02ae-466f-a0bd-345bf2278dd1.png) |


