### PR TITLE
Nmp styling adjustments

### DIFF
--- a/Sources/Charcoal/Filters/Root/Views/VerticalSelectorView.swift
+++ b/Sources/Charcoal/Filters/Root/Views/VerticalSelectorView.swift
@@ -19,7 +19,7 @@ final class VerticalSelectorView: UIView {
     var arrowDirection: ArrowDirection = .down {
         didSet {
             let asset: CharcoalImageAsset = arrowDirection == .up ? .arrowUp : .arrowDown
-            button.setImage(UIImage(named: asset), for: .normal)
+            button.setImage(UIImage(named: asset).withRenderingMode(.alwaysTemplate), for: .normal)
         }
     }
 

--- a/Sources/Charcoal/Filters/Root/Views/VerticalSelectorView.swift
+++ b/Sources/Charcoal/Filters/Root/Views/VerticalSelectorView.swift
@@ -43,6 +43,7 @@ final class VerticalSelectorView: UIView {
         button.titleLabel?.font = UIFont.bodyStrong(withSize: 17, textStyle: .footnote)
         button.titleLabel?.adjustsFontForContentSizeCategory = true
 
+        button.tintColor = .btnPrimary
         button.setTitleColor(.btnPrimary, for: .normal)
         button.setTitleColor(.callToActionButtonHighlightedBodyColor, for: .highlighted)
         button.setTitleColor(.callToActionButtonHighlightedBodyColor, for: .selected)

--- a/Sources/Charcoal/Filters/Root/Views/VerticalSelectorView.swift
+++ b/Sources/Charcoal/Filters/Root/Views/VerticalSelectorView.swift
@@ -33,7 +33,7 @@ final class VerticalSelectorView: UIView {
         let label = UILabel(withAutoLayout: true)
         label.font = UIFont.captionStrong.withSize(12).scaledFont(forTextStyle: .footnote)
         label.adjustsFontForContentSizeCategory = true
-        label.textColor = .spaceGray
+        label.textColor = .textSecondary
         label.textAlignment = .center
         return label
     }()


### PR DESCRIPTION
The `VerticalSelectorView` only applied the ColorProvider protocol style for the button text label and not for the button imageview. This PR simply applies the same style to the image as the text label as seen below on the images

Before:
![Simulator Screenshot - iPhone 14 - 2023-08-30 at 16 37 32](https://github.com/finn-no/charcoal-ios/assets/134999755/06aba31a-7eab-426c-bfa3-f8ed02ca61a4)

After:
![Simulator Screenshot - iPhone 14 - 2023-09-01 at 12 08 10](https://github.com/finn-no/charcoal-ios/assets/134999755/62cb4d9f-4ec2-4921-8d3f-15a9457f275b)
