### PR TITLE
configure default map filter mode

### DIFF
--- a/Sources/Charcoal/CharcoalViewController.swift
+++ b/Sources/Charcoal/CharcoalViewController.swift
@@ -32,6 +32,8 @@ public final class CharcoalViewController: UINavigationController {
         didSet { configure(with: filterContainer) }
     }
 
+    public var defaultMapMode: MapFilterMode = .radius
+
     public weak var textEditingDelegate: CharcoalViewControllerTextEditingDelegate?
     public weak var mapDelegate: CharcoalViewControllerMapDelegate?
     public weak var selectionDelegate: CharcoalViewControllerSelectionDelegate?
@@ -316,6 +318,7 @@ extension CharcoalViewController: FilterViewControllerDelegate {
                 locationNameFilter: locationNameFilter,
                 bboxFilter: bboxFilter,
                 polygonFilter: polygonFilter,
+                defaultMode: defaultMapMode,
                 selectionStore: selectionStore
             )
             mapFilterViewController.searchLocationDataSource = searchLocationDataSource

--- a/Sources/Charcoal/Filters/Map/MapFilterViewController.swift
+++ b/Sources/Charcoal/Filters/Map/MapFilterViewController.swift
@@ -32,6 +32,17 @@ public class MapFilterViewController: FilterViewController {
         }
     }
 
