### PR TITLE
Fix ipad background

### DIFF
--- a/Sources/Charcoal/CharcoalViewController.swift
+++ b/Sources/Charcoal/CharcoalViewController.swift
@@ -80,6 +80,7 @@ public final class CharcoalViewController: UINavigationController {
     public override func viewDidLoad() {
         super.viewDidLoad()
         setupNavigationBar()
+        view.backgroundColor = Theme.mainBackground
         delegate = self
     }
 


### PR DESCRIPTION
# Why?

`CharcoalFilterDrawer` looks into the its rootViewController's backgroundColor.

# What?

Change the background color on iPad

# Show me

![Simulator Screenshot - iPad (10th generation) - 2024-08-26 at 10 36 02](https://github.com/user-attachments/assets/8c67cca1-e6cd-452b-b136-6662d7062045)
![Simulator Screenshot - iPad (10th generation) - 2024-08-26 at 10 37 45](https://github.com/user-attachments/assets/27c39a71-12a6-40f5-876c-5d39f7710da5)
