### PR TITLE
Remove color provider

### DIFF
--- a/CharcoalDemo/CharcoalDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CharcoalDemo/CharcoalDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/finn-no/FinniversKit.git",
       "state" : {
-        "revision" : "f717edf981afd685282d6d2d92e5d95430b603e8",
-        "version" : "143.1.0"
+        "branch" : "remove-color-provider",
+        "revision" : "deb1daa080d6f5c8563f3972c843b0cbf7513474"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/warp-ds/warp-ios.git",
       "state" : {
-        "revision" : "528dc6eacf33b5bb18d094b6154df3071d261620",
-        "version" : "0.0.16"
+        "branch" : "remove-warp-config",
+        "revision" : "b58550b4ed9dcddc04c01f220edfbb58198afba7"
       }
     }
   ],

--- a/CharcoalDemo/CharcoalDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CharcoalDemo/CharcoalDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,7 +6,7 @@
       "location" : "https://github.com/finn-no/FinniversKit.git",
       "state" : {
         "branch" : "remove-color-provider",
-        "revision" : "deb1daa080d6f5c8563f3972c843b0cbf7513474"
+        "revision" : "8713ec0d435fe462874b7f28487595f7a49df1fc"
       }
     },
     {
@@ -24,7 +24,7 @@
       "location" : "https://github.com/warp-ds/warp-ios.git",
       "state" : {
         "branch" : "remove-warp-config",
-        "revision" : "b58550b4ed9dcddc04c01f220edfbb58198afba7"
+        "revision" : "4207c0ffe171e143e448f24e2a138c734dbaa888"
       }
     }
   ],