+    public var defaultMapMode: MapFilterMode {
+            didSet {
+                switch defaultMapMode {
+                    case .polygon:
+                        selectedViewController = mapPolygonFilterViewController ?? mapRadiusFilterViewController
+                    case .radius:
+                        selectedViewController = mapRadiusFilterViewController
+             }
+        }
+    }
+
     private lazy var toggleButton: UIBarButtonItem = {
         let buttonItem = UIBarButtonItem(
             title: nil,
@@ -53,7 +64,7 @@ public class MapFilterViewController: FilterViewController {
     private let polygonFilter: Filter?
 
     public init(title: String, latitudeFilter: Filter, longitudeFilter: Filter, radiusFilter: Filter,
-                locationNameFilter: Filter, bboxFilter: Filter?, polygonFilter: Filter?, defaultMode: MapFilterMode, selectionStore: FilterSelectionStore) {
+                locationNameFilter: Filter, bboxFilter: Filter?, polygonFilter: Filter?, defaultMode: MapFilterMode = .radius, selectionStore: FilterSelectionStore) {
         mapRadiusFilterViewController =
             MapRadiusFilterViewController(
                 latitudeFilter: latitudeFilter,
@@ -76,7 +87,8 @@ public class MapFilterViewController: FilterViewController {
             mapPolygonFilterViewController = nil
         }
 
-        switch defaultMode {
+        defaultMapMode = defaultMode
+        switch defaultMapMode {
         case .polygon:
             selectedViewController = mapPolygonFilterViewController ?? mapRadiusFilterViewController
         case .radius:

--- a/Sources/Charcoal/Filters/Map/MapFilterViewController.swift
+++ b/Sources/Charcoal/Filters/Map/MapFilterViewController.swift
@@ -13,6 +13,11 @@ protocol ToggleFilter: AnyObject {
     func updateFilterValues()
 }
 
+public enum MapFilterMode {
+    case polygon
+    case radius
+}
+
 public class MapFilterViewController: FilterViewController {
     private let mapRadiusFilterViewController: MapRadiusFilterViewController
     private let mapPolygonFilterViewController: MapPolygonFilterViewController?
@@ -48,7 +53,7 @@ public class MapFilterViewController: FilterViewController {
     private let polygonFilter: Filter?
 
     public init(title: String, latitudeFilter: Filter, longitudeFilter: Filter, radiusFilter: Filter,
-                locationNameFilter: Filter, bboxFilter: Filter?, polygonFilter: Filter?, selectionStore: FilterSelectionStore) {
+                locationNameFilter: Filter, bboxFilter: Filter?, polygonFilter: Filter?, defaultMode: MapFilterMode = .radius, selectionStore: FilterSelectionStore) {
         mapRadiusFilterViewController =
             MapRadiusFilterViewController(
                 latitudeFilter: latitudeFilter,
@@ -57,7 +62,6 @@ public class MapFilterViewController: FilterViewController {
                 locationNameFilter: locationNameFilter,
                 selectionStore: selectionStore
             )
-        selectedViewController = mapRadiusFilterViewController
 
         if let bboxFilter = bboxFilter,
             let polygonFilter = polygonFilter {
@@ -70,6 +74,13 @@ public class MapFilterViewController: FilterViewController {
                 )
         } else {
             mapPolygonFilterViewController = nil
+        }
+
+        switch defaultMode {
+        case .polygon:
+            selectedViewController = mapPolygonFilterViewController ?? mapRadiusFilterViewController
+        case .radius:
+            selectedViewController = mapRadiusFilterViewController
         }
 
         self.bboxFilter = bboxFilter
@@ -140,14 +151,6 @@ public class MapFilterViewController: FilterViewController {
         }
 
         navigationItem.rightBarButtonItem = toggleButton
-
-        if let bboxFilter = bboxFilter,
-            let polygonFilter = polygonFilter,
-            selectionStore.isSelected(polygonFilter) || selectionStore.isSelected(bboxFilter) {
-            selectedViewController = mapPolygonFilterViewController
-        } else {
-            selectedViewController = mapRadiusFilterViewController
-        }
 
         display(selectedViewController)
         updateToggleButtonLabel()

--- a/Sources/Charcoal/Filters/Map/MapFilterViewController.swift
+++ b/Sources/Charcoal/Filters/Map/MapFilterViewController.swift
@@ -33,13 +33,17 @@ public class MapFilterViewController: FilterViewController {
     }
 
     public var defaultMapMode: MapFilterMode {
-            didSet {
-                switch defaultMapMode {
-                    case .polygon:
-                        selectedViewController = mapPolygonFilterViewController ?? mapRadiusFilterViewController
-                    case .radius:
-                        selectedViewController = mapRadiusFilterViewController
-             }
+        didSet {
+            setMapViewToDefaultMode()
+        }
+    }
+
+    private func setMapViewToDefaultMode() {
+        switch defaultMapMode {
+        case .polygon:
+            selectedViewController = mapPolygonFilterViewController ?? mapRadiusFilterViewController
+        case .radius:
+            selectedViewController = mapRadiusFilterViewController
         }
     }
 
@@ -62,6 +66,7 @@ public class MapFilterViewController: FilterViewController {
 
     private let bboxFilter: Filter?
     private let polygonFilter: Filter?
+    private let radiusFilter: Filter?
 
     public init(title: String, latitudeFilter: Filter, longitudeFilter: Filter, radiusFilter: Filter,
                 locationNameFilter: Filter, bboxFilter: Filter?, polygonFilter: Filter?, defaultMode: MapFilterMode = .radius, selectionStore: FilterSelectionStore) {
@@ -97,6 +102,7 @@ public class MapFilterViewController: FilterViewController {
 
         self.bboxFilter = bboxFilter
         self.polygonFilter = polygonFilter
+        self.radiusFilter = radiusFilter
         super.init(title: title, selectionStore: selectionStore)
         self.title = title
 
@@ -156,6 +162,16 @@ public class MapFilterViewController: FilterViewController {
             mapContainerView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             mapContainerView.bottomAnchor.constraint(equalTo: bottomButton.topAnchor),
         ])
+
+        if let bboxFilter = bboxFilter,
+           let polygonFilter = polygonFilter,
+           selectionStore.isSelected(polygonFilter) || selectionStore.isSelected(bboxFilter) {
+            selectedViewController = mapPolygonFilterViewController ?? mapRadiusFilterViewController
+        } else if let radiusFilter = radiusFilter, selectionStore.isSelected(radiusFilter) {
+            selectedViewController = mapRadiusFilterViewController
+        } else {
+            setMapViewToDefaultMode()
+        }
 
         guard let mapPolygonFilterViewController = mapPolygonFilterViewController else {
             display(mapRadiusFilterViewController)

--- a/Sources/Charcoal/Filters/Map/MapFilterViewController.swift
+++ b/Sources/Charcoal/Filters/Map/MapFilterViewController.swift
@@ -53,7 +53,7 @@ public class MapFilterViewController: FilterViewController {
     private let polygonFilter: Filter?
 
     public init(title: String, latitudeFilter: Filter, longitudeFilter: Filter, radiusFilter: Filter,
-                locationNameFilter: Filter, bboxFilter: Filter?, polygonFilter: Filter?, defaultMode: MapFilterMode = .radius, selectionStore: FilterSelectionStore) {
+                locationNameFilter: Filter, bboxFilter: Filter?, polygonFilter: Filter?, defaultMode: MapFilterMode, selectionStore: FilterSelectionStore) {
         mapRadiusFilterViewController =
             MapRadiusFilterViewController(
                 latitudeFilter: latitudeFilter,


### PR DESCRIPTION
# Why?

we would like to have polygon search as the default, so adding the possibility to configure the default map filter mode.

also see https://github.schibsted.io/finn/ios-app/pull/6200 for context

**PR closed due to charcoal moved into main repo**

# What?

added an enum to the initialiser and removed a function in setup that seemed redundant. 

# Show me

| Before | After |
| --- | --- |
| radius search | polygon search |