### PR TITLE
Improved location sharing alert with button to open location settings

### DIFF
--- a/Sources/Charcoal/Filters/Map/LocationService.swift
+++ b/Sources/Charcoal/Filters/Map/LocationService.swift
@@ -1,0 +1,50 @@
+import Foundation
+import CoreLocation
+
+class LocationService: NSObject {
+    private let locationManager = CLLocationManager()
+    private var authorizationContinuations = [CheckedContinuation<CLAuthorizationStatus, Never>]()
+    private var didSyncAuthStatus = false
+
+    override init() {
+        super.init()
+        locationManager.delegate = self
+    }
+
+    func authorizationStatus() async -> CLAuthorizationStatus {
+        if didSyncAuthStatus {
+            return locationManager.authorizationStatus
+        }
+        return await withCheckedContinuation { continuation in
+            authorizationContinuations.append(continuation)
+        }
+    }
+
+    func requestWhenInUseAuthorization() {
+        locationManager.requestWhenInUseAuthorization()
+    }
+}
+
+extension LocationService: CLLocationManagerDelegate {
+    func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        didSyncAuthStatus = true
+
+        for continuation in authorizationContinuations {
+            continuation.resume(returning: manager.authorizationStatus)
+        }
+        authorizationContinuations.removeAll()
+    }
+}
+
+extension CLAuthorizationStatus {
+    var isLocationAuthorized: Bool {
+        switch self {
+        case .authorizedAlways, .authorizedWhenInUse:
+            return true
+        case .notDetermined, .restricted, .denied:
+            return false
+        default:
+            return false
+        }
+    }
+}

--- a/Sources/Charcoal/Filters/Map/Polygon/MapPolygonFilterViewController.swift
+++ b/Sources/Charcoal/Filters/Map/Polygon/MapPolygonFilterViewController.swift
@@ -189,11 +189,7 @@ final class MapPolygonFilterViewController: UIViewController {
             locationService.requestWhenInUseAuthorization()
         } else {
             // Not authorized
-            let title = "map.locationError.title".localized()
-            let message = "map.locationError.message".localized()
-            let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-
-            alert.addAction(UIAlertAction(title: "cancel".localized(), style: .default, handler: nil))
+            let alert = UIAlertController.locationSharingAlert
             present(alert, animated: true, completion: nil)
         }
     }

--- a/Sources/Charcoal/Filters/Map/Radius/MapRadiusFilterViewController.swift
+++ b/Sources/Charcoal/Filters/Map/Radius/MapRadiusFilterViewController.swift
@@ -31,7 +31,6 @@ final class MapRadiusFilterViewController: UIViewController {
     private var nextRegionChangeIsFromUserInteraction = false
     private var hasChanges = false
     private var isMapLoaded = false
-    private var authorizationContinuation: CheckedContinuation<CLAuthorizationStatus, Never>?
 
     private lazy var mapRadiusFilterView: MapRadiusFilterView = {
         let mapRadiusFilterView = MapRadiusFilterView(radius: radius, centerCoordinate: coordinate)
@@ -93,23 +92,6 @@ final class MapRadiusFilterViewController: UIViewController {
             }
 
             mapRadiusFilterView.centerOnUserLocation()
-        }
-    }
-
-    private func isLocationAuthorized() async -> Bool {
-        switch await getAuthorizationStatus() {
-        case .authorizedAlways, .authorizedWhenInUse:
-            return true
-        case .notDetermined, .restricted, .denied:
-            return false
-        default:
-            return false
-        }
-    }
-
-    private func getAuthorizationStatus() async -> CLAuthorizationStatus {
-        return await withCheckedContinuation { continuation in
-            self.authorizationContinuation = continuation
         }
     }
 

--- a/Sources/Charcoal/Filters/Map/Radius/MapRadiusFilterViewController.swift
+++ b/Sources/Charcoal/Filters/Map/Radius/MapRadiusFilterViewController.swift
@@ -101,11 +101,7 @@ final class MapRadiusFilterViewController: UIViewController {
             locationService.requestWhenInUseAuthorization()
         } else {
             // Not authorized
-            let title = "map.locationError.title".localized()
-            let message = "map.locationError.message".localized()
-            let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-
-            alert.addAction(UIAlertAction(title: "cancel".localized(), style: .default, handler: nil))
+            let alert = UIAlertController.locationSharingAlert
             present(alert, animated: true, completion: nil)
         }
     }

