### PR TITLE
Assume future versions of base libraries will not do unexpected breaking changes

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(name: "FinniversKit", url: "https://github.com/finn-no/FinniversKit.git", from: "109.2.1")
+        .package(name: "FinniversKit", url: "https://github.com/finn-no/FinniversKit.git", "109.2.1"..."999.0.0")
     ],
     targets: [
         .target(


### PR DESCRIPTION
# Why?
To avoid having to update all repos that use the base building blocks whenever there is a new major version (which is most likely not affecting all repos).

# What?
Support future major versions of `FinniversKit` without changing Package file.
