### PR TITLE
Include ruby in Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -275,6 +275,7 @@ GEM
     zeitwerk (2.6.1)
 
 PLATFORMS
+  ruby
   universal-darwin-21
   x86_64-darwin-19
 


### PR DESCRIPTION
# Why?

Ruby is added to my Gemfile.lock when running the project. Include it in master, so I can run fastlane scripts (it complains the git repository is dirty since it is auto generated).

# What?

Include it.

Referring to this comment from Robin last time we had to do this, 
`I don’t see an issue with committing these changes to Gemfile.lock. The section states what platforms our ruby gems are compatible with, but also where the ruby binary/directive exists (hence the reference to ruby  — exists in local/bin  or local/sbin depends on your PATH  configuration) => https://bundler.io/man/bundle-platform.1.html
`
# Show me

No UI.