### PR TITLE
Activate minusButton in stepper

### DIFF
--- a/Sources/Charcoal/Filters/Stepper/StepperFilterView.swift
+++ b/Sources/Charcoal/Filters/Stepper/StepperFilterView.swift
@@ -123,7 +123,9 @@ private extension StepperFilterView {
     func updateButtons(forValue value: Int?) {
         switch value {
         case nil: deactivateButton(minusButton)
-        case maximumValue: deactivateButton(plusButton)
+        case maximumValue:
+            deactivateButton(plusButton)
+            activateButton(minusButton)
         default:
             activateButton(minusButton)
             activateButton(plusButton)


### PR DESCRIPTION
# Why?
There is an issue with “Antal soverom” filter in realestate. If you go up to max level and the open the same filter again both - and + buttons are disabled.

# What?
Specify that the minusButton should be active when stepper is at max.

# Show me
| | Before | After |
| --- | --- | --- |
| **iPhone** | _![Simulator Screen Recording - iphone 13 pro - 2024-03-20 at 13 13 45](https://github.com/finn-no/charcoal-ios/assets/1043747/8735874d-bbcf-4070-b508-a28b73a52e43)_ | _![Simulator Screen Recording - iphone 13 pro - 2024-03-20 at 13 04 02](https://github.com/finn-no/charcoal-ios/assets/1043747/3f90eab7-e5c5-499f-88cc-bbb99dcb1454)_ |