### PR TITLE
Avoid animating inline filters if there are none - to avoid crash

### DIFF
--- a/Sources/Charcoal/Filters/Inline/InlineFilterView.swift
+++ b/Sources/Charcoal/Filters/Inline/InlineFilterView.swift
@@ -68,6 +68,8 @@ final class InlineFilterView: UIView {
     }
 
     func slideInWithFade() {
+        guard !segments.isEmpty else { return }
+
         collectionView.setContentOffset(CGPoint(x: -120, y: 0), animated: false)
         collectionView.alpha = 0
 


### PR DESCRIPTION
# Why?

At the moment, `InlineFilterView` will always animate in the first cell on `viewDidLoad`, without checking if there's actually any inline filters.
This has not caused any problems yet, since all searches currently have inline filters. But still adding this, to avoid any future problems - if we decide not to have inline filters for one kind of search - it will crash atm. 

I noticed it when implementing private user ads search in search quest, where the filter array is empty from backend. If we fail to disable the filter button in this case, it would crash when clicking it instead of displaying empty bottom sheet.

# What?

Check inline filter count before animating it in. 

# Show me

If we configure charcoal with zero filters, it will look like this, instead of crashing. 

![Simulator Screen Shot - iPhone 13 Pro - 2022-05-31 at 16 18 22](https://user-images.githubusercontent.com/17450858/171195777-d0ea1d05-1d9c-4466-8d7a-ea641f048e94.png)

