### PR TITLE
Nmp styling adjustments list filter cell

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/finn-no/FinniversKit.git",
         "state": {
           "branch": null,
-          "revision": "17915c1ee315cf8c0128abbf86f36a5d6c6777fa",
-          "version": "109.2.1"
+          "revision": "9063e5751c254634137ade013560ce7804625889",
+          "version": "117.0.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(name: "FinniversKit", url: "https://github.com/finn-no/FinniversKit.git", "109.2.1"..."999.0.0")
+        .package(name: "FinniversKit", url: "https://github.com/finn-no/FinniversKit.git", "117.0.0"..."999.0.0")
     ],
     targets: [
         .target(

--- a/Sources/Charcoal/Filters/List/Views/ListFilterCell.swift
+++ b/Sources/Charcoal/Filters/List/Views/ListFilterCell.swift
@@ -73,6 +73,7 @@ final class ListFilterCell: CheckboxTableViewCell {
 
         backgroundColor = Theme.mainBackground
         selectionStyle = .none
+        checkboxImageView.tintColor = .nmpBrandColorPrimary
 
         switch viewModel.accessoryStyle {
         case .external:
@@ -89,7 +90,7 @@ final class ListFilterCell: CheckboxTableViewCell {
 
         switch viewModel.checkboxStyle {
         case .selectedBordered:
-            checkboxImageView.setImage(UIImage(named: .checkboxBordered), for: .normal)
+            checkboxImageView.setImage(UIImage(named: .checkboxBordered).withRenderingMode(.alwaysTemplate), for: .normal)
             checkboxImageView.setImage(UIImage(named: .checkboxBorderedDisabled), for: .disabled)
         case .selectedFilled:
             checkboxImageView.setImage(nil, for: .normal)

--- a/Sources/Charcoal/Filters/List/Views/ListFilterCell.swift
+++ b/Sources/Charcoal/Filters/List/Views/ListFilterCell.swift
@@ -73,7 +73,6 @@ final class ListFilterCell: CheckboxTableViewCell {
 
         backgroundColor = Theme.mainBackground
         selectionStyle = .none
-        checkboxImageView.tintColor = .nmpBrandColorPrimary
 
         switch viewModel.accessoryStyle {
         case .external:
@@ -90,6 +89,7 @@ final class ListFilterCell: CheckboxTableViewCell {
 
         switch viewModel.checkboxStyle {
         case .selectedBordered:
+            checkboxImageView.tintColor = .nmpBrandControlSelected
             checkboxImageView.setImage(UIImage(named: .checkboxBordered).withRenderingMode(.alwaysTemplate), for: .normal)
             checkboxImageView.setImage(UIImage(named: .checkboxBorderedDisabled), for: .disabled)
         case .selectedFilled:


### PR DESCRIPTION
# Why?

Enabling NMP branding for components

# What?

Some parts of the filter components are branded using images (to support animations), but some are branded with tintColor. This PR adds a brand tintcolor to the checkboxbordered image as seen in the screenshots below (previously it would always be blue600)

This is a minor release.

# Show me

FINN: Before/After

<img width="397" alt="Screenshot 2023-09-18 at 11 44 11" src="https://github.com/finn-no/charcoal-ios/assets/134999755/e7750334-5e4a-4e4e-ab8b-22c70a371bac"> <img width="404" alt="Screenshot 2023-09-18 at 11 44 06" src="https://github.com/finn-no/charcoal-ios/assets/134999755/b0b2e500-b469-496c-ab23-7b21ab46b262">

Tori with new branding:
<img width="397" alt="Screenshot 2023-09-18 at 11 50 37" src="https://github.com/finn-no/charcoal-ios/assets/134999755/3206553f-78e0-45f6-9ea7-4cf72fbc673c"> <img width="393" alt="Screenshot 2023-09-18 at 11 50 28" src="https://github.com/finn-no/charcoal-ios/assets/134999755/cf4db662-965d-4423-a85b-d738bf3f82a5">