--- a/CharcoalDemo/CharcoalDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CharcoalDemo/CharcoalDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/finn-no/FinniversKit.git",
       "state" : {
-        "branch" : "remove-color-provider",
-        "revision" : "8713ec0d435fe462874b7f28487595f7a49df1fc"
+        "revision" : "b19561bb68282b5bc7f6a6535d2bc61637b75b66",
+        "version" : "144.0.1"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/warp-ds/warp-ios.git",
       "state" : {
-        "branch" : "remove-warp-config",
-        "revision" : "4207c0ffe171e143e448f24e2a138c734dbaa888"
+        "revision" : "aeb72c43f2918a290d00d9fe93035723accb876b",
+        "version" : "0.0.25"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/finn-no/FinniversKit.git",
       "state" : {
-        "revision" : "cf78ea25f68a5a4f4da5617e53559874d03f27ff",
-        "version" : "137.0.1"
+        "revision" : "b19561bb68282b5bc7f6a6535d2bc61637b75b66",
+        "version" : "144.0.1"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/warp-ds/warp-ios.git",
       "state" : {
-        "revision" : "eff9401d45e51115e3902cee9a01466fcc9fb28c",
-        "version" : "0.0.7"
+        "revision" : "aeb72c43f2918a290d00d9fe93035723accb876b",
+        "version" : "0.0.25"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/finn-no/FinniversKit.git", "143.1.0"..."999.0.0")
+        .package(url: "https://github.com/finn-no/FinniversKit.git", branch: "remove-color-provider")
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/finn-no/FinniversKit.git", branch: "remove-color-provider")
+        .package(url: "https://github.com/finn-no/FinniversKit.git", "144.0.1"..."999.0.0")
     ],
     targets: [
         .target(

--- a/Sources/Charcoal/Filters/FreeText/FreeTextFilterViewController.swift
+++ b/Sources/Charcoal/Filters/FreeText/FreeTextFilterViewController.swift
@@ -139,7 +139,7 @@ extension FreeTextFilterViewController: UITableViewDataSource {
         let title = filterDataSource?.freeTextFilterViewController(self, suggestionAt: indexPath)
         cell.titleLabel.font = .bodyRegular
         cell.titleLabel.adjustsFontForContentSizeCategory = true
-        cell.configure(with: FreeTextSuggestionCellViewModel(title: title ?? ""))
+        cell.configure(with: FreeTextSuggestionCellViewModel(title: title ?? "", iconTintColor: .iconSubtle))
         cell.separatorInset = .leadingInset(48)
         return cell
     }

--- a/Sources/Charcoal/Filters/FreeText/ViewModels/FreeTextSuggestionCellViewModel.swift
+++ b/Sources/Charcoal/Filters/FreeText/ViewModels/FreeTextSuggestionCellViewModel.swift
@@ -7,7 +7,7 @@ import FinniversKit
 struct FreeTextSuggestionCellViewModel: IconTitleTableViewCellViewModel {
     var title: String
     let icon: UIImage? = UIImage(named: .searchSmall)
-    let iconTintColor: UIColor? = nil
+    var iconTintColor: UIColor? = nil
     let hasChevron = false
     let externalIcon: UIImage? = nil
     let subtitle: String? = nil

--- a/Sources/Charcoal/Filters/Map/Polygon/Views/InitialAreaSelectionOverlayView.swift
+++ b/Sources/Charcoal/Filters/Map/Polygon/Views/InitialAreaSelectionOverlayView.swift
@@ -3,13 +3,14 @@
 //
 
 import UIKit
+import Warp
 
 final class InitialAreaSelectionOverlayView: UIView {
     var width: CGFloat = 180
 
     private lazy var squareView: UIView = {
         let view = UIView(withAutoLayout: true)
-        let color: UIColor = .borderSecondary
+        let color: UIColor = Warp.UIToken.borderSecondary
         view.backgroundColor = color.withAlphaComponent(0.15)
         view.layer.borderColor = color.cgColor
         view.layer.borderWidth = 2

--- a/Sources/Charcoal/Filters/Map/Polygon/Views/MapPolygonFilterView.swift
+++ b/Sources/Charcoal/Filters/Map/Polygon/Views/MapPolygonFilterView.swift
@@ -25,13 +25,13 @@ final class MapPolygonFilterView: UIView {
         case polygonSelection
     }
 
-    static let overlayColor: UIColor = .borderSecondary
+    static let overlayColor: UIColor = Warp.UIToken.borderSecondary
 
     // MARK: - Private properties
 
     private static let defaultRadius = 40000
     private static let defaultCenterCoordinate = Charcoal.configuration.mapConfig.defaultMapCenterCoordinate
-    private static let annotationFillColor: CGColor = UIColor.milk.cgColor
+    private static let annotationFillColor: CGColor = CGColor.iconInvertedStatic
     private static let annotationBorderColor: CGColor = MapPolygonFilterView.overlayColor.cgColor
 
     private var polygon: MKPolygon?
@@ -122,7 +122,7 @@ final class MapPolygonFilterView: UIView {
 
         button.setImage(UIImage(named: .areaSelectionPin)
             .withRenderingMode(.alwaysTemplate), for: .normal)
-        button.imageView?.tintColor = .ice
+        button.imageView?.tintColor = .backgroundInfoSubtle
         button.adjustsImageWhenHighlighted = false
         button.imageEdgeInsets = UIEdgeInsets(leading: -Warp.Spacing.spacing100)
 

--- a/Sources/Charcoal/Filters/Map/Radius/MapView/MapRadiusOverlayView.swift
+++ b/Sources/Charcoal/Filters/Map/Radius/MapView/MapRadiusOverlayView.swift
@@ -3,6 +3,7 @@
 //
 
 import FinniversKit
+import Warp
 
 final class MapRadiusOverlayView: UIView {
     var radius: CGFloat = 5 {
@@ -27,7 +28,7 @@ final class MapRadiusOverlayView: UIView {
 
     private lazy var widthConstraint = radiusView.widthAnchor.constraint(equalToConstant: radius * 2)
 
-    static let overlayColor: UIColor = .borderSecondary
+    static let overlayColor: UIColor = Warp.UIToken.borderSecondary
 
     // MARK: - Init
 

--- a/Sources/Charcoal/Filters/Map/SearchLocationViewController.swift
+++ b/Sources/Charcoal/Filters/Map/SearchLocationViewController.swift
@@ -132,12 +132,12 @@ extension SearchLocationViewController: UITableViewDataSource {
         case .homeAddress:
             let cell = tableView.dequeue(IconTitleTableViewCell.self, for: indexPath)
             cell.configure(with: HomeAddressCellViewModel())
-            cell.iconImageView.tintColor = .watermelon
+            cell.iconImageView.tintColor = Warp.UIToken.iconNegative
             return cell
         case .currentLocation:
             let cell = tableView.dequeue(IconTitleTableViewCell.self, for: indexPath)
             cell.configure(with: CurrentLocationCellViewModel())
-            cell.iconImageView.tintColor = .watermelon
+            cell.iconImageView.tintColor = Warp.UIToken.iconNegative
             return cell
         case .recentLocations:
             let cell = tableView.dequeue(IconTitleTableViewCell.self, for: indexPath)

--- a/Sources/Charcoal/Filters/Root/Views/CalloutOverlay.swift
+++ b/Sources/Charcoal/Filters/Root/Views/CalloutOverlay.swift
@@ -36,7 +36,7 @@ final class CalloutOverlay: UIView {
 
     private lazy var bodyView: UIView = {
         let view = UIView(withAutoLayout: true)
-        view.backgroundColor = .overlayBackground
+        view.backgroundColor = .surfaceElevated300
         return view
     }()
 
@@ -119,11 +119,5 @@ final class CalloutOverlay: UIView {
 
     @objc private func handleTap() {
         delegate?.calloutOverlayDidTapInside(self)
-    }
-}
-
-private extension UIColor {
-    class var overlayBackground: UIColor {
-        dynamicColorIfAvailable(defaultColor: milk.withAlphaComponent(0.8), darkModeColor: darkIce.withAlphaComponent(0.6))
     }
 }

--- a/Sources/Charcoal/Filters/Root/Views/VerticalSelectorView.swift
+++ b/Sources/Charcoal/Filters/Root/Views/VerticalSelectorView.swift
@@ -46,9 +46,9 @@ final class VerticalSelectorView: UIView {
 
         button.tintColor = .textLink
         button.setTitleColor(.textLink, for: .normal)
-        button.setTitleColor(.callToActionButtonHighlightedBodyColor, for: .highlighted)
-        button.setTitleColor(.callToActionButtonHighlightedBodyColor, for: .selected)
-        button.setTitleColor(UIColor.textLink.withAlphaComponent(0.5), for: .disabled)
+        button.setTitleColor(.textLink.withAlphaComponent(0.8), for: .highlighted)
+        button.setTitleColor(.textLink.withAlphaComponent(0.8), for: .selected)
+        button.setTitleColor(.textLink.withAlphaComponent(0.5), for: .disabled)
 
         let spacing = Warp.Spacing.spacing50 / 2
 

--- a/Sources/Charcoal/Vertical/VerticalCell.swift
+++ b/Sources/Charcoal/Vertical/VerticalCell.swift
@@ -90,7 +90,7 @@ final class VerticalCell: UITableViewCell {
 
     private func setup() {
         let selectedBackgroundView = UIView()
-        selectedBackgroundView.backgroundColor = .defaultCellSelectedBackgroundColor
+        selectedBackgroundView.backgroundColor = .backgroundSubtle
         self.selectedBackgroundView = selectedBackgroundView
         backgroundColor = .clear
 


### PR DESCRIPTION
# Why?

We are going to start using WARP colors instead of old colors, to make it easier to move forward with other brands.

# What?

Removing Finniverskit ColorProvider so everywhere we are forced to use WARP colors.

# Changelog

# Tests

No

# UI Changes

There are lots of UI changes, mainly color changes.