### PR TITLE
Support nested inline filters

### DIFF
--- a/Sources/Charcoal/CharcoalViewController.swift
+++ b/Sources/Charcoal/CharcoalViewController.swift
@@ -277,7 +277,7 @@ extension CharcoalViewController: FilterViewControllerDelegate {
 
     public func filterViewController(_ viewController: FilterViewController, didSelectFilter filter: Filter) {
         switch filter.kind {
-        case .standard, .freeText, .freeTextOnly:
+        case .standard, .freeText, .freeTextOnly, .inline:
             guard !filter.subfilters.isEmpty else { break }
 
             let listViewController = ListFilterViewController(filter: filter, selectionStore: selectionStore)

--- a/UnitTests/Charcoal/Models/FilterTests.swift
+++ b/UnitTests/Charcoal/Models/FilterTests.swift
@@ -54,7 +54,47 @@ final class FilterTests: XCTestCase {
         XCTAssertEqual(filter.numberOfResults, 0)
         XCTAssertEqual(filter.style, .normal)
         XCTAssertEqual(filter.subfilters.count, 2)
-        XCTAssertEqual(filter.kind, .standard)
+        XCTAssertEqual(filter.kind, .inline)
+    }
+
+    func testNestedInlineFilters() {
+        let filter = Filter.inline(
+            title: "Inline",
+            key: "inline",
+            subfilters: [
+                Filter(title: "Group 1", key: "shipping_types", subfilters: [
+                    Filter(title: "Subfilter A", key: "shipping_types", subfilters: [
+                        Filter(title: "Nested subfilter A.1", key: "shipping_types", subfilters: [
+                            Filter(title: "Nested nested subfilter A.1", key: "shipping_types")
+                        ]),
+                        Filter(title: "Nested subfilter A.2", key: "shipping_types")
+                    ])
+                ]),
+                Filter(title: "Group 2", key: "published", subfilters: [
+                    Filter(title: "Subfilter B", key: "published"),
+                    Filter(title: "Subfilter C", key: "published")
+                ])
+            ]
+        )
+
+        XCTAssertEqual(filter.subfilters.count, 2)
+        XCTAssertEqual(filter.kind, .inline)
+
+        let subfilterTitles = filter.subfilters.map { $0.subfilters.map { $0.title} }
+
+        // Expect nested subfilters to be flattened
+        let expectedFilters = [
+            [
+                "Subfilter A",
+                "Nested subfilter A.1",
+                "Nested nested subfilter A.1",
+                "Nested subfilter A.2"
+            ], [
+                "Subfilter B",
+                "Subfilter C"
+            ]
+        ]
+        XCTAssertEqual(subfilterTitles, expectedFilters)
     }
 
     func testStepperFilter() {


### PR DESCRIPTION
# Why?

We need to support nested inline filters, it's going to be used for "free shipping" filter for recommerce. 

# What?

Currently we support inline filters with 1 level of subfilters only. Nested inline filters are ignored.
Now we want nested filters to be treated like a flat structure. So I manipulated the inline filter by flattening it in init.
Also wrote tests to confirm the expected behaviour. 

A selection of parent and child at the same time should give the same results as selecting child only. 

# Show me

This is how the filter response from backend looks:
```
    {
      "display_name": "Fiks ferdig",
      "name": "shipping_types",
      "filter_items": [
        {
          "display_name": "Fiks ferdig",
          "name": "shipping_types",
          "value": "0",
          "hits": 104,
          "filter_items": [
            {
              "display_name": "Gratis frakt",
              "name": "shipping_types",
              "value": "1",
              "hits": 20,
              "filter_items": [],
              "selected": true
            }
          ],
          "selected": true
        }
      ],
      "type": "STANDARD_FILTER"
    },

```

## Before

The "Gratis frakt" filter is nested, so the filter that should be placed in the same group as "Fiks ferdig" is missing.

<img src="https://github.com/user-attachments/assets/5c0bf4c2-e0aa-4925-814f-6934c718271d" width=400 />

## After

https://github.com/user-attachments/assets/5aab38f9-66ad-4003-a7e3-bb89efe92a79

