### PR TITLE
Fix: Memory leak for filters

### DIFF
--- a/Sources/Charcoal/Models/Filter.swift
+++ b/Sources/Charcoal/Models/Filter.swift
@@ -29,7 +29,7 @@ public final class Filter {
     public var numberOfResults: Int
     public var mutuallyExclusiveFilterKeys = Set<String>()
 
-    public var parent: Filter?
+    public weak var parent: Filter?
     public fileprivate(set) var subfilters: [Filter] = []
 
     // MARK: - Init


### PR DESCRIPTION
# Why?

I found a memory leak.

# What?

Each filter keeps a array of sub filters. The sub filters also keep a reference to their parent filter, which should be weak to avoid memory leak.