### PR TITLE
Remove callout to næringstorget

### DIFF
--- a/Sources/Charcoal/CharcoalViewController.swift
+++ b/Sources/Charcoal/CharcoalViewController.swift
@@ -83,17 +83,6 @@ public final class CharcoalViewController: UINavigationController {
         delegate = self
     }
 
-    public override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-
-        let userDefaults = UserDefaults.standard
-
-        if let naeringsTorgetCalloutText = filterContainer?.naeringsTorgetCalloutText, !userDefaults.naeringsTorgetCalloutShown {
-            showCalloutOverlay(withText: naeringsTorgetCalloutText, andDirection: .up, constrainedToTopAnchor: navigationBar.bottomAnchor)
-            userDefaults.naeringsTorgetCalloutShown = true
-        }
-    }
-
     public override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         calloutOverlay?.removeFromSuperview()
@@ -432,10 +421,5 @@ private extension UserDefaults {
     var bottomButtomCalloutShown: Bool {
         get { return bool(forKey: #function) }
         set { set(newValue, forKey: #function) }
-    }
-
-    var naeringsTorgetCalloutShown: Bool {
-        get { return bool(forKey: "Charcoal." + #function) }
-        set { set(newValue, forKey: "Charcoal." + #function) }
     }
 }

--- a/Sources/Charcoal/Models/FilterContainer.swift
+++ b/Sources/Charcoal/Models/FilterContainer.swift
@@ -8,7 +8,6 @@ public class FilterContainer {
     // MARK: - Public properties
 
     public var verticals: [Vertical]?
-    public var naeringsTorgetCalloutText: String?
 
     // MARK: - Internal properties
 


### PR DESCRIPTION
# Why?

We used to promote næringstorget with a callout, but the project has been shut down.

# What?

- Delete the callout

# Show me

Imagine there's no callout when opening the motor market filters.