### PR TITLE
CLLocationManager warnings fix

### DIFF
--- a/Sources/Charcoal/Filters/Map/LocationService.swift
+++ b/Sources/Charcoal/Filters/Map/LocationService.swift
@@ -43,7 +43,7 @@ extension CLAuthorizationStatus {
             return true
         case .notDetermined, .restricted, .denied:
             return false
-        default:
+        @unknown default:
             return false
         }
     }

--- a/Sources/Charcoal/Filters/Map/LocationService.swift
+++ b/Sources/Charcoal/Filters/Map/LocationService.swift
@@ -1,0 +1,50 @@
+import Foundation
+import CoreLocation
+
+class LocationService: NSObject {
+    private let locationManager = CLLocationManager()
+    private var authorizationContinuations = [CheckedContinuation<CLAuthorizationStatus, Never>]()
+    private var didSyncAuthStatus = false
+
+    override init() {
+        super.init()
+        locationManager.delegate = self
+    }
+
+    func authorizationStatus() async -> CLAuthorizationStatus {
+        if didSyncAuthStatus {
+            return locationManager.authorizationStatus
+        }
+        return await withCheckedContinuation { continuation in
+            authorizationContinuations.append(continuation)
+        }
+    }
+
+    func requestWhenInUseAuthorization() {
+        locationManager.requestWhenInUseAuthorization()
+    }
+}
+
+extension LocationService: CLLocationManagerDelegate {
+    func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        didSyncAuthStatus = true
+
+        for continuation in authorizationContinuations {
+            continuation.resume(returning: manager.authorizationStatus)
+        }
+        authorizationContinuations.removeAll()
+    }
+}
+
+extension CLAuthorizationStatus {
+    var isLocationAuthorized: Bool {
+        switch self {
+        case .authorizedAlways, .authorizedWhenInUse:
+            return true
+        case .notDetermined, .restricted, .denied:
+            return false
+        default:
+            return false
+        }
+    }
+}

--- a/Sources/Charcoal/Filters/Map/Radius/MapRadiusFilterViewController.swift
+++ b/Sources/Charcoal/Filters/Map/Radius/MapRadiusFilterViewController.swift
@@ -31,7 +31,6 @@ final class MapRadiusFilterViewController: UIViewController {
     private var nextRegionChangeIsFromUserInteraction = false
     private var hasChanges = false
     private var isMapLoaded = false
-    private var authorizationContinuation: CheckedContinuation<CLAuthorizationStatus, Never>?
 
     private lazy var mapRadiusFilterView: MapRadiusFilterView = {
         let mapRadiusFilterView = MapRadiusFilterView(radius: radius, centerCoordinate: coordinate)
@@ -93,23 +92,6 @@ final class MapRadiusFilterViewController: UIViewController {
             }
 
             mapRadiusFilterView.centerOnUserLocation()
-        }
-    }
-
-    private func isLocationAuthorized() async -> Bool {
-        switch await getAuthorizationStatus() {
-        case .authorizedAlways, .authorizedWhenInUse:
-            return true
-        case .notDetermined, .restricted, .denied:
-            return false
-        default:
-            return false
-        }
-    }
-
-    private func getAuthorizationStatus() async -> CLAuthorizationStatus {
-        return await withCheckedContinuation { continuation in
-            self.authorizationContinuation = continuation
         }
     }
 


### PR DESCRIPTION
# Why?

We have a runtime warning when using CLLocationManager's `locationServicesEnabled()`

![Screenshot 2024-08-20 at 08 43 17](https://github.com/user-attachments/assets/605872ab-b65a-4bf6-bf92-8f648cb3f1fa)

# What?

According to [Apple's documentation](https://developer.apple.com/documentation/corelocation/cllocationmanager/authorizationstatus-swift.property), we should use a delegate function [locationManagerDidChangeAuthorization(_:)](https://developer.apple.com/documentation/corelocation/cllocationmanagerdelegate/locationmanagerdidchangeauthorization(_:)) to check the app's initial authorization state. The system guarantees to call it after init of `CLLocationManager`.

Added a new `LocationService` to share logic between polygon and radius filter. The users of it can now get the authorization status, but the difference from before is that it's now async, since we have to wait for the delegate function to be called first.

# Show me

No UI change.