### PR TITLE
Fix truncated units on iOS 16

### DIFF
--- a/Sources/Charcoal/Filters/Range/Input/NumberInputView.swift
+++ b/Sources/Charcoal/Filters/Range/Input/NumberInputView.swift
@@ -193,7 +193,6 @@ final class NumberInputView: UIView {
         let style = NSMutableParagraphStyle()
         style.alignment = .justified
         style.headIndent = .spacingS
-        style.tailIndent = -.spacingS
         style.lineBreakMode = .byCharWrapping
 
         let attributes = [


### PR DESCRIPTION
# Why?
The units text was truncated on iOS 16

# What?
Apparently the `tailIndent` of `NSMutableParagraphStyle` works differently on iOS 16, but there is no change on previous iOS versions when it is removed so that is good 😄 

Also started updated the project quite a bit, but then realized it made this fix a bit hard to find, so there will be another PR that fixes all that.

# Show me
| iOS 16 Before | iOS 16 After |
| --- | --- |
| ![Simulator Screen Shot - iPhone 8 - 2022-10-26 at 15 13 06](https://user-images.githubusercontent.com/3169203/198035229-aed45907-24bf-4b8f-b1eb-8693034290b6.png) | ![Simulator Screen Shot - iPhone 8 - 2022-10-26 at 15 14 35](https://user-images.githubusercontent.com/3169203/198035359-af0ad403-207c-48cb-b60d-7ac19d4f708a.png) |

| iOS 15.4 Before | iOS 15.4 After |
| --- | --- |
| ![Simulator Screen Shot - iPhone 8 - 2022-10-26 at 15 12 38](https://user-images.githubusercontent.com/3169203/198035428-7bfa688c-4342-4216-91b2-62a2cac8849f.png) | ![Simulator Screen Shot - iPhone 8 - 2022-10-26 at 15 15 48](https://user-images.githubusercontent.com/3169203/198035652-01dc0c43-11ab-4389-9625-ad4d15df6210.png) |
