### PR TITLE
Bump FinniversKit to 96.0.2

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/finn-no/FinniversKit.git",
         "state": {
           "branch": null,
-          "revision": "5d8c7148e3298fdb2ecb087c003d66088e3a024c",
-          "version": "93.10.0"
+          "revision": "9dd17a57ed36f8842abb8c5d49c2e9b08e8c0b3f",
+          "version": "96.0.2"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(name: "FinniversKit", url: "https://github.com/finn-no/FinniversKit.git", from: "93.10.0")
+        .package(name: "FinniversKit", url: "https://github.com/finn-no/FinniversKit.git", from: "96.0.2")
     ],
     targets: [
         .target(


### PR DESCRIPTION
# Why?

I want to bump it in SearchQuest - then it has to be bumped here as well.

# What?

Bump FinniversKit to 96.0.2.

# Show me

No charcoal related changes.