### PR TITLE
BTPB-2280: Add a new kind to Filter model called freeTextOnly 

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/finn-no/FinniversKit.git",
       "state" : {
-        "revision" : "ae037d661da2da43a81c3996649c8fbe7d079566",
-        "version" : "119.0.0"
+        "revision" : "cf78ea25f68a5a4f4da5617e53559874d03f27ff",
+        "version" : "137.0.1"
+      }
+    },
+    {
+      "identity" : "warp-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/warp-ds/warp-ios.git",
+      "state" : {
+        "revision" : "eff9401d45e51115e3902cee9a01466fcc9fb28c",
+        "version" : "0.0.7"
       }
     }
   ],

--- a/Sources/Charcoal/CharcoalViewController.swift
+++ b/Sources/Charcoal/CharcoalViewController.swift
@@ -114,8 +114,9 @@ public final class CharcoalViewController: UINavigationController {
         guard let rootFilterViewController = rootFilterViewController else { return }
         popToRootViewController(animated: false)
 
-        if filter.kind == .freeText {
+        if filter.kind == .freeText || filter.kind == .freeTextOnly {
             rootFilterViewController.focusOnFreeTextFilterOnNextAppearance = true
+            rootFilterViewController.isFreeTextOnlySelected = filter.kind == .freeTextOnly
             return
         }
 
@@ -260,7 +261,7 @@ extension CharcoalViewController: FilterViewControllerDelegate {
 
     public func filterViewController(_ viewController: FilterViewController, didSelectFilter filter: Filter) {
         switch filter.kind {
-        case .standard, .freeText:
+        case .standard, .freeText, .freeTextOnly:
             guard !filter.subfilters.isEmpty else { break }
 
             let listViewController = ListFilterViewController(filter: filter, selectionStore: selectionStore)

--- a/Sources/Charcoal/Filters/FreeText/FreeTextFilterViewController.swift
+++ b/Sources/Charcoal/Filters/FreeText/FreeTextFilterViewController.swift
@@ -31,6 +31,10 @@ public class FreeTextFilterViewController: ScrollViewController {
 
     weak var delegate: FreeTextFilterViewControllerDelegate?
 
+    // MARK: - Internal Properties
+    
+    var isFreeTextOnlySelected = false
+
     // MARK: - Private Properties
 
     private var didClearText = false
@@ -61,10 +65,11 @@ public class FreeTextFilterViewController: ScrollViewController {
 
     // MARK: - Init
 
-    init(filter: Filter, selectionStore: FilterSelectionStore, notificationCenter: NotificationCenter = .default) {
+    init(filter: Filter, selectionStore: FilterSelectionStore, notificationCenter: NotificationCenter = .default, isFreeTextOnlySelected: Bool = false) {
         self.filter = filter
         self.selectionStore = selectionStore
         self.notificationCenter = notificationCenter
+        self.isFreeTextOnlySelected = isFreeTextOnlySelected
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -223,11 +228,21 @@ extension FreeTextFilterViewController: UISearchBarDelegate {
 
 private extension FreeTextFilterViewController {
     func returnToSuperView() {
+        guard !isFreeTextOnlySelected else {
+            dismissView()
+            return
+        }
+        
         if view.superview != nil {
             searchBar.endEditing(false)
             searchBar.setShowsCancelButton(false, animated: false)
             delegate?.freeTextFilterViewControllerWillEndEditing(self)
         }
+    }
+
+    func dismissView() {
+        dismiss(animated: true)
+        isFreeTextOnlySelected = false
     }
 
     func setup() {

--- a/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
+++ b/Sources/Charcoal/Filters/Root/RootFilterViewController.swift
@@ -28,6 +28,7 @@ final class RootFilterViewController: FilterViewController {
         didSet { freeTextFilterViewController?.filterDataSource = freeTextFilterDataSource }
     }
 
+    var isFreeTextOnlySelected: Bool = false
     var focusOnFreeTextFilterOnNextAppearance: Bool = false
 
     // MARK: - Private properties
@@ -113,6 +114,11 @@ final class RootFilterViewController: FilterViewController {
         if focusOnFreeTextFilterOnNextAppearance {
             freeTextFilterViewController?.searchBar.becomeFirstResponder()
             focusOnFreeTextFilterOnNextAppearance = false
+        }
+        
+        if isFreeTextOnlySelected {
+            freeTextFilterViewController?.isFreeTextOnlySelected = true
+            isFreeTextOnlySelected = false
         }
     }
 
@@ -469,7 +475,7 @@ private extension RootFilterViewController {
         guard let freeTextFilter = filterContainer.freeTextFilter else { return }
 
         if freeTextFilterViewController == nil {
-            let freeTextFilterViewController = FreeTextFilterViewController(filter: freeTextFilter, selectionStore: selectionStore)
+            let freeTextFilterViewController = FreeTextFilterViewController(filter: freeTextFilter, selectionStore: selectionStore, isFreeTextOnlySelected: isFreeTextOnlySelected)
             self.freeTextFilterViewController = freeTextFilterViewController
             freeTextFilterViewController.delegate = self
             freeTextFilterViewController.filterDelegate = freeTextFilterDelegate

--- a/Sources/Charcoal/Models/Filter.swift
+++ b/Sources/Charcoal/Models/Filter.swift
@@ -12,6 +12,7 @@ public final class Filter {
 
     public enum Kind: Equatable {
         case freeText
+        case freeTextOnly
         case standard
         case grid
         case stepper(config: StepperFilterConfiguration)
@@ -72,7 +73,12 @@ extension Filter {
         let title = title ?? "searchPlaceholder".localized()
         return Filter(kind: .freeText, title: title, key: key, value: nil, numberOfResults: 0)
     }
-
+    
+    public static func freeTextOnly(title: String? = nil, key: String) -> Filter {
+        let title = title ?? "searchPlaceholder".localized()
+        return Filter(kind: .freeTextOnly, title: title, key: key, value: nil, numberOfResults: 0)
+    }
+    
     public static func inline(title: String, key: String, subfilters: [Filter]) -> Filter {
         return Filter(title: title, key: key, value: nil, numberOfResults: 0, subfilters: subfilters)
     }


### PR DESCRIPTION
# Why?

We needed to add a new filter kind to handle a new state for the search bar in the search results view in FINN and Tori.

# What?

- Added new `freeTextOnly` option to `Filter.Kind` model
- Handle FreeTextFilterViewController presentation based on filter model kind