### PR TITLE
Bump FinniversKit to version 93.7.0

### DIFF
--- a/CharcoalDemo/CharcoalDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CharcoalDemo/CharcoalDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/finn-no/FinniversKit.git",
         "state": {
           "branch": null,
-          "revision": "fde0a61ad119361e86fc5514dd32b1af9f8510da",
-          "version": "90.3.0"
+          "revision": "30b696203b5b3c349f27dbbf38e3f3bc262a7d94",
+          "version": "93.7.0"
         }
       },
       {

--- a/CharcoalDemo/CharcoalDemo/AppDelegate.swift
+++ b/CharcoalDemo/CharcoalDemo/AppDelegate.swift
@@ -4,32 +4,21 @@ import FinniversKit
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        if #available(iOS 13.0, *) {
-            FinniversKit.Config.userInterfaceStyleSupport = .dynamic
+        let navigationBarAppearance = UINavigationBar.appearance()
+        navigationBarAppearance.isTranslucent = false
+        navigationBarAppearance.tintColor = .textAction
 
-            let navigationBarAppearance = UINavigationBar.appearance()
-            navigationBarAppearance.isTranslucent = false
-            navigationBarAppearance.tintColor = .textAction
+        let appearance = UINavigationBarAppearance()
+        appearance.backgroundColor = Theme.mainBackground
 
-            let appearance = UINavigationBarAppearance()
-            appearance.backgroundColor = Theme.mainBackground
+        appearance.titleTextAttributes = [
+            .foregroundColor: UIColor.textPrimary,
+            .font: UIFont.bodyStrong
+        ]
 
-            appearance.titleTextAttributes = [
-                .foregroundColor: UIColor.textPrimary,
-                .font: UIFont.bodyStrong,
-            ]
-
-            navigationBarAppearance.standardAppearance = appearance
-            navigationBarAppearance.scrollEdgeAppearance = appearance
-            navigationBarAppearance.compactAppearance = appearance
-        } else {
-            UINavigationBar.appearance().barTintColor = Theme.mainBackground
-            UINavigationBar.appearance().tintColor = .btnPrimary
-            UINavigationBar.appearance().isTranslucent = false
-            UINavigationBar.appearance().titleTextAttributes = [.font: UIFont.bodyStrong, .foregroundColor: UIColor.textPrimary]
-            UIBarButtonItem.appearance().setTitleTextAttributes([.font: UIFont.body, .foregroundColor: UIColor.textPrimary], for: .normal)
-        }
-
+        navigationBarAppearance.standardAppearance = appearance
+        navigationBarAppearance.scrollEdgeAppearance = appearance
+        navigationBarAppearance.compactAppearance = appearance
         return true
     }
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/finn-no/FinniversKit.git",
         "state": {
           "branch": null,
-          "revision": "fde0a61ad119361e86fc5514dd32b1af9f8510da",
-          "version": "90.3.0"
+          "revision": "30b696203b5b3c349f27dbbf38e3f3bc262a7d94",
+          "version": "93.7.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(name: "FinniversKit", url: "https://github.com/finn-no/FinniversKit.git", from: "90.3.0")
+        .package(name: "FinniversKit", url: "https://github.com/finn-no/FinniversKit.git", from: "93.7.0")
     ],
     targets: [
         .target(


### PR DESCRIPTION
# Why?

Bumping FinniversKit to latest version, so it's possible to bump it in packages that depend on Charcoal. 

# What?

Bum FinniversKit to version 93.7.0

A breaking change in FinniversKit is that iOS 13 is the minimum target, so we can remove `userInterfaceStyleSupport` config. Also removed a iOS 13 check for this package.

# Show me

No UI.