--- a/Sources/Charcoal/Filters/Map/UIAlertController+Extensions.swift
+++ b/Sources/Charcoal/Filters/Map/UIAlertController+Extensions.swift
@@ -1,0 +1,28 @@
+import Foundation
+import UIKit
+
+extension UIAlertController {
+    static var locationSharingAlert: UIAlertController {
+        let title = "map.locationError.title".localized()
+        let message = "map.locationError.message".localized()
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+
+        alert.addAction(UIAlertAction(title: "cancel".localized(), style: .cancel, handler: nil))
+
+        let openSettingsAction = UIAlertAction(
+            title: "map.locationError.settings".localized(),
+            style: .default,
+            handler: { _ in
+                guard
+                    let settingsUrl = URL(string: UIApplication.openSettingsURLString),
+                    UIApplication.shared.canOpenURL(settingsUrl)
+                else { return }
+                UIApplication.shared.open(settingsUrl)
+            }
+        )
+        alert.addAction(openSettingsAction)
+        alert.preferredAction = openSettingsAction
+
+        return alert
+    }
+}

--- a/Sources/Charcoal/Resources/en.lproj/Localizable.strings
+++ b/Sources/Charcoal/Resources/en.lproj/Localizable.strings
@@ -63,8 +63,9 @@
 "map.homeAddress" = "My home address";
 "map.currentLocation" = "My current location";
 "map.valueSliderAccessibilityLabel" = "Slider for value";
-"map.locationError.title" = "Information";
-"map.locationError.message" = "To use this functionality, you must give us access to your location. This is done in the main settings of your device, under privacy and then location services.";
+"map.locationError.title" = "To use this feature, we need to know your location";
+"map.locationError.message" = "Your location is used to display nearby ads. Your location on the map is only active while you are using the {brand} app.";
+"map.locationError.settings" = "Settings";
 "map.search.placeholder" = "Search by place or address";
 "map.polygonSearch.filter.title" = "Custom section";
 "map.polygonSearch.initialAreaSelection.button" = "Attach the map section here";

--- a/Sources/Charcoal/Resources/fi.lproj/Localizable.strings
+++ b/Sources/Charcoal/Resources/fi.lproj/Localizable.strings
@@ -63,8 +63,9 @@
 "map.homeAddress" = "Kotiosoitteeni";
 "map.currentLocation" = "Nykyinen sijaintini";
 "map.valueSliderAccessibilityLabel" = "Arvon liukusäädin";
-"map.locationError.title" = "Tiedot";
-"map.locationError.message" = "Anna Torille pääsy sijaintitietohisi käyttääksesi tätä toimintoa. Voit muuttaa asetuksia laitteesi pääasetuksissa valitsemalla Tietosuoja ja suojaus ja sitten Sijaintipalvelut.";
+"map.locationError.title" = "Salli sijainnin käyttö käyttääksesi tätä toimintoa";
+"map.locationError.message" = "Sijaintiasi käytetään näyttämään lähistöllä sijaitsevia ilmoituksia. Paikannus on aktiivinen vain silloin, kun käytät Toria.";
+"map.locationError.settings" = "Asetukset";
 "map.search.placeholder" = "Hae paikan tai osoitteen perusteella";
 "map.polygonSearch.filter.title" = "Mukautettu osio";
 "map.polygonSearch.initialAreaSelection.button" = "Liitä karttaosio tähän";

--- a/Sources/Charcoal/Resources/nb.lproj/Localizable.strings
+++ b/Sources/Charcoal/Resources/nb.lproj/Localizable.strings
@@ -63,8 +63,9 @@
 "map.homeAddress" = "Min hjemmeadresse";
 "map.currentLocation" = "Min nåværende posisjon";
 "map.valueSliderAccessibilityLabel" = "Slider for verdi";
-"map.locationError.title" = "Informasjon";
-"map.locationError.message" = "For å bruke denne funksjonaliteten må du gi oss tilgang til din posisjon. Dette gjøres i hovedinnstillingene på enheten din, under personvern og deretter stedtjenester.";
+"map.locationError.title" = "For å bruke denne funksjonen trenger vi å vite din posisjon";
+"map.locationError.message" = "Din posisjon benyttes til å vise annonser i nærheten, samt din posisjon i kartet og er kun aktiv mens du bruker FINN-appen.";
+"map.locationError.settings" = "Innstillinger";
 "map.search.placeholder" = "Søk etter sted eller adresse";
 "map.polygonSearch.filter.title" = "Egendefinert utsnitt";
 "map.polygonSearch.initialAreaSelection.button" = "Fest kartutsnittet her";


### PR DESCRIPTION
# Why?

We currently display an alert with some vague outdated description on how to make it work.

# What?

Improved it by guiding the user, now we provide a button to open settings for the app, where the user easily can change their location sharing.

This alert is the same we use other places in the app.

# Show me

| Before | After |
| --- | --- |
| ![IMG_2566](https://github.com/user-attachments/assets/3663f1e2-b81a-48b6-b253-92d9abb0e239) | ![IMG_2569](https://github.com/user-attachments/assets/506d1a03-5912-4274-86d1-00c26f04f627) |
